### PR TITLE
Skill Training Bug Fix

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4748,13 +4748,13 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
 
     // check level requirement
     bool prof = SpellMgr::IsProfessionSpell(trainer_spell->spell);
-    if (prof || trainer_spell->reqLevel && (trainer_spell->reqLevel) < reqLevel)
+    if (!prof || trainer_spell->reqLevel && (trainer_spell->reqLevel) < reqLevel)
     {
         return TRAINER_SPELL_RED;
     }
 
     // check skill requirement
-    if (prof || trainer_spell->reqSkill && GetBaseSkillValue(trainer_spell->reqSkill) < trainer_spell->reqSkillValue)
+    if (!prof || trainer_spell->reqSkill && GetBaseSkillValue(trainer_spell->reqSkill) < trainer_spell->reqSkillValue)
     {
         return TRAINER_SPELL_RED;
     }


### PR DESCRIPTION
Fix a typo from the initial commit https://github.com/mangosthree/server/commit/2e4111aed436595dd93f5e89a1d690316a3345bd.

@i-am-fyre @billy1arm 
This will need retesting to make sure this is tested properly. Should have been tested a bit more outside of the configuration change.

**Update:**
With M3, this change brakes the functionality of learning spells; according to @i-am-fyre. Looked at the other source to compare and the code itself is not consistent across the board, resulting in malfunctioning system. Will have to review this more in depth.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/82)
<!-- Reviewable:end -->
