### PR TITLE
Align Cell.data.Part fields by 8 bits and enlarge Cell structure to 8 bytes

### DIFF
--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Configure Windows
-        run: choco install --no-progress openssl
+        run: choco install --no-progress openssl --version=3.1.1
 
       - name: Checkout Submodules
         shell: bash

--- a/src/game/WorldHandlers/Cell.h
+++ b/src/game/WorldHandlers/Cell.h
@@ -50,8 +50,7 @@ struct CellArea
 
 struct Cell
 {
-        Cell() { data.All = 0; }
-        Cell(const Cell& cell) { data.All = cell.data.All; }
+        Cell() : data() { };
         explicit Cell(CellPair const& p);
 
         void Compute(uint32& x, uint32& y) const
@@ -88,26 +87,19 @@ struct Cell
                        data.Part.grid_y * MAX_NUMBER_OF_CELLS + data.Part.cell_y);
         }
 
-        Cell& operator=(const Cell& cell)
-        {
-            data.All = cell.data.All;
-            return *this;
-        }
-
         bool operator==(const Cell& cell) const { return (data.All == cell.data.All); }
         bool operator!=(const Cell& cell) const { return !operator==(cell); }
         union
         {
             struct
             {
-                unsigned grid_x : 6;
-                unsigned grid_y : 6;
-                unsigned cell_x : 6;
-                unsigned cell_y : 6;
-                unsigned nocreate : 1;
-                unsigned reserved : 7;
+                uint8 grid_x : 8;
+                uint8 grid_y : 8;
+                uint8 cell_x : 8;
+                uint8 cell_y : 8;
+                uint8 nocreate : 8;
             } Part;
-            uint32 All;
+            uint64 All;
         } data;
 
         template<class T, class CONTAINER> void Visit(const CellPair& cellPair, TypeContainerVisitor<T, CONTAINER> &visitor, Map& m, float x, float y, float radius) const;

--- a/src/game/WorldHandlers/CellImpl.h
+++ b/src/game/WorldHandlers/CellImpl.h
@@ -30,14 +30,13 @@
 #include "Map.h"
 #include <cmath>
 
-inline Cell::Cell(CellPair const& p)
+inline Cell::Cell(CellPair const& p) : data()
 {
     data.Part.grid_x = p.x_coord / MAX_NUMBER_OF_CELLS;
     data.Part.grid_y = p.y_coord / MAX_NUMBER_OF_CELLS;
     data.Part.cell_x = p.x_coord % MAX_NUMBER_OF_CELLS;
     data.Part.cell_y = p.y_coord % MAX_NUMBER_OF_CELLS;
     data.Part.nocreate = 0;
-    data.Part.reserved = 0;
 }
 
 inline CellArea Cell::CalculateCellArea(float x, float y, float radius)


### PR DESCRIPTION
Aligns cell struct for better performance.
Credits to @Lordron - https://github.com/TrinityCore/TrinityCore/pull/29371

And @Gamemechanicwow for further porting - https://github.com/vmangos/core/pull/2261

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/83)
<!-- Reviewable:end -->
