### PR TITLE
Script refactoring done as per previous cores

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -2339,7 +2339,8 @@ std::string Creature::GetScriptName() const
 
 uint32 Creature::GetScriptId() const
 {
-    return ObjectMgr::GetCreatureTemplate(GetEntry())->ScriptID;
+	// scripts bound to DB guid have priority over ones bound to creature entry
+	return sScriptMgr.GetBoundScriptId(SCRIPTED_UNIT, -int32(GetGUIDLow())) ? sScriptMgr.GetBoundScriptId(SCRIPTED_UNIT, -int32(GetGUIDLow())) : sScriptMgr.GetBoundScriptId(SCRIPTED_UNIT, GetEntry());
 }
 
 VendorItemData const* Creature::GetVendorItems() const

--- a/src/game/Object/Creature.h
+++ b/src/game/Object/Creature.h
@@ -145,7 +145,6 @@ struct CreatureInfo
     uint32  vendorId;
     uint32  MechanicImmuneMask;
     uint32  ExtraFlags;
-    uint32  ScriptID;
 
     // helpers
     HighGuid GetHighGuid() const

--- a/src/game/Object/GameObject.h
+++ b/src/game/Object/GameObject.h
@@ -426,7 +426,6 @@ struct GameObjectInfo
     uint32 unk2;
     uint32 MinMoneyLoot;
     uint32 MaxMoneyLoot;
-    uint32 ScriptId;
 
     // helpers
     bool IsDespawnAtAction() const

--- a/src/game/Object/ItemPrototype.h
+++ b/src/game/Object/ItemPrototype.h
@@ -622,8 +622,7 @@ struct ItemPrototype
     float  ArmorDamageModifier;
     uint32 Duration;
     uint32 ItemLimitCategory;                               // id from ItemLimitCategory.dbc
-    uint32 HolidayId;                                       // id from Holidays.dbc
-    uint32 ScriptId;
+    uint32 HolidayId;  
     uint32 DisenchantID;
     uint32 FoodType;
     float  StatScalingFactor;

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -571,7 +571,7 @@ void ObjectMgr::LoadCreatureTemplates()
                 continue;
             }
 
-            if (difficultyInfo->ScriptID)
+			if (sScriptMgr.GetBoundScriptId(SCRIPTED_UNIT, difficultyInfo->Entry))
             {
                 sLog.outErrorDb("Difficulty %u mode creature (Entry: %u) has `ScriptName`, but in any case will used difficulty 0 mode creature (Entry: %u) ScriptName.",
                                 diff + 1, cInfo->DifficultyEntry[diff], i);

--- a/src/game/Server/SQLStorages.cpp
+++ b/src/game/Server/SQLStorages.cpp
@@ -44,20 +44,21 @@
 // };
 //
 
-const char CreatureInfosrcfmt[] = "iiiiiiiiiisssiiiiiiiiiiifffiffiifiiiiiiiiiiiffiiiiiiiiiiiiiiisiiffliiiiiiiliiiiiis";
-const char CreatureInfodstfmt[] = "iiiiiiiiiisssiiiiiiiiiiifffiffiifiiiiiiiiiiiffiiiiiiiiiiiiiiisiiffliiiiiiiliiiiiii";
+const char CreatureInfosrcfmt[] = "iiiiiiiiiisssiiiiiiiiiiifffiffiifiiiiiiiiiiiffiiiiiiiiiiiiiiisiiffliiiiiiiliiiiii";
+const char CreatureInfodstfmt[] = "iiiiiiiiiisssiiiiiiiiiiifffiffiifiiiiiiiiiiiffiiiiiiiiiiiiiiisiiffliiiiiiiliiiiii";
 const char CreatureDataAddonInfofmt[] = "iiibbiis";
 const char CreatureModelfmt[] = "iffbii";
 const char CreatureInfoAddonInfofmt[] = "iiibbiis";
 const char GameObjectInfoAddonInfofmt[] = "iffff";
 const char EquipmentInfofmt[] = "iiii";
-const char GameObjectInfosrcfmt[] = "iiissssiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiis";
-const char GameObjectInfodstfmt[] = "iiissssiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii";
-const char ItemPrototypesrcfmt[] = "iiiisiiiiffiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiifiiiiiifiiiiiifiiiiiifiiiiiifiiiisiiiiiiiiiiiiiiiiiiiiiiiifiiisiifiiiii";
-const char ItemPrototypedstfmt[] = "iiiisiiiiffiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiifiiiiiifiiiiiifiiiiiifiiiiiifiiiisiiiiiiiiiiiiiiiiiiiiiiiifiiiiiifiiiii";
+const char GameObjectInfosrcfmt[] = "iiissssiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+const char GameObjectInfodstfmt[] = "iiissssiifiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii";
+//                                  1        10        20        30        40        50        60        70        80        90        100       110       120       130       140       150       160
+const char ItemPrototypesrcfmt[] = "iiiisiiiiffiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiifiiiiiifiiiiiifiiiiiifiiiiiifiiiisiiiiiiiiiiiiiiiiiiiiiiiifiiiiifiiiii";
+const char ItemPrototypedstfmt[] = "iiiisiiiiffiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiifiiifiiiiiifiiiiiifiiiiiifiiiiiifiiiisiiiiiiiiiiiiiiiiiiiiiiiifiiiiifiiiii";
 const char PageTextfmt[] = "isi";
-const char InstanceTemplatesrcfmt[] = "iiiis";
-const char InstanceTemplatedstfmt[] = "iiiii";
+const char InstanceTemplatesrcfmt[] = "iiii";
+const char InstanceTemplatedstfmt[] = "iiii";
 const char WorldTemplatesrcfmt[] = "is";
 const char WorldTemplatedstfmt[] = "ii";
 const char ConditionsSrcFmt[] = "iiii";

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -78,7 +78,6 @@ struct InstanceTemplate
     // or 0 (not related to continent 0 map id)
     uint32 levelMin;
     uint32 levelMax;
-    uint32 script_id;
 };
 
 struct WorldTemplate


### PR DESCRIPTION
Script name now no longer exists in creature_template, item_template,
instance_template, and gameobject_template.

They are now held in the script_binding table.

Changes made to the core to reflect this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/75)
<!-- Reviewable:end -->
