### PR TITLE
Adjusting Codestyle Check to Exclude External Libraries

### DIFF
--- a/apps/ci/ci-codestyle.sh
+++ b/apps/ci/ci-codestyle.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# exclude external libraries from code style check
+exclude=(
+    # dirs
+    "Eluna"
+)
+
+exclude_dirs=""
+for dir in "${exclude[@]}"; do
+    exclude_dirs+="--exclude-dir=$dir "
+done
+
 set -e
 
 echo "Starting Codestyling Script:"
@@ -13,7 +24,7 @@ declare -A singleLineRegexChecks=(
 for check in ${!singleLineRegexChecks[@]}; do
     echo "  Checking RegEx: '${check}'"
     
-    if grep -P -r -I -n ${check} src; then
+    if grep -P -r -I -n $exclude_dirs ${check} src; then
         echo
         echo "${singleLineRegexChecks[$check]}"
         exit 1


### PR DESCRIPTION
This aims to optimize the codestyle check by excluding external libraries from the inspection. 
The current codestyle check scrutinizes all files, including external libraries, like Eluna, leading to unnecessary failure. 

Further directories may be excluded from check by adding them to array `exclude` in file [apps/ci/ci-codestyle.sh](https://github.com/mangosthree/server/blob/master/apps/ci/ci-codestyle.sh)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/80)
<!-- Reviewable:end -->
