### PR TITLE
Fixed issue with NPC quest indicators not displaying properly.

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -17741,6 +17741,7 @@ void Player::SendQuestUpdateAddCreatureOrGo(Quest const* pQuest, ObjectGuid guid
 void Player::SendQuestGiverStatusMultiple()
 {
     uint32 count = 0;
+    uint32 dialogStatus = DIALOG_STATUS_NONE;
 
     WorldPacket data(SMSG_QUESTGIVER_STATUS_MULTIPLE, 4);
     data << uint32(count);                                  // placeholder
@@ -17762,15 +17763,15 @@ void Player::SendQuestGiverStatusMultiple()
                 continue;
             }
 
-            uint8 dialogStatus = sScriptMgr.GetDialogStatus(this, questgiver);
+            dialogStatus = sScriptMgr.GetDialogStatus(this, questgiver);
 
-            if (dialogStatus == DIALOG_STATUS_REWARD_REP)
+            if (dialogStatus > DIALOG_STATUS_REWARD_REP)
             {
                 dialogStatus = GetSession()->getDialogStatus(this, questgiver, DIALOG_STATUS_NONE);
             }
 
             data << questgiver->GetObjectGuid();
-            data << uint8(dialogStatus);
+            data << dialogStatus;
             ++count;
         }
         else if (itr->IsGameObject())
@@ -17787,15 +17788,15 @@ void Player::SendQuestGiverStatusMultiple()
                 continue;
             }
 
-            uint8 dialogStatus = sScriptMgr.GetDialogStatus(this, questgiver);
+            dialogStatus = sScriptMgr.GetDialogStatus(this, questgiver);
 
-            if (dialogStatus == DIALOG_STATUS_REWARD_REP)
+            if (dialogStatus > DIALOG_STATUS_REWARD_REP)
             {
                 dialogStatus = GetSession()->getDialogStatus(this, questgiver, DIALOG_STATUS_NONE);
             }
 
             data << questgiver->GetObjectGuid();
-            data << uint8(dialogStatus);
+            data << dialogStatus;
             ++count;
         }
     }


### PR DESCRIPTION
Player::SendQuestGiverStatusMultiple() is called whenever the player accepts or hands in a quest, or levels up. Its function is to send a list of all the local quest-giving NPCs and what their status is so the client can display the proper icon above them.

Because the method was never executing a secondary call to getDialogStatus from the WorldSession when the script manager was returning an undefined status, due to a misplaced equality operator, every NPC was being given an undefined dialog status. Additionally, due to the local variable dialogStatus being declared as a uint8, the return value from ScriptMgr::GetDialogStatus() was being truncated. Because of this, the data packet being sent back to the client was improperly formatted, causing all local NPCs to have randomly selected icons.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/88)
<!-- Reviewable:end -->
