### PR TITLE
Comment out tapping status updates

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -2351,7 +2351,7 @@ void GameObject::SetLootRecipient(Unit* pUnit)
     {
         m_lootRecipientGuid.Clear();
         m_lootGroupRecipientId = 0;
-        ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);       // needed to be sure tapping status is updated
+        //ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);       // needed to be sure tapping status is updated
         return;
     }
 
@@ -2370,7 +2370,7 @@ void GameObject::SetLootRecipient(Unit* pUnit)
         m_lootGroupRecipientId = group->GetId();
     }
 
-    ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);           // needed to be sure tapping status is updated
+    //ForceValuesUpdateAtIndex(UNIT_DYNAMIC_FLAGS);           // needed to be sure tapping status is updated
 }
 
 float GameObject::GetObjectBoundingRadius() const


### PR DESCRIPTION
Commented out problematic tapping status updates. Server was crashing when some gobjects for quests were used. At this time, unable to identify what other impacts this may have - but did result in stability at time of testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/77)
<!-- Reviewable:end -->
