### PR TITLE
StormLib ver 9.2 implemented

### DIFF
--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -294,7 +294,7 @@ uint32 ReadMapDBC(int const locale)
     printf("Read Map.dbc file... ");
 
     HANDLE dbcFile;
-    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\Map.dbc", SFILE_OPEN_PATCHED_FILE, &dbcFile))
+    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\Map.dbc", SFILE_OPEN_FROM_MPQ, &dbcFile))
     {
         printf("Fatal error: Cannot find Map.dbc in archive!\n");
         exit(1);
@@ -329,7 +329,7 @@ void ReadAreaTableDBC(int const locale)
     printf("Read AreaTable.dbc file...");
 
     HANDLE dbcFile;
-    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\AreaTable.dbc", SFILE_OPEN_PATCHED_FILE, &dbcFile))
+    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\AreaTable.dbc", SFILE_OPEN_FROM_MPQ, &dbcFile))
     {
         printf("Fatal error: Cannot find AreaTable.dbc in archive!\n");
         exit(1);
@@ -367,7 +367,7 @@ void ReadLiquidTypeTableDBC(int const locale)
     printf("Read LiquidType.dbc file...");
 
     HANDLE dbcFile;
-    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\LiquidType.dbc", SFILE_OPEN_PATCHED_FILE, &dbcFile))
+    if (!SFileOpenFileEx(localeFile, "DBFilesClient\\LiquidType.dbc", SFILE_OPEN_FROM_MPQ, &dbcFile))
     {
         printf("Fatal error: Cannot find LiquidType.dbc in archive!\n");
         exit(1);

--- a/src/tools/Extractor_projects/shared/ExtractorCommon.cpp
+++ b/src/tools/Extractor_projects/shared/ExtractorCommon.cpp
@@ -366,7 +366,7 @@ void setVMapMagicVersion(int iCoreNumber, char* magic)
         std::strcpy(magic,"VMAPt06");
         break;
     case CLIENT_CATA:
-        std::strcpy(magic,"VMAPc04");
+        std::strcpy(magic,"VMAPc06");
         break;
     case CLIENT_MOP:
         std::strcpy(magic,"VMAPp06");

--- a/src/tools/Extractor_projects/vmap-extractor/dbcfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/dbcfile.cpp
@@ -33,7 +33,7 @@ DBCFile::DBCFile(HANDLE mpq, const char* filename) :
 
 bool DBCFile::open()
 {
-    if (!SFileOpenFileEx(_mpq, _filename, SFILE_OPEN_PATCHED_FILE, &_file))
+    if (!SFileOpenFileEx(_mpq, _filename, SFILE_OPEN_FROM_MPQ, &_file))
         return false;
 
     char header[4];

--- a/src/tools/Extractor_projects/vmap-extractor/mpqfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/mpqfile.cpp
@@ -10,7 +10,7 @@ MPQFile::MPQFile(HANDLE mpq, const char* filename):
     size(0)
 {
     HANDLE file;
-    if (!SFileOpenFileEx(mpq, filename, SFILE_OPEN_PATCHED_FILE, &file))
+    if (!SFileOpenFileEx(mpq, filename, SFILE_OPEN_FROM_MPQ, &file))
     {
         int error = GetLastError();
         if ( error != ERROR_FILE_NOT_FOUND )

--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -113,7 +113,7 @@ bool preciseVectorData = false;
 
 //static const char * szWorkDirMaps = ".\\Maps";
 const char* szWorkDirWmo = "./Buildings";
-const char* szRawVMAPMagic = "VMAPc04";
+const char* szRawVMAPMagic = "VMAPc06";
 
 bool LoadLocaleMPQFile(int locale)
 {


### PR DESCRIPTION
Changes made in order to implement StormLib 9.2

SFILE_OPEN_PATCHED_FILE no longer exists in StormLib
Therefore now using SFILE_OPEN_FROM_MPQ

File extraction tested and working as intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/72)
<!-- Reviewable:end -->
