### PR TITLE
Code change for the acquisition of the locale

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -289,6 +289,23 @@ static bool ReadDBCBuildFileText(const std::string& dbc_path, char const* locale
         return false;
 }
 
+int ReadDBCLocale(const std::string sDataPath)
+{
+	std::string sDBCpath = sDataPath + "dbc/";
+    std::string sFilename;
+    
+	for (int uLocaleIndex = 0; uLocaleIndex < MAX_LOCALE; ++uLocaleIndex)
+	{
+        sFilename  = sDBCpath + "component.wow-" + fullLocaleNameList[uLocaleIndex].name + ".txt";
+		if (FILE* file = fopen(sFilename.c_str(), "rb"))
+		{
+			return uLocaleIndex; // Successfully located the locale
+		}
+	}
+
+	return -1; // Failed to locate or access the component.wow<locale>.txt file
+}
+
 static uint32 ReadDBCBuild(const std::string& dbc_path, LocaleNameStr const*&localeNameStr)
 {
     std::string text;

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -34,6 +34,15 @@
 bool IsAcceptableClientBuild(uint32 build);
 std::string AcceptableClientBuildsListStr();
 
+/**
+ * This function checks to see if there is a valid locale file (component.wow-<locale>.txt) 
+ * and returns an index to the locale or -1 if not found
+ * @PARAM dataPath full path to the data directory
+ * @RETURN index number representing the location of the locale in the its structure,
+ * LocaleNameStr in Common.cpp
+ */
+int ReadDBCLocale(const std::string sDataPath);
+
 typedef std::list<uint32> SimpleFactionsList;
 
 SimpleFactionsList const* GetFactionTeamList(uint32 faction);
@@ -48,8 +57,8 @@ uint32 GetAreaFlagByMapId(uint32 mapid);
 
 WMOAreaTableEntry const* GetWMOAreaTableEntryByTripple(int32 rootid, int32 adtid, int32 groupid);
 
- AreaTableEntry const* GetAreaEntryByAreaID(uint32 area_id);
- AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_id);
+AreaTableEntry const* GetAreaEntryByAreaID(uint32 area_id);
+AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_id);
 
 uint32 GetVirtualMapForMapAndZone(uint32 mapid, uint32 zoneId);
 

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1529,6 +1529,23 @@ void World::SetInitialWorldSettings()
 
 void World::DetectDBCLang()
 {
+    // get the DBC Locale
+    int uLocale = ReadDBCLocale(m_dataPath);
+
+    if (!uLocale)
+    {
+        sLog.outError("Unable to determine your DBC Locale! (corrupt or missing component.wow-<locale>.txt file)");
+        Log::WaitBeforeContinueIfNeed();
+        exit(1);
+    }
+
+    m_defaultDbcLocale = LocaleConstant(uLocale);
+
+    sLog.outString("Using %s DBC Locale as default", localeNames[m_defaultDbcLocale]);
+    sLog.outString();
+    
+    /* OLD VERSION - delete this code if the above proves to work as intended
+    
     uint32 m_lang_confid = sConfig.GetIntDefault("DBC.Locale", 255);
 
     if (m_lang_confid != 255 && m_lang_confid >= MAX_LOCALE)
@@ -1571,6 +1588,8 @@ void World::DetectDBCLang()
 
     sLog.outString("Using %s DBC Locale as default. All available DBC locales: %s", localeNames[m_defaultDbcLocale], availableLocalsStr.empty() ? "<none>" : availableLocalsStr.c_str());
     sLog.outString();
+    
+    */
 }
 
 /// Update the World !


### PR DESCRIPTION
The original code was making use of a structure that is used for races
(Human, Orc, etc), which was rather an odd thing to do.

Seeing as the code would not work in this core, I took the opportunity
to rewrite it so that it checked the actual locale file instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/71)
<!-- Reviewable:end -->
