### PR TITLE
Fixed  chest game objects interactions

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -6087,6 +6087,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                     if ((canFailAtMax || skillValue < sWorld.GetConfigMaxSkillValue()) && reqSkillValue > irand(skillValue - 25, skillValue + 37))
                         return SPELL_FAILED_TRY_AGAIN;
                 }
+                break;
             }
             case SPELL_EFFECT_SUMMON_DEAD_PET:
             {


### PR DESCRIPTION
This will fix the "you do not have a pet" message when interacting with
chest game objects.

Would like to thank - Snowdog on the MaNGOS forums for the fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/127)
<!-- Reviewable:end -->
