### PR TITLE
quest_template columns now read and stored in the correct order

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -3743,52 +3743,56 @@ void ObjectMgr::LoadQuests()
     QueryResult* result = WorldDatabase.Query("SELECT entry, Method, ZoneOrSort, MinLevel, QuestLevel, Type, RequiredClasses, RequiredRaces, RequiredSkill, RequiredSkillValue,"
                           //   10                   11                 12                     13                   14                     15                   16                17
                           "RepObjectiveFaction, RepObjectiveValue, RequiredMinRepFaction, RequiredMinRepValue, RequiredMaxRepFaction, RequiredMaxRepValue, SuggestedPlayers, LimitTime,"
-                          //   18          19            20           21            22            23           24           25              26
-                          "QuestFlags, SpecialFlags, CharTitleId, PlayersSlain, BonusTalents, PrevQuestId, NextQuestId, ExclusiveGroup, NextQuestInChain,"
-                          //   27        28         29           30
+                          //   18          19            20           21            22            23           24           25              26              27               28
+                          "QuestFlags, SpecialFlags, CharTitleId, PlayersSlain, BonusTalents, PortraitGiver, PortraitTurnIn, PrevQuestId, NextQuestId, ExclusiveGroup, NextQuestInChain,"
+                          //   29        30        31           32
                           "RewXPId, SrcItemId, SrcItemCount, SrcSpell,"
-                          //   31     32       33          34               35                36       37             38              39              40              41
-                          "Title, Details, Objectives, OfferRewardText, RequestItemsText, EndText, CompletedText, ObjectiveText1, ObjectiveText2, ObjectiveText3, ObjectiveText4,"
-                          //   42          43          44          45          46          47          48             49             50             51             52             53
+                          //   33     34       35          36               37                38       39               40                  41                  42                  43
+                          "Title, Details, Objectives, OfferRewardText, RequestItemsText, EndText, CompletedText, PortraitGiverName, PortraitGiverText, PortraitTurnInName, PortraitTurnInText,"                          
+                          //    44               45             46               47                 
+                          "ObjectiveText1, ObjectiveText2, ObjectiveText3, ObjectiveText4,"
+                          //   48          49          50          51          52          53           54             55             56             57             58             59
                           "ReqItemId1, ReqItemId2, ReqItemId3, ReqItemId4, ReqItemId5, ReqItemId6, ReqItemCount1, ReqItemCount2, ReqItemCount3, ReqItemCount4, ReqItemCount5, ReqItemCount6,"
-                          //   54            55            56            57            58               59               60               61
+                          //   60            61            62             63             64               65               66               67
                           "ReqSourceId1, ReqSourceId2, ReqSourceId3, ReqSourceId4, ReqSourceCount1, ReqSourceCount2, ReqSourceCount3, ReqSourceCount4,"
-                          //   62                  63                  64                  65                  66                     67                     68                     69
+                          //   68                  69                  70                  71                  72                     73                     74                     75
                           "ReqCreatureOrGOId1, ReqCreatureOrGOId2, ReqCreatureOrGOId3, ReqCreatureOrGOId4, ReqCreatureOrGOCount1, ReqCreatureOrGOCount2, ReqCreatureOrGOCount3, ReqCreatureOrGOCount4,"
-                          //   70             71             72             73
-                          "ReqSpellCast1, ReqSpellCast2, ReqSpellCast3, ReqSpellCast4,"
-                          //   74                75                76                77                78                79
+                          //   76               77             78               79
+                          "ReqCurrencyId1, ReqCurrencyId2, ReqCurrencyId3, ReqCurrencyId4,"
+                          //   80                   81                82                83
+                          "ReqCurrencyCount1, ReqCurrencyCount1, ReqCurrencyCount1, ReqCurrencyCount1,"
+                          //   84             85             86             87              88
+                          "ReqSpellCast1, ReqSpellCast2, ReqSpellCast3, ReqSpellCast4, ReqSpellLearned,"
+                          //   89                90                91                92                93                94
                           "RewChoiceItemId1, RewChoiceItemId2, RewChoiceItemId3, RewChoiceItemId4, RewChoiceItemId5, RewChoiceItemId6,"
-                          //   80                   81                   82                   83                   84                   85
+                          //   95                   96                   97                   98                   99                   100
                           "RewChoiceItemCount1, RewChoiceItemCount2, RewChoiceItemCount3, RewChoiceItemCount4, RewChoiceItemCount5, RewChoiceItemCount6,"
-                          //   86          87          88          89          90             91             92             93
-                          "RewItemId1, RewItemId2, RewItemId3, RewItemId4, RewItemCount1, RewItemCount2, RewItemCount3, RewItemCount4,"
-                          //   94              95              96              97              98
+                          //  101         102         103         104          105            106             107            108
+                          "RewItemId1, RewItemId2, RewItemId3, RewItemId4, RewItemCount1, RewItemCount2, RewItemCount3, RewItemCount4,"                          
+                          //  109                110              111              112
+                          "RewCurrencyId1, RewCurrencyId2, RewCurrencyId3, RewCurrencyId4,"
+                          //  113                   114                115                116
+                          "RewCurrencyCount1, RewCurrencyCount2, RewCurrencyCount3, RewCurrencyCount4,"                          
+                          //  117         118          
+                          "RewSkill, RewSkillValue,"
+                          //   119              120             121             122             123
                           "RewRepFaction1, RewRepFaction2, RewRepFaction3, RewRepFaction4, RewRepFaction5,"
-                          //   99              100             101             102             103
+                          //   124              125             126             127             128
                           "RewRepValueId1, RewRepValueId2, RewRepValueId3, RewRepValueId4, RewRepValueId5,"
-                          //   104           105           106           107           108
+                          //   129           130           131           132           133
                           "RewRepValue1, RewRepValue2, RewRepValue3, RewRepValue4, RewRepValue5,"
-                          //   109               110                 111            112               113       114
+                          //   134               135                 136            137             138        139
                           "RewHonorAddition, RewHonorMultiplier, RewOrReqMoney, RewMoneyMaxLevel, RewSpell, RewSpellCast,"
-                          //   115                116               117         118     119     120
+                          //   140                141              142       143     144      145
                           "RewMailTemplateId, RewMailDelaySecs, PointMapId, PointX, PointY, PointOpt,"
-                          //   121            122            123            124            125                 126                 127                 128
+                          //   146            147            148            149            150                 151                 152                 153
                           "DetailsEmote1, DetailsEmote2, DetailsEmote3, DetailsEmote4, DetailsEmoteDelay1, DetailsEmoteDelay2, DetailsEmoteDelay3, DetailsEmoteDelay4,"
-                          //   129              130            131                132                133                134
+                          //   154              155            156                157                158                159
                           "IncompleteEmote, CompleteEmote, OfferRewardEmote1, OfferRewardEmote2, OfferRewardEmote3, OfferRewardEmote4,"
-                          //   135                     136                     137                     138
+                          //   160                        161                     162                     153
                           "OfferRewardEmoteDelay1, OfferRewardEmoteDelay2, OfferRewardEmoteDelay3, OfferRewardEmoteDelay4,"
-                          //   139          140
-                          "StartScript, CompleteScript, "
-                          //   141          142            143             144                145                146                 147
-                          "ReqSpellLearned, PortraitGiver, PortraitTurnIn, PortraitGiverName, PortraitGiverText, PortraitTurnInName, PortraitTurnInText, "
-                          //   148         149             150             151             152                153                154                155
-                          "ReqCurrencyId1, ReqCurrencyId2, ReqCurrencyId3, ReqCurrencyId4, ReqCurrencyCount1, ReqCurrencyCount2, ReqCurrencyCount3, ReqCurrencyCount4, "
-                          //   156         157             158             159             160                161                162                163
-                          "RewCurrencyId1, RewCurrencyId2, RewCurrencyId3, RewCurrencyId4, RewCurrencyCount1, RewCurrencyCount2, RewCurrencyCount3, RewCurrencyCount4, "
-                          //   164   165            166          167
-                          "RewSkill, RewSkillValue, SoundAccept, SoundTurnIn "
+                          //   164          165         166           167
+                          "SoundAccept, SoundTurnIn, StartScript, CompleteScript"
                           " FROM quest_template");
     if (!result)
     {

--- a/src/game/WorldHandlers/QuestDef.cpp
+++ b/src/game/WorldHandlers/QuestDef.cpp
@@ -52,122 +52,125 @@ Quest::Quest(Field* questRecord)
     CharTitleId = questRecord[20].GetUInt32();
     PlayersSlain = questRecord[21].GetUInt32();
     BonusTalents = questRecord[22].GetUInt32();
-    PrevQuestId = questRecord[23].GetInt32();
-    NextQuestId = questRecord[24].GetInt32();
-    ExclusiveGroup = questRecord[25].GetInt32();
-    NextQuestInChain = questRecord[26].GetUInt32();
-    RewXPId = questRecord[27].GetUInt32();
-    SrcItemId = questRecord[28].GetUInt32();
-    SrcItemCount = questRecord[29].GetUInt32();
-    SrcSpell = questRecord[30].GetUInt32();
-    Title = questRecord[31].GetCppString();
-    Details = questRecord[32].GetCppString();
-    Objectives = questRecord[33].GetCppString();
-    OfferRewardText = questRecord[34].GetCppString();
-    RequestItemsText = questRecord[35].GetCppString();
-    EndText = questRecord[36].GetCppString();
-    CompletedText = questRecord[37].GetCppString();
+    
+    PortraitGiver = questRecord[23].GetUInt32();
+    PortraitTurnIn = questRecord[24].GetUInt32();
+
+    PrevQuestId = questRecord[25].GetInt32();
+    NextQuestId = questRecord[26].GetInt32();
+    ExclusiveGroup = questRecord[27].GetInt32();
+    NextQuestInChain = questRecord[28].GetUInt32();
+    RewXPId = questRecord[29].GetUInt32();
+    SrcItemId = questRecord[30].GetUInt32();
+    SrcItemCount = questRecord[31].GetUInt32();
+    SrcSpell = questRecord[32].GetUInt32();
+    Title = questRecord[33].GetCppString();
+    Details = questRecord[34].GetCppString();
+    Objectives = questRecord[35].GetCppString();
+    OfferRewardText = questRecord[36].GetCppString();
+    RequestItemsText = questRecord[37].GetCppString();
+    EndText = questRecord[38].GetCppString();
+    CompletedText = questRecord[39].GetCppString();
+        
+    PortraitGiverName = questRecord[40].GetCppString();
+    PortraitGiverText = questRecord[41].GetCppString();
+    PortraitTurnInName = questRecord[42].GetCppString();
+    PortraitTurnInText = questRecord[43].GetCppString();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ObjectiveText[i] = questRecord[38 + i].GetCppString();
+        ObjectiveText[i] = questRecord[44 + i].GetCppString();
 
     for (int i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
-        ReqItemId[i] = questRecord[42 + i].GetUInt32();
+        ReqItemId[i] = questRecord[48 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
-        ReqItemCount[i] = questRecord[48 + i].GetUInt32();
+        ReqItemCount[i] = questRecord[54 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceId[i] = questRecord[54 + i].GetUInt32();
+        ReqSourceId[i] = questRecord[60 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
-        ReqSourceCount[i] = questRecord[58 + i].GetUInt32();
+        ReqSourceCount[i] = questRecord[64 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOId[i] = questRecord[62 + i].GetInt32();
+        ReqCreatureOrGOId[i] = questRecord[68 + i].GetInt32();
 
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqCreatureOrGOCount[i] = questRecord[66 + i].GetUInt32();
-
+        ReqCreatureOrGOCount[i] = questRecord[72 + i].GetUInt32();
+    
+    for (int i = 0; i < QUEST_REQUIRED_CURRENCY_COUNT; ++i)
+        ReqCurrencyId[i] = questRecord[76 + i].GetUInt32();
+    for (int i = 0; i < QUEST_REQUIRED_CURRENCY_COUNT; ++i)
+        ReqCurrencyCount[i] = questRecord[80 + i].GetUInt32();
+    
     for (int i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
-        ReqSpell[i] = questRecord[70 + i].GetUInt32();
+        ReqSpell[i] = questRecord[84 + i].GetUInt32();
+
+    ReqSpellLearned = questRecord[88].GetUInt32();
+
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemId[i] = questRecord[74 + i].GetUInt32();
+        RewChoiceItemId[i] = questRecord[89 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
-        RewChoiceItemCount[i] = questRecord[80 + i].GetUInt32();
+        RewChoiceItemCount[i] = questRecord[95 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemId[i] = questRecord[86 + i].GetUInt32();
+        RewItemId[i] = questRecord[101 + i].GetUInt32();
 
     for (int i = 0; i < QUEST_REWARDS_COUNT; ++i)
-        RewItemCount[i] = questRecord[90 + i].GetUInt32();
-
-    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepFaction[i] = questRecord[94 + i].GetUInt32();
-
-    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepValueId[i] = questRecord[99 + i].GetInt32();
-
-    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
-        RewRepValue[i] = questRecord[104 + i].GetInt32();
-
-    RewHonorAddition = questRecord[109].GetUInt32();
-    RewHonorMultiplier = questRecord[110].GetFloat();
-    RewOrReqMoney = questRecord[111].GetInt32();
-    RewMoneyMaxLevel = questRecord[112].GetUInt32();
-    RewSpell = questRecord[113].GetUInt32();
-    RewSpellCast = questRecord[114].GetUInt32();
-    RewMailTemplateId = questRecord[115].GetUInt32();
-    RewMailDelaySecs = questRecord[116].GetUInt32();
-    PointMapId = questRecord[117].GetUInt32();
-    PointX = questRecord[118].GetFloat();
-    PointY = questRecord[119].GetFloat();
-    PointOpt = questRecord[120].GetUInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        DetailsEmote[i] = questRecord[121 + i].GetUInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        DetailsEmoteDelay[i] = questRecord[125 + i].GetUInt32();
-
-    IncompleteEmote = questRecord[129].GetUInt32();
-    CompleteEmote = questRecord[130].GetUInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmote[i] = questRecord[131 + i].GetInt32();
-
-    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        OfferRewardEmoteDelay[i] = questRecord[135 + i].GetInt32();
-
-    QuestStartScript = questRecord[139].GetUInt32();
-    QuestCompleteScript = questRecord[140].GetUInt32();
-
-    ReqSpellLearned = questRecord[141].GetUInt32();
-    PortraitGiver = questRecord[142].GetUInt32();
-    PortraitTurnIn = questRecord[143].GetUInt32();
-
-    PortraitGiverName = questRecord[144].GetCppString();
-    PortraitGiverText = questRecord[145].GetCppString();
-    PortraitTurnInName = questRecord[146].GetCppString();
-    PortraitTurnInText = questRecord[147].GetCppString();
-
-    for (int i = 0; i < QUEST_REQUIRED_CURRENCY_COUNT; ++i)
-        ReqCurrencyId[i] = questRecord[148 + i].GetUInt32();
-    for (int i = 0; i < QUEST_REQUIRED_CURRENCY_COUNT; ++i)
-        ReqCurrencyCount[i] = questRecord[152 + i].GetUInt32();
-
+        RewItemCount[i] = questRecord[105 + i].GetUInt32();       
+    
     for (int i = 0; i < QUEST_REWARD_CURRENCY_COUNT; ++i)
-        RewCurrencyId[i] = questRecord[156 + i].GetUInt32();
+        RewCurrencyId[i] = questRecord[109 + i].GetUInt32();
     for (int i = 0; i < QUEST_REWARD_CURRENCY_COUNT; ++i)
-        RewCurrencyCount[i] = questRecord[160 + i].GetUInt32();
+        RewCurrencyCount[i] = questRecord[113 + i].GetUInt32();
 
-    RewSkill = questRecord[164].GetUInt32();
-    RewSkillValue = questRecord[165].GetUInt32();
+    RewSkill = questRecord[117].GetUInt32();
+    RewSkillValue = questRecord[118].GetUInt32();
 
-    SoundAcceptId = questRecord[166].GetUInt32();
-    SoundTurnInId = questRecord[167].GetUInt32();
+    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
+        RewRepFaction[i] = questRecord[119 + i].GetUInt32();
+
+    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
+        RewRepValueId[i] = questRecord[124 + i].GetInt32();
+
+    for (int i = 0; i < QUEST_REPUTATIONS_COUNT; ++i)
+        RewRepValue[i] = questRecord[129 + i].GetInt32();
+
+    RewHonorAddition = questRecord[134].GetUInt32();
+    RewHonorMultiplier = questRecord[135].GetFloat();
+    RewOrReqMoney = questRecord[136].GetInt32();
+    RewMoneyMaxLevel = questRecord[137].GetUInt32();
+    RewSpell = questRecord[138].GetUInt32();
+    RewSpellCast = questRecord[139].GetUInt32();
+    RewMailTemplateId = questRecord[140].GetUInt32();
+    RewMailDelaySecs = questRecord[141].GetUInt32();
+    PointMapId = questRecord[142].GetUInt32();
+    PointX = questRecord[143].GetFloat();
+    PointY = questRecord[144].GetFloat();
+    PointOpt = questRecord[145].GetUInt32();
+
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        DetailsEmote[i] = questRecord[146 + i].GetUInt32();
+
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        DetailsEmoteDelay[i] = questRecord[150 + i].GetUInt32();
+
+    IncompleteEmote = questRecord[154].GetUInt32();
+    CompleteEmote = questRecord[155].GetUInt32();
+
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        OfferRewardEmote[i] = questRecord[156 + i].GetInt32();
+
+    for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
+        OfferRewardEmoteDelay[i] = questRecord[160 + i].GetInt32();    
+
+    SoundAcceptId = questRecord[164].GetUInt32();
+    SoundTurnInId = questRecord[165].GetUInt32();
+
+    QuestStartScript = questRecord[166].GetUInt32();
+    QuestCompleteScript = questRecord[167].GetUInt32();
 
     m_isActive = true;
 


### PR DESCRIPTION
Columns now read and stored in the correct order for the quest_template
table.

New to m3 columns had been placed at the end of the SELECT statement,
which resulted them being stored in the wrong location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/115)
<!-- Reviewable:end -->
