### PR TITLE
Fix uint32 overflow UB in damage/XP/health calculations and 2 test fa…

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -919,11 +919,11 @@ void Creature::RegenerateHealth()
         float Spirit = GetStat(STAT_SPIRIT); //for charmed creatures, spirit = 0!
         if (GetPower(POWER_MANA) > 0)
         {
-            addvalue = uint32(Spirit * 0.25 * HealthIncreaseRate);
+            addvalue = SafeUInt32FromFloat(Spirit * 0.25 * HealthIncreaseRate);
         }
         else
         {
-            addvalue = uint32(Spirit * 0.80 * HealthIncreaseRate);
+            addvalue = SafeUInt32FromFloat(Spirit * 0.80 * HealthIncreaseRate);
         }
     }
     else

--- a/src/game/Object/LootMgr.cpp
+++ b/src/game/Object/LootMgr.cpp
@@ -851,15 +851,15 @@ void Loot::generateMoneyLoot(uint32 minAmount, uint32 maxAmount)
     {
         if (maxAmount <= minAmount)
         {
-            gold = uint32(maxAmount * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
+            gold = SafeUInt32FromFloat(maxAmount * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
         }
         else if ((maxAmount - minAmount) < 32700)
         {
-            gold = uint32(urand(minAmount, maxAmount) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
+            gold = SafeUInt32FromFloat(urand(minAmount, maxAmount) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
         }
         else
         {
-            gold = uint32(urand(minAmount >> 8, maxAmount >> 8) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY)) << 8;
+            gold = SafeUInt32FromFloat(urand(minAmount >> 8, maxAmount >> 8) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY)) << 8;
         }
     }
 }

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -1003,7 +1003,7 @@ int32 Player::getMaxTimer(MirrorTimerType timer)
             AuraList const& mModWaterBreathing = GetAurasByType(SPELL_AURA_MOD_WATER_BREATHING);
             for (AuraList::const_iterator i = mModWaterBreathing.begin(); i != mModWaterBreathing.end(); ++i)
             {
-                UnderWaterTime = uint32(UnderWaterTime * (100.0f + (*i)->GetModifier()->m_amount) / 100.0f);
+                UnderWaterTime = SafeUInt32FromFloat(UnderWaterTime * (100.0f + (*i)->GetModifier()->m_amount) / 100.0f);
             }
             return UnderWaterTime;
         }
@@ -2944,7 +2944,7 @@ void Player::GiveXP(uint32 xp, Unit* victim)
         Unit::AuraList const& ModXPPctAuras = GetAurasByType(SPELL_AURA_MOD_KILL_XP_PCT);
         for (Unit::AuraList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
         {
-            xp = uint32(xp * (1.0f + (*i)->GetModifier()->m_amount / 100.0f));
+            xp = SafeUInt32FromFloat(xp * (1.0f + (*i)->GetModifier()->m_amount / 100.0f));
         }
     }
     else
@@ -2953,7 +2953,7 @@ void Player::GiveXP(uint32 xp, Unit* victim)
         Unit::AuraList const& ModXPPctAuras = GetAurasByType(SPELL_AURA_MOD_QUEST_XP_PCT);
         for (Unit::AuraList::const_iterator i = ModXPPctAuras.begin(); i != ModXPPctAuras.end(); ++i)
         {
-            xp = uint32(xp * (1.0f + (*i)->GetModifier()->m_amount / 100.0f));
+            xp = SafeUInt32FromFloat(xp * (1.0f + (*i)->GetModifier()->m_amount / 100.0f));
         }
     }
 
@@ -5685,9 +5685,9 @@ uint32 Player::DurabilityRepair(uint16 pos, bool cost, float discountMod, bool g
             }
 
             uint32 dmultiplier = dcost->multiplier[ItemSubClassToDurabilityMultiplierId(ditemProto->Class, ditemProto->SubClass)];
-            uint32 costs = uint32(LostDurability * dmultiplier * double(dQualitymodEntry->quality_mod));
+            uint32 costs = SafeUInt32FromDouble(LostDurability * dmultiplier * double(dQualitymodEntry->quality_mod));
 
-            costs = uint32(costs * discountMod);
+            costs = SafeUInt32FromDouble(costs * discountMod);
 
             if (costs == 0)                                 // fix for ITEM_QUALITY_ARTIFACT
             {
@@ -7387,11 +7387,11 @@ void Player::CheckAreaExploreAndOutdoor()
                         exploration_percent = 0;
                     }
 
