### PR TITLE
[TEMPORARY] Adjust locale int

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -307,7 +307,7 @@ int ReadDBCLocale(const std::string sDataPath)
         sFilename  = sDBCpath + "component.wow-" + fullLocaleNameList[uLocaleIndex].name + ".txt";
         if (FILE* file = fopen(sFilename.c_str(), "rb"))
         {
-            return uLocaleIndex; // Successfully located the locale
+            return uLocaleIndex - 1; // Successfully located the locale
         }
     }
 


### PR DESCRIPTION
THIS SHOULD BE CONSIDERED A TEMPORARY FIX.

Adjusts the locale integer by -1 to match properly.

Tested with all DBC locales.

**NOTE: Did NOT work for enUS and ruRU.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/44)
<!-- Reviewable:end -->
