### PR TITLE
Support Kaja'Cola conditional loot activation

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -1046,7 +1046,8 @@ bool GameObject::ActivateToQuest(Player* pTarget) const
                 return true;
             }
 
-            if (LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), pTarget))
+            if (LootTemplates_Gameobject.HaveQuestLootForPlayer(GetGOInfo()->GetLootId(), pTarget) ||
+                LootTemplates_Gameobject.HaveConditionalLootForPlayer(GetGOInfo()->GetLootId(), pTarget, this))
             {
                 // look for battlegroundAV for some objects which are only activated after mine gots captured by own team
                 if (GetEntry() == BG_AV_OBJECTID_MINE_N || GetEntry() == BG_AV_OBJECTID_MINE_S)

--- a/src/game/Object/LootMgr.cpp
+++ b/src/game/Object/LootMgr.cpp
@@ -63,7 +63,8 @@ class LootTemplate::LootGroup                               // A set of loot def
         void AddEntry(LootStoreItem& item);                 // Adds an entry to the group (at loading stage)
         bool HasQuestDrop() const;                          // True if group includes at least 1 quest drop entry
         bool HasQuestDropForPlayer(Player const* player) const; // The same for active quests of the player
-        // The same for active quests of the player
+        bool HasConditionalDrop() const;                    // True if group includes at least 1 conditional entry
+        bool HasConditionalDropForPlayer(Player const* player, WorldObject const* lootTarget) const;
         void Process(Loot& loot) const;                     // Rolls an item from the group (if any) and adds the item to the loot
         float RawTotalChance() const;                       // Overall chance for the group (without equal chanced items)
         float TotalChance() const;                          // Overall chance for the group
@@ -217,6 +218,33 @@ bool LootStore::HaveQuestLootForPlayer(uint32 loot_id, Player* player) const
         }
 
     return false;
+}
+
+bool LootStore::HaveConditionalLootFor(uint32 loot_id) const
+{
+    LootTemplateMap::const_iterator itr = m_LootTemplates.find(loot_id);
+    if (itr == m_LootTemplates.end())
+    {
+        return false;
+    }
+
+    return itr->second->HasConditionalDrop(m_LootTemplates);
+}
+
+bool LootStore::HaveConditionalLootForPlayer(uint32 loot_id, Player* player, WorldObject const* lootTarget) const
+{
+    if (!player)
+    {
+        return false;
+    }
+
+    LootTemplateMap::const_iterator itr = m_LootTemplates.find(loot_id);
+    if (itr == m_LootTemplates.end())
+    {
+        return false;
+    }
+
+    return itr->second->HasConditionalDropForPlayer(m_LootTemplates, player, lootTarget);
 }
 
 LootTemplate const* LootStore::GetLootFor(uint32 loot_id) const
@@ -1176,6 +1204,38 @@ bool LootTemplate::LootGroup::HasQuestDropForPlayer(Player const* player) const
     return false;
 }
 