-                    XP = uint32(sObjectMgr.GetBaseXP(p->area_level) * exploration_percent / 100 * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_EXPLORE));
+                    XP = SafeUInt32FromFloat(sObjectMgr.GetBaseXP(p->area_level) * exploration_percent / 100 * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_EXPLORE));
                 }
                 else
                 {
-                    XP = uint32(sObjectMgr.GetBaseXP(p->area_level) * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_EXPLORE));
+                    XP = SafeUInt32FromFloat(sObjectMgr.GetBaseXP(p->area_level) * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_EXPLORE));
                 }
 
                 GiveXP(XP, NULL);
@@ -9686,7 +9686,7 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
                 }
                 // It may need a better formula
                 // Now it works like this: lvl10: ~6copper, lvl70: ~9silver
-                bones->loot.gold = (uint32)(urand(50, 150) * 0.016f * pow(((float)pLevel) / 5.76f, 2.5f) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
+                bones->loot.gold = SafeUInt32FromFloat(urand(50, 150) * 0.016f * pow(((float)pLevel) / 5.76f, 2.5f) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
             }
 
             if (bones->lootRecipient != this)
@@ -9735,7 +9735,7 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
                     // Generate extra money for pick pocket loot
                     const uint32 a = urand(0, creature->getLevel() / 2);
                     const uint32 b = urand(0, getLevel() / 2);
-                    loot->gold = uint32(10 * (a + b) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
+                    loot->gold = SafeUInt32FromFloat(10 * (a + b) * sWorld.getConfig(CONFIG_FLOAT_RATE_DROP_MONEY));
                     permission = OWNER_PERMISSION;
                 }
             }
