### PR TITLE
[Spell] Guard encounter-state update against removed caster (Fixes #70)

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4679,10 +4679,16 @@ void Spell::finish(bool ok)
     }
 
     // update encounter state if needed
-    Map* map = m_caster->GetMap();
-    if (map->IsDungeon())
+    // Caster may have left the world during the cast pipeline (e.g. a
+    // DB-script-triggered cast targeting a unit that despawned mid-step);
+    // without this guard GetMap() would assert on a NULL m_currMap.
+    if (m_caster->IsInWorld())
     {
-        ((DungeonMap*)map)->GetPersistanceState()->UpdateEncounterState(ENCOUNTER_CREDIT_CAST_SPELL, m_spellInfo->Id);
+        Map* map = m_caster->GetMap();
+        if (map->IsDungeon())
+        {
+            ((DungeonMap*)map)->GetPersistanceState()->UpdateEncounterState(ENCOUNTER_CREDIT_CAST_SPELL, m_spellInfo->Id);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #70 — server crash on entering older instances (Molten Core, Blackwing Lair) with assertion `WorldObject::GetMap failed: m_currMap`.

`Spell::finish` reads `m_caster->GetMap()` to credit `ENCOUNTER_CREDIT_CAST_SPELL` to the dungeon's persistence state. If the caster has been removed from the world earlier in the cast pipeline — most commonly a DB-script `SCRIPT_COMMAND_CAST_SPELL` whose source/target was looked up before an intervening despawn, but also visible with GO-triggered teleports like Orb of Command (spell 23460, `SPELL_EFFECT_TELEPORT_UNITS`) — `m_currMap` is `NULL` and the assertion fires, aborting the world thread.

The crashing block has been in the file unchanged since 2011-09-04 (commit `8e4c46ff2a` by Shauren). The fix is a single `IsInWorld()` guard around the encounter-state-update, matching the idiom already used 6 times elsewhere in `Spell.cpp` (e.g. line 422: `caster->IsInWorld() && caster->GetMap()->IsDungeon()`).

## What changes

5-line guard in `Spell::finish` (`src/game/WorldHandlers/Spell.cpp`). No header, ABI, or signature changes.

## Test plan

- [x] Release build of game.lib clean (warnings-as-errors gate satisfied; no new warnings)
- [x] Live before/after on the two reproducers from the issue:
  - **Molten Core** entrance via instance portal — pre-patch: world thread aborts on assertion, loading screen hangs, `Peer has closed connection`. Post-patch: instance loads cleanly.
  - **Blackwing Lair** entrance via Orb of Command (casts spell 23460 = `SPELL_EFFECT_TELEPORT_UNITS`) — same before/after behavior.
- [x] Smoke verified on a mangosthree install populated with mangos3 / character3 / realmd databases, build 15595, Eluna + SD3 enabled.

## Notes / follow-ups (not in this PR)

1. **mangostwo carries the identical unguarded code** at its `src/game/WorldHandlers/Spell.cpp` line 4459. Mirroring this fix into mangostwo is a sensible follow-up but kept out to stay scoped (one concern per PR).
2. **Root cause defense-in-depth:** `ScriptAction::HandleScriptStep`'s `LogIfNotUnit` validation only checks pointer-non-null + is-Unit, not `IsInWorld()`. Adding that check at the script layer would prevent the bad cast from being issued in the first place, but it's a different subsystem and a different concern.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/102)
<!-- Reviewable:end -->
