### PR TITLE
Time Format Update

### DIFF
--- a/src/game/ChatCommands/BanAndKickCommands.cpp
+++ b/src/game/ChatCommands/BanAndKickCommands.cpp
@@ -26,6 +26,7 @@
 #include "Language.h"
 #include "World.h"
 #include "AccountMgr.h"
+#include "Util.h"
 
  /**********************************************************************
      CommandTable : banCommandTable
@@ -177,7 +178,7 @@ bool ChatHandler::HandleBanHelper(BanMode mode, char* args)
         case BAN_SUCCESS:
             if (duration_secs > 0)
             {
-                PSendSysMessage(LANG_BAN_YOUBANNED, nameOrIP.c_str(), secsToTimeString(duration_secs, true).c_str(), reason);
+                PSendSysMessage(LANG_BAN_YOUBANNED, nameOrIP.c_str(), secsToTimeString(duration_secs, TimeFormat::ShortText).c_str(), reason);
             }
             else
             {
@@ -288,7 +289,7 @@ bool ChatHandler::HandleBanInfoIPCommand(char* args)
     bool permanent = !fields[6].GetUInt64();
     PSendSysMessage(LANG_BANINFO_IPENTRY,
                     fields[0].GetString(), fields[1].GetString(), permanent ? GetMangosString(LANG_BANINFO_NEVER) : fields[2].GetString(),
-                    permanent ? GetMangosString(LANG_BANINFO_INFINITE) : secsToTimeString(fields[3].GetUInt64(), true).c_str(), fields[4].GetString(), fields[5].GetString());
+                    permanent ? GetMangosString(LANG_BANINFO_INFINITE) : secsToTimeString(fields[3].GetUInt64(), TimeFormat::ShortText).c_str(), fields[4].GetString(), fields[5].GetString());
     delete result;
     return true;
 }

--- a/src/game/ChatCommands/BanAndKickCommands.cpp
+++ b/src/game/ChatCommands/BanAndKickCommands.cpp
@@ -247,7 +247,7 @@ bool ChatHandler::HandleBanInfoHelper(uint32 accountid, char const* accountname)
             active = true;
         }
         bool permanent = (fields[1].GetUInt64() == (uint64)0);
-        std::string bantime = permanent ? GetMangosString(LANG_BANINFO_INFINITE) : secsToTimeString(fields[1].GetUInt64(), true);
+        std::string bantime = permanent ? GetMangosString(LANG_BANINFO_INFINITE) : secsToTimeString(fields[1].GetUInt64(), TimeFormat::ShortText);
         PSendSysMessage(LANG_BANINFO_HISTORYENTRY,
                         fields[0].GetString(), bantime.c_str(), active ? GetMangosString(LANG_BANINFO_YES) : GetMangosString(LANG_BANINFO_NO), fields[4].GetString(), fields[5].GetString());
     }

--- a/src/game/ChatCommands/CreatureCommands.cpp
+++ b/src/game/ChatCommands/CreatureCommands.cpp
@@ -1203,8 +1203,8 @@ bool ChatHandler::HandleNpcInfoCommand(char* /*args*/)
     {
         curRespawnDelay = 0;
     }
-    std::string curRespawnDelayStr = secsToTimeString(curRespawnDelay, true);
-    std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), true);
+    std::string curRespawnDelayStr = secsToTimeString(curRespawnDelay, TimeFormat::ShortText);
+    std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), TimeFormat::ShortText);
 
     // Send information dependend on difficulty mode
     CreatureInfo const* baseInfo = ObjectMgr::GetCreatureTemplate(Entry);

--- a/src/game/ChatCommands/GMCommands.cpp
+++ b/src/game/ChatCommands/GMCommands.cpp
@@ -27,7 +27,7 @@
 #include "World.h"
 #include "Weather.h"
 #include "SpellMgr.h"