+// True if group includes at least 1 conditional entry
+bool LootTemplate::LootGroup::HasConditionalDrop() const
+{
+    for (LootStoreItemList::const_iterator i = ExplicitlyChanced.begin(); i != ExplicitlyChanced.end(); ++i)
+        if (i->conditionId)
+        {
+            return true;
+        }
+    for (LootStoreItemList::const_iterator i = EqualChanced.begin(); i != EqualChanced.end(); ++i)
+        if (i->conditionId)
+        {
+            return true;
+        }
+    return false;
+}
+
+// True if group includes at least 1 conditional entry available to the player
+bool LootTemplate::LootGroup::HasConditionalDropForPlayer(Player const* player, WorldObject const* lootTarget) const
+{
+    for (LootStoreItemList::const_iterator i = ExplicitlyChanced.begin(); i != ExplicitlyChanced.end(); ++i)
+        if (i->conditionId && sObjectMgr.IsPlayerMeetToCondition(i->conditionId, player, player->GetMap(), lootTarget, CONDITION_FROM_LOOT))
+        {
+            return true;
+        }
+    for (LootStoreItemList::const_iterator i = EqualChanced.begin(); i != EqualChanced.end(); ++i)
+        if (i->conditionId && sObjectMgr.IsPlayerMeetToCondition(i->conditionId, player, player->GetMap(), lootTarget, CONDITION_FROM_LOOT))
+        {
+            return true;
+        }
+    return false;
+}
+
 // Rolls an item from the group (if any takes its chance) and adds the item to the loot
 void LootTemplate::LootGroup::Process(Loot& loot) const
 {
@@ -1414,6 +1474,104 @@ bool LootTemplate::HasQuestDropForPlayer(LootTemplateMap const& store, Player co
     // Now checking groups
     for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
         if (i->HasQuestDropForPlayer(player))
+        {
+            return true;
+        }
+
+    return false;
+}
+
+// True if template includes at least 1 conditional entry
+bool LootTemplate::HasConditionalDrop(LootTemplateMap const& store, uint8 groupId) const
+{
+    if (groupId)                                            // Group reference
+    {
+        if (groupId > Groups.size())
+        {
+            return false;                                    // Error message [should be] already printed at loading stage
+        }
+        return Groups[groupId - 1].HasConditionalDrop();
+    }
+
+    for (LootStoreItemList::const_iterator i = Entries.begin(); i != Entries.end(); ++i)
+    {
+        if (i->conditionId)
+        {
+            return true;
+        }
+
+        if (i->mincountOrRef < 0)                           // References
+        {
+            LootTemplateMap::const_iterator Referenced = store.find(-i->mincountOrRef);
+            if (Referenced == store.end())
+            {
+                continue;                                    // Error message [should be] already printed at loading stage
+            }
+            if (Referenced->second->HasConditionalDrop(store, i->group))
+            {
+                return true;
+            }
+        }
+    }
+
+    for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
+        if (i->HasConditionalDrop())
+        {
+            return true;
+        }
+
+    return false;
+}
+
+// True if template includes at least 1 conditional entry available to the player
+bool LootTemplate::HasConditionalDropForPlayer(LootTemplateMap const& store, Player const* player, WorldObject const* lootTarget, uint8 groupId) const
+{
+    if (!player)
+    {
+        return false;
+    }
+
+    if (groupId)                                            // Group reference
+    {
+        if (groupId > Groups.size())
+        {
+            return false;                                    // Error message already printed at loading stage
+        }
+        return Groups[groupId - 1].HasConditionalDropForPlayer(player, lootTarget);
+    }
+
+    for (LootStoreItemList::const_iterator i = Entries.begin(); i != Entries.end(); ++i)
+    {
+        if (i->mincountOrRef < 0)                           // References
+        {
+            if (i->conditionId)
+            {
+                if (sObjectMgr.IsPlayerMeetToCondition(i->conditionId, player, player->GetMap(), lootTarget, CONDITION_FROM_REFERING_LOOT))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            LootTemplateMap::const_iterator Referenced = store.find(-i->mincountOrRef);
+            if (Referenced == store.end())
+            {
+                continue;                                    // Error message already printed at loading stage
+            }
+            if (Referenced->second->HasConditionalDropForPlayer(store, player, lootTarget, i->group))
+            {
+                return true;
+            }
+        }
+        else if (i->conditionId && sObjectMgr.IsPlayerMeetToCondition(i->conditionId, player, player->GetMap(), lootTarget, CONDITION_FROM_LOOT))
+        {
+            return true;
+        }
+    }
+
+    for (LootGroups::const_iterator i = Groups.begin(); i != Groups.end(); ++i)
+        if (i->HasConditionalDropForPlayer(player, lootTarget))
         {
             return true;
         }

--- a/src/game/Object/LootMgr.h
+++ b/src/game/Object/LootMgr.h
@@ -178,6 +178,8 @@ class LootStore
         bool HaveLootFor(uint32 loot_id) const { return m_LootTemplates.find(loot_id) != m_LootTemplates.end(); }
         bool HaveQuestLootFor(uint32 loot_id) const;
         bool HaveQuestLootForPlayer(uint32 loot_id, Player* player) const;
+        bool HaveConditionalLootFor(uint32 loot_id) const;
+        bool HaveConditionalLootForPlayer(uint32 loot_id, Player* player, WorldObject const* lootTarget) const;
 
         LootTemplate const* GetLootFor(uint32 loot_id) const;
 
@@ -209,6 +211,8 @@ class LootTemplate
         bool HasQuestDrop(LootTemplateMap const& store, uint8 GroupId = 0) const;
         // True if template includes at least 1 quest drop for an active quest of the player
         bool HasQuestDropForPlayer(LootTemplateMap const& store, Player const* player, uint8 GroupId = 0) const;
+        bool HasConditionalDrop(LootTemplateMap const& store, uint8 groupId = 0) const;
+        bool HasConditionalDropForPlayer(LootTemplateMap const& store, Player const* player, WorldObject const* lootTarget, uint8 groupId = 0) const;
 
         // Checks integrity of the template
         void Verify(LootStore const& store, uint32 Id) const;

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -8410,7 +8410,8 @@ void ObjectMgr::LoadGameObjectForQuests()
                 uint32 loot_id = itr->GetLootId();
 
                 // always activate to quest, GO may not have loot, OR find if GO has loot for quest.
-                if (itr->chest.questId || LootTemplates_Gameobject.HaveQuestLootFor(loot_id))
+                if (itr->chest.questId || LootTemplates_Gameobject.HaveQuestLootFor(loot_id) ||
+                    LootTemplates_Gameobject.HaveConditionalLootFor(loot_id))
                 {
                     mGameObjectForQuestSet.insert(itr->id);
                     ++count;

--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -3860,11 +3860,9 @@ void Aura::HandleAuraDummy(bool apply, bool Real)
         }
     }
 
-    // script has to "handle with care", only use where data are not ok to use in the above code.
-    if (target->GetTypeId() == TYPEID_UNIT)
-    {
-        sScriptMgr.OnAuraDummy(this, apply);
-    }
+    // Script has to "handle with care", only use where data are not ok to use in the above code.
+    // Aura scripts are DB-bound by spell/effect and can be needed for player self-use dummy auras.
+    sScriptMgr.OnAuraDummy(this, apply);
 }
 
 void Aura::HandleAuraMounted(bool apply, bool Real)


### PR DESCRIPTION
Adds conditional loot awareness to GO quest activation/sparkle and lets player self dummy auras call DB-bound aura scripts. Required for Kaja'Cola item effect and post-25473 GO loot gating.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/101)
<!-- Reviewable:end -->
