### PR TITLE
Update Judgement spell ID from 54158 to 20271 in `SpellEffects.cpp`

### DIFF
--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -864,7 +864,7 @@ void Spell::EffectSchoolDMG(SpellEffectEntry const* effect)
                     damage += count * int32(average * IN_MILLISECONDS) / m_caster->GetAttackTime(BASE_ATTACK);
                 }
                 // Judgement
-                else if (m_spellInfo->Id == 54158)
+                else if (m_spellInfo->Id == 20271)
                 {
                     // [1 + 0.25 * SPH + 0.16 * AP]
                     damage += int32(m_caster->GetTotalAttackPowerValue(BASE_ATTACK) * 0.16f);
@@ -11844,7 +11844,7 @@ void Spell::EffectScriptEffect(SpellEffectEntry const* effect)
                         {
                             continue;
                         }
-                        spellId2 = 54158;
+                        spellId2 = 20271;
                         break;
                     }
                 }


### PR DESCRIPTION
Associated issue: https://www.getmangos.eu/bug-tracker/mangos-three/spell-judgment-r1311/

The original is an uncategorized spell that isn't on the GCD and has no cooldown - Paladins can't learn it (https://www.wowhead.com/cata/spell=54158) 

The new ID is the paladin ability (https://www.wowhead.com/cata/spell=20271)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/92)
<!-- Reviewable:end -->