-
+#include "Util.h"
 
  /**********************************************************************
      CommandTable : commandTable
@@ -129,7 +129,7 @@ bool ChatHandler::HandlePInfoCommand(char* args)
 
     PSendSysMessage(LANG_PINFO_ACCOUNT, (target ? "" : GetMangosString(LANG_OFFLINE)), nameLink.c_str(), target_guid.GetCounter(), username.c_str(), accId, security, email.c_str(), last_ip.c_str(), last_login.c_str(), latency);
 
-    std::string timeStr = secsToTimeString(total_player_time, true, true);
+    std::string timeStr = secsToTimeString(total_player_time, TimeFormat::ShortText, true);
     uint32 gold = money / GOLD;
     uint32 silv = (money % GOLD) / SILVER;
     uint32 copp = (money % GOLD) % SILVER;

--- a/src/game/ChatCommands/GameObjectCommands.cpp
+++ b/src/game/ChatCommands/GameObjectCommands.cpp
@@ -531,8 +531,8 @@ bool ChatHandler::HandleGameObjectTargetCommand(char* args)
             curRespawnDelay = 0;
         }
 
-        std::string curRespawnDelayStr = secsToTimeString(curRespawnDelay, true);
-        std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), true);
+        std::string curRespawnDelayStr = secsToTimeString(curRespawnDelay, TimeFormat::ShortText);
+        std::string defRespawnDelayStr = secsToTimeString(target->GetRespawnDelay(), TimeFormat::ShortText);
 
         PSendSysMessage(LANG_COMMAND_RAWPAWNTIMES, defRespawnDelayStr.c_str(), curRespawnDelayStr.c_str());
 

--- a/src/game/ChatCommands/InstanceCommands.cpp
+++ b/src/game/ChatCommands/InstanceCommands.cpp
@@ -45,7 +45,7 @@ bool ChatHandler::HandleInstanceListBindsCommand(char* /*args*/)
         for (Player::BoundInstancesMap::const_iterator itr = binds.begin(); itr != binds.end(); ++itr)
         {
             DungeonPersistentState* state = itr->second.state;
-            std::string timeleft = secsToTimeString(state->GetResetTime() - time(NULL), true);
+            std::string timeleft = secsToTimeString(state->GetResetTime() - time(NULL), TimeFormat::ShortText);
             if (const MapEntry* entry = sMapStore.LookupEntry(itr->first))
             {
                 PSendSysMessage("map: %d (%s) inst: %d perm: %s diff: %d canReset: %s TTR: %s",
@@ -68,7 +68,7 @@ bool ChatHandler::HandleInstanceListBindsCommand(char* /*args*/)
             for (Group::BoundInstancesMap::const_iterator itr = binds.begin(); itr != binds.end(); ++itr)
             {
                 DungeonPersistentState* state = itr->second.state;
-                std::string timeleft = secsToTimeString(state->GetResetTime() - time(NULL), true);
+                std::string timeleft = secsToTimeString(state->GetResetTime() - time(NULL), TimeFormat::ShortText);
                 if (const MapEntry* entry = sMapStore.LookupEntry(itr->first))
                 {
                     PSendSysMessage("map: %d (%s) inst: %d perm: %s diff: %d canReset: %s TTR: %s",
@@ -126,7 +126,7 @@ bool ChatHandler::HandleInstanceUnbindCommand(char* args)
             if (itr->first != player->GetMapId())
             {
                 DungeonPersistentState* save = itr->second.state;
-                std::string timeleft = secsToTimeString(save->GetResetTime() - time(NULL), true);
+                std::string timeleft = secsToTimeString(save->GetResetTime() - time(NULL), TimeFormat::ShortText);
 
                 if (const MapEntry* entry = sMapStore.LookupEntry(itr->first))
                 {

--- a/src/game/Warden/Warden.cpp
+++ b/src/game/Warden/Warden.cpp
@@ -148,7 +148,7 @@ void Warden::Update()
                 if (_clientResponseTimer > maxClientResponseDelay * IN_MILLISECONDS)
                 {
                     sLog.outWarden("%s (latency: %u, IP: %s) exceeded Warden module response delay on state %s for more than %s - disconnecting client",
-                                   _session->GetPlayerName(), _session->GetLatency(), _session->GetRemoteAddress().c_str(), WardenState::to_string(_state), secsToTimeString(maxClientResponseDelay, true).c_str());
+                                   _session->GetPlayerName(), _session->GetLatency(), _session->GetRemoteAddress().c_str(), WardenState::to_string(_state), secsToTimeString(maxClientResponseDelay, TimeFormat::ShortText).c_str());
                     _session->KickPlayer();
                 }
                 else

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -2285,7 +2285,7 @@ void World::ShutdownMsg(bool show /*= false*/, Player* player /*= NULL*/)
         (m_ShutdownTimer < 12 * HOUR && (m_ShutdownTimer % HOUR) == 0) ||           // < 12 h; every 1 h
         (m_ShutdownTimer >= 12 * HOUR && (m_ShutdownTimer % (12 * HOUR)) == 0))     // >= 12 h; every 12 h
     {
-        std::string str = secsToTimeString(m_ShutdownTimer);
+        std::string str = secsToTimeString(m_ShutdownTimer, TimeFormat::Numeric);
 
         ServerMessageType msgid = (m_ShutdownMask & SHUTDOWN_MASK_RESTART) ? SERVER_MSG_RESTART_TIME : SERVER_MSG_SHUTDOWN_TIME;
 

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -31,6 +31,8 @@
 #include <ace/INET_Addr.h>
 #include "Log/Log.h"
 
+#include <iomanip>
+
 static ACE_Time_Value g_SystemTickTime = ACE_OS::gettimeofday();
 
 uint32 WorldTimer::m_iTime = 0;
@@ -209,7 +211,7 @@ void stripLineInvisibleChars(std::string& str)
     }
 }
 
-std::string secsToTimeString(time_t timeInSecs, bool shortText, bool hoursOnly)
+std::string secsToTimeString(time_t timeInSecs, TimeFormat timeFormat, bool hoursOnly)
 {
     time_t secs    = timeInSecs % MINUTE;
     time_t minutes = timeInSecs % HOUR / MINUTE;
@@ -219,21 +221,107 @@ std::string secsToTimeString(time_t timeInSecs, bool shortText, bool hoursOnly)
     std::ostringstream ss;
     if (days)
     {
-        ss << days << (shortText ? "d" : " Day(s) ");
+        ss << days;
+        if (timeFormat == TimeFormat::Numeric)
+        {
+            ss << ":";
+        }
+        else if (timeFormat == TimeFormat::ShortText)
+        {
+            ss << "d";
+        }
+        else // if (timeFormat == TimeFormat::FullText)
+        {
+            if (days == 1)
+            {
+                ss << " Day ";
+            }
+            else
+            {
+                ss << " Days ";
+            }
+        }
     }
+
     if (hours || hoursOnly)
     {
-        ss << hours << (shortText ? "h" : " Hour(s) ");
+        ss << hours;
+        if (timeFormat == TimeFormat::Numeric)
+        {
+            ss << ":";
+        }
+        else if (timeFormat == TimeFormat::ShortText)
+        {
+            ss << "h";
+        }
+        else // if (timeFormat == TimeFormat::FullText)
+        {
+            if (hours <= 1)
+            {
+                ss << " Hour ";
+            }
+            else
+            {
+                ss << " Hours ";
+            }
+        }
     }
+    
     if (!hoursOnly)
     {
-        if (minutes)
+        ss << minutes;
+        if (timeFormat == TimeFormat::Numeric)
         {
-            ss << minutes << (shortText ? "m" : " Minute(s) ");
+            ss << ":";
         }
-        if (secs || (!days && !hours && !minutes))
+        else if (timeFormat == TimeFormat::ShortText)
         {
-            ss << secs << (shortText ? "s" : " Second(s).");
+            ss << "m";
+        }
+        else // if (timeFormat == TimeFormat::FullText)
+        {
+            if (minutes == 1)
+            {
+                ss << " Minute ";
+            }
+            else
+            {
+                ss << " Minutes ";
+            }
+        }
+    }
+    else
+    {
+        if (timeFormat == TimeFormat::Numeric)
+        {
+            ss << "0:";
+        }
+    }
+
+    if (secs || (!days && !hours && !minutes))
+    {
+        ss << std::setw(2) << std::setfill('0') << secs;
+        if (timeFormat == TimeFormat::ShortText)
+        {
+            ss << "s";
+        }
+        else if (timeFormat == TimeFormat::FullText)
+        {
+            if (secs <= 1)
+            {
+                ss << " Second.";
+            }
+            else
+            {
+                ss << " Seconds.";
+            }
+        }
+    }
+    else
+    {
+        if (timeFormat == TimeFormat::Numeric)
+        {
+            ss << "00";
         }
     }
 

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -266,7 +266,7 @@ std::string secsToTimeString(time_t timeInSecs, TimeFormat timeFormat, bool hour
             }
         }
     }
-    
+
     if (!hoursOnly)
     {
         ss << minutes;

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -32,6 +32,13 @@
 #include <string>
 #include <vector>
 
+enum class TimeFormat : uint8
+{
+    FullText,       // 1 Days 2 Hours 3 Minutes 4 Seconds
+    ShortText,      // 1d 2h 3m 4s
+    Numeric         // 1:2:3:4
+};
+
 /**
  * @brief
  *
@@ -79,7 +86,7 @@ void stripLineInvisibleChars(std::string& src);
  * @param hoursOnly
  * @return std::string
  */
-std::string secsToTimeString(time_t timeInSecs, bool shortText = false, bool hoursOnly = false);
+std::string secsToTimeString(time_t timeInSecs, TimeFormat timeFormat = TimeFormat::FullText, bool hoursOnly = false);
 /**
  * @brief
  *


### PR DESCRIPTION
**Changes Made:**
- change the time output format for restart / shutdown notifications
- also check where we should use singular or plural forms for words: Day, Hour, Minute, Second

**Format:**
It should be like: [SERVER] Shutdown in 15:00 and NOT like: [SERVER] Shutdown in 15 Minute(s)

**Video Evidence:**
https://www.youtube.com/watch?v=z8za1_ozG-U

**Examples:**
```
[SERVER] Shutdown in 7:00
[SERVER] Shutdown in 6:00

<-- When the timer gets down to 05:00 it will then start to display seconds as shown below. -->
[SERVER] Shutdown in 5:00
[SERVER] Shutdown in 4:45
[SERVER] Shutdown in 4:30
[SERVER] Shutdown in 4:15
[SERVER] Shutdown in 4:00
```

**Notice:**
This has been shared around from TrinityCore, Skyfire and AzerothCore. Not the original author!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/32)
<!-- Reviewable:end -->