@@ -16184,7 +16184,7 @@ void Player::RewardQuest(Quest const* pQuest, uint32 reward, Object* questGiver,
     QuestStatusData& q_status = mQuestStatus[quest_id];
 
     // Used for client inform but rewarded only in case not max level
-    uint32 xp = uint32(pQuest->XPValue(this) * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_QUEST));
+    uint32 xp = SafeUInt32FromFloat(pQuest->XPValue(this) * sWorld.getConfig(CONFIG_FLOAT_RATE_XP_QUEST));
 
     if (getLevel() < sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
     {

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -1157,7 +1157,7 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
             if (shareTarget != pVictim && ((*itr)->GetMiscValue() & damageSchoolMask))
             {
                 SpellEntry const* shareSpell = (*itr)->GetSpellProto();
-                uint32 shareDamage = uint32(damage*(*itr)->GetModifier()->m_amount / 100.0f);
+                uint32 shareDamage = SafeUInt32FromFloat(damage*(*itr)->GetModifier()->m_amount / 100.0f);
                 DealDamageMods(shareTarget, shareDamage, NULL);
                 DealDamage(shareTarget, shareDamage, NULL, damagetype, GetSpellSchoolMask(shareSpell), shareSpell, false);
             }
@@ -3247,7 +3247,7 @@ void Unit::CalculateDamageAbsorbAndResist(Unit* pCaster, SpellSchoolMask schoolM
                 continue;
             }
 
-            uint32 splitted = uint32(RemainingDamage * (*i)->GetModifier()->m_amount / 100.0f);
+            uint32 splitted = SafeUInt32FromFloat(RemainingDamage * (*i)->GetModifier()->m_amount / 100.0f);
 
             RemainingDamage -=  int32(splitted);
 
@@ -3316,7 +3316,7 @@ void Unit::CalculateAbsorbResistBlock(Unit* pCaster, SpellNonMeleeDamage* damage
 
     if (blocked)
     {
-        damageInfo->blocked = uint32(damageInfo->damage * GetShieldBlockDamageValue() / 100.0f);
+        damageInfo->blocked = SafeUInt32FromFloat(damageInfo->damage * GetShieldBlockDamageValue() / 100.0f);
         if (damageInfo->damage < damageInfo->blocked)
         {
             damageInfo->blocked = damageInfo->damage;
@@ -12085,7 +12085,7 @@ void Unit::SetMaxHealth(uint32 val)
 
 void Unit::SetHealthPercent(float percent)
 {
-    uint32 newHealth = GetMaxHealth() * percent / 100.0f;
+    uint32 newHealth = SafeUInt32FromFloat(GetMaxHealth() * percent / 100.0f);
     SetHealth(newHealth);
 }
 
@@ -13897,7 +13897,7 @@ uint32 Unit::GetCombatRatingDamageReduction(CombatRating cr, float rate, float c
     {
         percent = cap;
     }
-    return uint32(percent * damage / 100.0f);
+    return SafeUInt32FromFloat(percent * damage / 100.0f);
 }
 
 void Unit::SendThreatUpdate()

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -2322,7 +2322,7 @@ static void RewardGroupAtKill_helper(Player* pGroupGuy, Unit* pVictim, uint32 co
         if (pGroupGuy->IsAlive() && not_gray_member_with_max_level &&
             pGroupGuy->getLevel() <= not_gray_member_with_max_level->getLevel())
         {
-            uint32 itr_xp = (member_with_max_level == not_gray_member_with_max_level) ? uint32(xp * rate) : uint32((xp * rate / 2) + 1);
+            uint32 itr_xp = (member_with_max_level == not_gray_member_with_max_level) ? SafeUInt32FromFloat(xp * rate) : SafeUInt32FromFloat((xp * rate / 2) + 1);
 
             pGroupGuy->GiveXP(itr_xp, pVictim);
             if (Pet* pet = pGroupGuy->GetPet())

--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -6859,7 +6859,7 @@ void Aura::HandleModTotalPercentStat(bool apply, bool /*Real*/)
     // recalculate current HP/MP after applying aura modifications (only for spells with 0x10 flag)
     if ((miscValueB & (1 << STAT_STAMINA)) && maxHPValue > 0 && GetSpellProto()->HasAttribute(SPELL_ATTR_ABILITY))
     {
-        uint32 newHPValue = uint32(float(target->GetMaxHealth()) / maxHPValue * curHPValue);
+        uint32 newHPValue = SafeUInt32FromFloat(float(target->GetMaxHealth()) / maxHPValue * curHPValue);
         target->SetHealth(newHPValue);
     }
 }
@@ -8420,7 +8420,7 @@ void Aura::PeriodicTick()
             }
             else
             {
-                pdamage = uint32(target->GetMaxHealth() * amount / 100);
+                pdamage = SafeUInt32FromFloat(float(target->GetMaxHealth()) * amount / 100);
             }
 
             // SpellDamageBonus for magic spells
@@ -8671,7 +8671,7 @@ void Aura::PeriodicTick()
 
                 if (m_modifier.m_auraname == SPELL_AURA_OBS_MOD_HEALTH)
                 {
-                    pdamage = uint32(target->GetMaxHealth() * amount / 100);
+                    pdamage = SafeUInt32FromFloat(float(target->GetMaxHealth()) * amount / 100);
                 }
                 else
                 {
@@ -8939,7 +8939,7 @@ void Aura::PeriodicTick()
             // ignore non positive values (can be result apply spellmods to aura damage
             uint32 amount = m_modifier.m_amount > 0 ? m_modifier.m_amount : 0;
 
-            uint32 pdamage = uint32(target->GetMaxPower(POWER_MANA) * amount / 100);
+            uint32 pdamage = SafeUInt32FromFloat(float(target->GetMaxPower(POWER_MANA)) * amount / 100);
 
             DETAIL_FILTER_LOG(LOG_FILTER_PERIODIC_AFFECTS, "PeriodicTick: %s energize %s for %u mana inflicted by %u",
                               GetCasterGuid().GetString().c_str(), target->GetGuidStr().c_str(), pdamage, GetId());
@@ -9850,7 +9850,7 @@ void Aura::PeriodicDummyTick()
             if (spell->IsFitToFamilyMask(UI64LIT(0x0000000020000000)))
             {
                 // damage not expected to be show in logs, not any damage spell related to damage apply
-                uint32 deal = m_modifier.m_amount * target->GetMaxHealth() / 100;
+                uint32 deal = SafeUInt32FromFloat(float(m_modifier.m_amount) * target->GetMaxHealth() / 100);
                 target->DealDamage(target, deal, NULL, DIRECT_DAMAGE, SPELL_SCHOOL_MASK_NORMAL, NULL, false);
                 return;
             }

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -5641,7 +5641,7 @@ void Spell::EffectHealPct(SpellEffectEntry const* /*effect*/)
             return;
         }
 
-        uint32 addhealth = unitTarget->GetMaxHealth() * damage / 100;
+        uint32 addhealth = SafeUInt32FromFloat(float(unitTarget->GetMaxHealth()) * damage / 100);
 
         addhealth = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, addhealth, HEAL);
         addhealth = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, addhealth, HEAL);
@@ -12668,8 +12668,8 @@ void Spell::EffectResurrect(SpellEffectEntry const* /*effect*/)
         return;
     }
 
-    uint32 health = pTarget->GetMaxHealth() * damage / 100;
-    uint32 mana   = pTarget->GetMaxPower(POWER_MANA) * damage / 100;
+    uint32 health = SafeUInt32FromFloat(float(pTarget->GetMaxHealth()) * damage / 100);
+    uint32 mana   = SafeUInt32FromFloat(float(pTarget->GetMaxPower(POWER_MANA)) * damage / 100);
 
     pTarget->setResurrectRequestData(m_caster->GetObjectGuid(), m_caster->GetMapId(), m_caster->GetPositionX(), m_caster->GetPositionY(), m_caster->GetPositionZ(), health, mana);
     SendResurrectRequest(pTarget);
@@ -13168,7 +13168,7 @@ void Spell::EffectSummonDeadPet(SpellEffectEntry const* /*effect*/)
     pet->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SKINNABLE);
     pet->SetDeathState(ALIVE);
     pet->clearUnitState(UNIT_STAT_ALL_STATE);
-    pet->SetHealth(uint32(pet->GetMaxHealth() * (float(damage) / 100)));
+    pet->SetHealth(SafeUInt32FromFloat(pet->GetMaxHealth() * (float(damage) / 100)));
 
     pet->AIM_Initialize();
 

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -34,6 +34,23 @@
 #include <algorithm>
 #include <cctype>
 #include <functional>
+#include <limits>
+
+// Safely convert a float/double to uint32, clamping to [0, UINT32_MAX]
+// to avoid undefined behavior when the float exceeds the uint32 range.
+inline uint32 SafeUInt32FromFloat(float val)
+{
+    if (val < 0.0f) return 0;
+    if (val >= 4294967296.0f) return std::numeric_limits<uint32>::max();
+    return static_cast<uint32>(val);
+}
+
+inline uint32 SafeUInt32FromDouble(double val)
+{
+    if (val < 0.0) return 0;
+    if (val >= 4294967296.0) return std::numeric_limits<uint32>::max();
+    return static_cast<uint32>(val);
+}
 
 enum class TimeFormat : uint8
 {

--- a/tests/test_GameStress.cpp
+++ b/tests/test_GameStress.cpp
@@ -63,7 +63,14 @@ inline float finiteAlways(float f) { return std::isfinite(f) ? f : 0.0f; }
 
 // ---- Damage helpers ----
 inline uint32_t CalculateDamage(uint32_t base, float pct)
-{ return uint32_t(float(base) * pct / 100.0f); }
+{
+    float result = float(base) * pct / 100.0f;
+    if (result < 0.0f) return 0;
+    // float(UINT32_MAX) rounds up to 4294967296.0f, so use double for comparison
+    if (result >= 4294967296.0f)
+        return std::numeric_limits<uint32_t>::max();
+    return uint32_t(result);
+}
 
 inline int32_t CalculateAbsorbAmount(int32_t damage, int32_t absorb)
 {
@@ -110,7 +117,10 @@ inline uint32_t CalculateQuestXP(uint32_t questLevel, uint32_t playerLevel, uint
     int32_t diff = int32_t(playerLevel) - int32_t(questLevel);
     float scale = 1.0f - float(diff) / 5.0f;
     if (scale < 0.1f) scale = 0.1f;
-    return uint32_t(questXP * scale);
+    float result = float(questXP) * scale;
+    if (result >= 4294967296.0f)
+        return std::numeric_limits<uint32_t>::max();
+    return uint32_t(result);
 }
 
 // ---- Money ----


### PR DESCRIPTION
…ilures

The test suite exposed 2 failing stress tests (DamageWithMaxUint32, MaxQuestXP) caused by float-to-uint32 casts overflowing when float values exceed UINT32_MAX (4294967296.0f). This is undefined behavior in C++ and silently produces 0 on common platforms.

Added SafeUInt32FromFloat/SafeUInt32FromDouble helpers to Util.h that clamp to [0, UINT32_MAX] before casting. Applied the fix across 20+ locations in the server source where the same pattern existed:
- Damage sharing (Unit.cpp)
- Shield block calculation (Unit.cpp)
- SetHealthPercent (Unit.cpp)
- Combat rating damage reduction (Unit.cpp)
- XP modifiers from auras (Player.cpp)
- Quest/exploration XP with rate multipliers (Player.cpp)
- Gold/loot drops with rate multipliers (Player.cpp, LootMgr.cpp)
- Spell heal/damage percent-of-max-health (SpellAuras.cpp, SpellEffects.cpp)
- Mana regen percent calculations (SpellAuras.cpp)
- Group XP distribution (Group.cpp)
- Creature health regen (Creature.cpp)
- Durability repair costs (Player.cpp)

All 902 tests now pass (was 900/902).

https://claude.ai/code/session_01RLuCkH1nCbpmCxSo7xhUWL

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/96)
<!-- Reviewable:end -->
