### PR TITLE
Show questgiver follow-up menu after reward

### DIFF
--- a/src/game/WorldHandlers/QuestHandler.cpp
+++ b/src/game/WorldHandlers/QuestHandler.cpp
@@ -292,6 +292,21 @@ void WorldSession::HandleQuestgiverChooseRewardOpcode(WorldPacket& recv_data)
             {
                 _player->PlayerTalkClass->SendQuestGiverQuestDetails(nextquest, guid, true);
             }
+            else if (pObject->GetTypeId() == TYPEID_UNIT)
+            {
+                Creature* pCreature = (Creature*)pObject;
+                _player->PrepareGossipMenu(pCreature, pCreature->GetCreatureInfo()->GossipMenuId);
+
+                if (!_player->PlayerTalkClass->Empty())
+                {
+                    _player->SendPreparedGossip(pCreature);
+                }
+            }
+            else
+            {
+                _player->PrepareQuestMenu(guid);
+                _player->SendPreparedQuest(guid);
+            }
         }
         else
         {


### PR DESCRIPTION
After turning in a quest, the server now shows the next quest in the chain. If there is no direct `NextQuestInChain`, it reopens the same questgiver’s menu with the available follow-up quests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/100)
<!-- Reviewable:end -->
