### PR TITLE
Disable MultiLine Checks

### DIFF
--- a/apps/ci/ci-codestyle.sh
+++ b/apps/ci/ci-codestyle.sh
@@ -20,20 +20,20 @@ for check in ${!singleLineRegexChecks[@]}; do
     fi
 done
 
-declare -A multiLineRegexChecks=(
-    ["\n\n\n"]="Multiple blank lines detected, keep only one. Check the files above"
-)
+# declare -A multiLineRegexChecks=(
+#     ["\n\n\n"]="Multiple blank lines detected, keep only one. Check the files above"
+# )
 
-for check in ${!multiLineRegexChecks[@]}; do
-    echo "  Checking RegEx: '${check}'"
+# for check in ${!multiLineRegexChecks[@]}; do
+#     echo "  Checking RegEx: '${check}'"
 
-    if grep -Pzo -r -I ${check} src; then
-        echo
-        echo
-        echo "${multiLineRegexChecks[$check]}"
-        exit 1
-    fi
-done
+#     if grep -Pzo -r -I ${check} src; then
+#         echo
+#         echo
+#         echo "${multiLineRegexChecks[$check]}"
+#         exit 1
+#     fi
+# done
 
 echo
 echo "Awesome! No issues..."


### PR DESCRIPTION
**Changes Made:**
- Disable multi-line check do to it not working as intended.
  It is counting empty lines through out the file instead of lines at the end of files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/28)
<!-- Reviewable:end -->
