### PR TITLE
Player health regen fixed - temporary fix

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2247,6 +2247,8 @@ void Player::RegenerateHealth(uint32 diff)
     if (curValue >= maxValue) return;
 
     float HealthIncreaseRate = sWorld.getConfig(CONFIG_FLOAT_RATE_HEALTH);
+    // This needs fixing
+    HealthIncreaseRate = 1.0f; // having to do this as the above constantly results in 0 - mangosd.conf is obviously not being read properly
 
     float addvalue = 0.0f;
 


### PR DESCRIPTION
The regen wroks, but only due to assigning the default regen value as a
constant, instead of loading it from the mangosd.conf file.

The reading of the value from the mangosd.conf file still needs to be
fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/107)
<!-- Reviewable:end -->
