### PR TITLE
OpenSSL3 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+# proper support for openssl3.x was added in CMake 3.18
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -109,6 +110,8 @@ find_package(DL      REQUIRED)
 find_package(ZLIB  QUIET)
 find_package(BZip2 QUIET)
 
+#static linkage for openssl libs
+set(OPENSSL_USE_STATIC_LIBS ON)
 find_package(OpenSSL REQUIRED)
 
 include(${CMAKE_SOURCE_DIR}/cmake/GenRevision.cmake)


### PR DESCRIPTION
Raise CMake minimum version to 3.18 (because proper support for OpenSSL 3.x was added in that version).
Put an initialization sequence in mangosd.cpp as instructed by OpenSSL 3 wiki (with slight changes specific to MaNGOS)
Enforced static linkage for OpenSSL libs.

Thank you to @Gamemechanicwow & @H0zen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/75)
<!-- Reviewable:end -->
