### PR TITLE
[VMap] Use provided invDirection instead of calculating it ourselves

### DIFF
--- a/src/game/vmap/BIH.h
+++ b/src/game/vmap/BIH.h
@@ -188,12 +188,11 @@ class BIH
         {
             float intervalMin = -1.f;
             float intervalMax = -1.f;
-            Vector3 org = r.origin();
-            Vector3 dir = r.direction();
-            Vector3 invDir;
+            Vector3 const& org = r.origin();
+            Vector3 const& dir = r.direction();
+            Vector3 const& invDir = r.invDirection();
             for (int i = 0; i < 3; ++i)
             {
-                invDir[i] = 1.f / dir[i];
                 if (G3D::fuzzyNe(dir[i], 0.0f))
                 {
                     float t1 = (bounds.low()[i]  - org[i]) * invDir[i];


### PR DESCRIPTION
**Purpose:**
- Both Ray::origin and Ray::direction returns refs
- Plus no need to calculate inv direction since Ray also contains it

Source: https://github.com/TrinityCore/TrinityCore/pull/27883

**Notice:** May have to regenerate vmap files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/50)
<!-- Reviewable:end -->
