### PR TITLE
Fix applied for Quest Log, Bags, and money issues

### DIFF
--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1549,7 +1549,7 @@ class Player : public Unit
         void SendQuestFailed(uint32 quest_id, InventoryResult reason = EQUIP_ERR_OK);
         void SendQuestTimerFailed(uint32 quest_id);
         void SendCanTakeQuestResponse(uint32 msg) const;
-        void SendQuestConfirmAccept(Quest const* pQuest, Player* pReceiver);
+        void SendQuestConfirmAccept(const Quest* pQuest, Player* pReceiver);
         void SendPushToPartyResponse(Player* pPlayer, uint32 msg);
         void SendQuestUpdateAddCreatureOrGo(Quest const* pQuest, ObjectGuid guid, uint32 creatureOrGO_idx, uint32 count);
 

--- a/src/game/Object/UpdateFields.h
+++ b/src/game/Object/UpdateFields.h
@@ -129,7 +129,7 @@ enum EUnitFields
     UNIT_FIELD_HOVERHEIGHT                           = OBJECT_END + 0x87,
     UNIT_FIELD_MAXITEMLEVEL                          = OBJECT_END + 0x88,
     UNIT_FIELD_PADDING                               = OBJECT_END + 0x89,
-    UNIT_END                                         = OBJECT_END + 0x008E,
+    UNIT_END                                         = OBJECT_END + 0x8A
 };
 
 enum EItemFields


### PR DESCRIPTION
Quests were not going into the Quest Log.
Could not move items around in bags.
Total money could not be viewed (always 0).

Plus additional unrelated fix - incorrect parameter definition of
function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/110)
<!-- Reviewable:end -->
