### PR TITLE
LoadCreatureClassLvlStats() fixed

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -870,78 +870,82 @@ void ObjectMgr::LoadCreatureAddons()
 
 void ObjectMgr::LoadCreatureClassLvlStats()
 {
-    // initialize data array
-    memset(&m_creatureClassLvlStats, 0, sizeof(m_creatureClassLvlStats));
+	// initialize data array
+	memset(&m_creatureClassLvlStats, 0, sizeof(m_creatureClassLvlStats));
 
-    std::string queryStr = "SELECT Class, Level, BaseMana, BaseMeleeAttackPower, BaseRangedAttackPower, BaseArmor";
+	std::string queryStr = "SELECT Class, Level, BaseMana, BaseMeleeAttackPower, BaseRangedAttackPower, BaseArmor";
 
-    for (int i = 0; i <= MAX_EXPANSION; i++)
-    {
-        std::ostringstream str;
-        str << ", `BaseHealthExp" << i << "`, `BaseDamageExp" << i << "`";
-        queryStr.append(str.str().c_str());
-    }
+	for (int i = 0; i <= MAX_EXPANSION; i++)
+	{
+		std::ostringstream str;
+		str << ", `BaseHealthExp" << i << "`, `BaseDamageExp" << i << "`";
+		queryStr.append(str.str().c_str());
+	}
 
-    queryStr.append(" FROM `creature_template_classlevelstats` ORDER BY `Class`, `Level`");
-    QueryResult* result = WorldDatabase.Query(queryStr.c_str());
+	sLog.outErrorDb("Querying creature_template_classlevelstats table");
+	queryStr.append(" FROM `creature_template_classlevelstats` ORDER BY `Class`, `Level`");
+	QueryResult* result = WorldDatabase.Query(queryStr.c_str());
+	sLog.outErrorDb("Finished querying creature_template_classlevelstats table");
 
-    if (!result)
-    {
-        BarGoLink bar(1);
+	if (!result)
+	{
+		BarGoLink bar(1);
 
-        bar.step();
+		bar.step();
 
-        sLog.outString();
-        sLog.outErrorDb("DB table `creature_template_classlevelstats` is empty.");
-        return;
-    }
+		sLog.outString();
+		sLog.outErrorDb("DB table `creature_template_classlevelstats` is empty.");
+		return;
+	}
 
-    BarGoLink bar(result->GetRowCount());
-    uint32 DataCount = 0;
+	BarGoLink bar(result->GetRowCount());
+	uint32 DataCount = 0;
 
-    do
-    {
-        Field* fields = result->Fetch();
-        bar.step();
+	sLog.outErrorDb("Processing rows of creature_template_classlevelstats table");
+	do
+	{
+		Field* fields = result->Fetch();
+		bar.step();
 
-        uint32 creatureClass = fields[0].GetUInt32();
-        uint32 creatureLevel = fields[1].GetUInt32();
+		uint32 creatureClass = fields[0].GetUInt32();
+		uint32 creatureLevel = fields[1].GetUInt32();
 
-        if (creatureLevel == 0 || creatureLevel > DEFAULT_MAX_CREATURE_LEVEL)
-        {
-            sLog.outErrorDb("Found stats for creature level [%u] with incorrect level. Skipping!", creatureLevel);
-            continue;
-        }
+		if (creatureLevel == 0 || creatureLevel > DEFAULT_MAX_CREATURE_LEVEL)
+		{
+			sLog.outErrorDb("Found stats for creature level [%u] with incorrect level. Skipping!", creatureLevel);
+			continue;
+		}
 
-        if (((1 << (creatureClass - 1)) & CLASSMASK_ALL_CREATURES) == 0)
-        {
-            sLog.outErrorDb("Found stats for creature class [%u] with incorrect class. Skipping!", creatureClass);
-            continue;
-        }
+		if (((1 << (creatureClass - 1)) & CLASSMASK_ALL_CREATURES) == 0)
+		{
+			sLog.outErrorDb("Found stats for creature class [%u] with incorrect class. Skipping!", creatureClass);
+			continue;
+		}
 
-        uint32  baseMana = fields[2].GetUInt32();
-        float   baseMeleeAttackPower = fields[3].GetFloat();
-        float   baseRangedAttackPower = fields[4].GetFloat();
-        uint32  baseArmor = fields[5].GetUInt32();
+		uint32  baseMana = fields[2].GetUInt32();
+		float   baseMeleeAttackPower = fields[3].GetFloat();
+		float   baseRangedAttackPower = fields[4].GetFloat();
+		uint32  baseArmor = fields[5].GetUInt32();
 
-        for (uint8 i = 0; i <= MAX_EXPANSION; ++i)
-        {
-            CreatureClassLvlStats &cCLS = m_creatureClassLvlStats[creatureLevel][classToIndex[creatureClass]][i - 1];   // values should start from 0
-            cCLS.BaseMana = baseMana;
-            cCLS.BaseMeleeAttackPower = baseMeleeAttackPower;
-            cCLS.BaseRangedAttackPower = baseRangedAttackPower;
-            cCLS.BaseArmor = baseArmor;
+		for (uint8 i = 0; i <= MAX_EXPANSION; ++i)
+		{
+			CreatureClassLvlStats &cCLS = m_creatureClassLvlStats[creatureLevel][classToIndex[creatureClass]][i - 1];   // values should start from 0
+			cCLS.BaseMana = baseMana;
+			cCLS.BaseMeleeAttackPower = baseMeleeAttackPower;
+			cCLS.BaseRangedAttackPower = baseRangedAttackPower;
+			cCLS.BaseArmor = baseArmor;
 
-            cCLS.BaseHealth = fields[6 + (i * 2)].GetUInt32();
-            cCLS.BaseDamage = fields[7 + (i * 2)].GetFloat();
-        }
-        ++DataCount;
-    } while (result->NextRow());
+			cCLS.BaseHealth = fields[6 + (i * 2)].GetUInt32();
+			cCLS.BaseDamage = fields[7 + (i * 2)].GetFloat();
+		}
+		++DataCount;
+	} while (result->NextRow());
+	sLog.outErrorDb("Finished processing rows of creature_template_classlevelstats table");
 
-    delete result;
+	delete result;
 
-    sLog.outString();
-    sLog.outString(">> Loaded %u creature class level stats definitions.", DataCount);
+	sLog.outString();
+	sLog.outString(">> Loaded %u creature class level stats definitions.", DataCount);
 }
 
 void ObjectMgr::LoadEquipmentTemplates()

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -37,7 +37,7 @@
     #define CHAR_DB_UPDATE_DESCRIPTION "match_client_limits"
 
     #define WORLD_DB_VERSION_NR 21
-    #define WORLD_DB_STRUCTURE_NR 1
-    #define WORLD_DB_CONTENT_NR 0
+    #define WORLD_DB_STRUCTURE_NR 2
+    #define WORLD_DB_CONTENT_NR 1
     #define WORLD_DB_UPDATE_DESCRIPTION "revision_refactor"
 #endif // __REVISION_H__


### PR DESCRIPTION
LoadCreatureClassLvlStats() taken from Two due to Three's own
implementation of the function not working.
The table creature_template_classlevelstats has now been added to Three,
therefore this function needed to be working.

World database revision updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/76)
<!-- Reviewable:end -->
