### PR TITLE
Add missing packages to docker image

### DIFF
--- a/dockercontainer/DockerFile-mangosd
+++ b/dockercontainer/DockerFile-mangosd
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04 as build-step
 
 RUN apt-get -y update
-RUN apt-get -y install curl autoconf automake libbz2-dev libace-dev libssl-dev libmysqlclient-dev libtool build-essential gpg wget
+RUN apt-get -y install curl autoconf automake libbz2-dev libace-dev libssl-dev libmysqlclient-dev libtool build-essential gpg wget lsb-release software-properties-common
 
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
     echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \


### PR DESCRIPTION
Fixes Docker build failures:

```shell
 > [mangosd build-step  9/17] RUN apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main":
0.394 /bin/sh: 1: lsb_release: not found
0.394 /bin/sh: 1: apt-add-repository: not found
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/86)
<!-- Reviewable:end -->
