### PR TITLE
[MapUpdater] Port from mangostwo

### DIFF
--- a/src/game/Maps/MapUpdater.cpp
+++ b/src/game/Maps/MapUpdater.cpp
@@ -1,0 +1,167 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "MapUpdater.h"
+#include "DelayExecutor.h"
+#include "Map.h"
+
+#include <ace/Guard_T.h>
+#include <ace/Method_Request.h>
+
+/**
+ * @brief A request to update a map.
+ */
+class MapUpdateRequest : public ACE_Method_Request
+{
+    private:
+        Map& m_map; ///< Reference to the map to be updated.
+        MapUpdater& m_updater; ///< Reference to the map updater.
+        ACE_UINT32 m_diff; ///< Time difference for the update.
+
+    public:
+        /**
+         * @brief Constructor for MapUpdateRequest.
+         * @param m Reference to the map.
+         * @param u Reference to the map updater.
+         * @param d Time difference for the update.
+         */
+        MapUpdateRequest(Map& m, MapUpdater& u, ACE_UINT32 d)
+            : m_map(m), m_updater(u), m_diff(d)
+        {
+        }
+
+        /**
+         * @brief Executes the map update request.
+         * @return Always returns 0.
+         */
+        virtual int call()
+        {
+            m_map.Update(m_diff);
+            m_updater.update_finished();
+            return 0;
+        }
+};
+
+/**
+ * @brief Constructor for MapUpdater.
+ */
+MapUpdater::MapUpdater():
+m_executor(), m_mutex(), m_condition(m_mutex), pending_requests(0)
+{
+}
+
+/**
+ * @brief Destructor for MapUpdater.
+ */
+MapUpdater::~MapUpdater()
+{
+    deactivate();
+}
+
+/**
+ * @brief Activates the map updater with the specified number of threads.
+ * @param num_threads Number of threads to activate.
+ * @return Result of the activation.
+ */
+int MapUpdater::activate(size_t num_threads)
+{
+    // mangosthree's DelayExecutor names this entry point activate(); mangostwo uses _activate().
+    return m_executor.activate((int)num_threads);
+}
+
+/**
+ * @brief Deactivates the map updater.
+ * @return Result of the deactivation.
+ */
+int MapUpdater::deactivate()
+{
+    wait();
+    return m_executor.deactivate();
+}
+
+/**
+ * @brief Waits for all pending requests to be processed.
+ * @return Always returns 0.
+ */
+int MapUpdater::wait()
+{
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, m_mutex, -1);
+
+    while (pending_requests > 0)
+    {
+        m_condition.wait();
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Schedules a map update.
+ * @param map Reference to the map to be updated.
+ * @param diff Time difference for the update.
+ * @return Result of the scheduling.
+ */
+int MapUpdater::schedule_update(Map& map, ACE_UINT32 diff)
+{
+    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, m_mutex, -1);
+
+    ++pending_requests;
+
+    if (m_executor.execute(new MapUpdateRequest(map, *this, diff)) == -1)
+    {
+        ACE_DEBUG((LM_ERROR, ACE_TEXT("(%t) \n"), ACE_TEXT("Failed to schedule Map Update")));
+
+        --pending_requests;
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Checks if the map updater is activated.
+ * @return True if activated, false otherwise.
+ */
+bool MapUpdater::activated()
+{
+    return m_executor.activated();
+}
+
+/**
+ * @brief Called when a map update is finished.
+ */
+void MapUpdater::update_finished()
+{
+    ACE_GUARD(ACE_Thread_Mutex, guard, m_mutex);
+
+    if (pending_requests == 0)
+    {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("(%t)\n"), ACE_TEXT("MapUpdater::update_finished BUG, report to devs")));
+        return;
+    }
+
+    --pending_requests;
+
+    m_condition.broadcast();
+}

--- a/src/game/Maps/MapUpdater.h
+++ b/src/game/Maps/MapUpdater.h
@@ -1,0 +1,98 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef _MAP_UPDATER_H_INCLUDED
+#define _MAP_UPDATER_H_INCLUDED
+
+#include <ace/Thread_Mutex.h>
+#include <ace/Condition_Thread_Mutex.h>
+
+#include "DelayExecutor.h"
+
+class Map;
+
+/**
+ * @brief The MapUpdater class is responsible for managing map update requests.
+ */
+class MapUpdater
+{
+    public:
+        /**
+         * @brief Constructor for MapUpdater.
+         */
+        MapUpdater();
+
+        /**
+         * @brief Destructor for MapUpdater.
+         */
+        virtual ~MapUpdater();
+
+        friend class MapUpdateRequest;
+
+        /**
+         * @brief Schedules a map update.
+         * @param map Reference to the map to be updated.
+         * @param diff Time difference for the update.
+         * @return Result of the scheduling.
+         */
+        int schedule_update(Map& map, ACE_UINT32 diff);
+
+        /**
+         * @brief Waits for all pending requests to be processed.
+         * @return Always returns 0.
+         */
+        int wait();
+
+        /**
+         * @brief Activates the map updater with the specified number of threads.
+         * @param num_threads Number of threads to activate.
+         * @return Result of the activation.
+         */
+        int activate(size_t num_threads);
+
+        /**
+         * @brief Deactivates the map updater.
+         * @return Result of the deactivation.
+         */
+        int deactivate();
+
+        /**
+         * @brief Checks if the map updater is activated.
+         * @return True if activated, false otherwise.
+         */
+        bool activated();
+
+    private:
+        DelayExecutor m_executor; ///< Executor for handling delayed tasks.
+        ACE_Thread_Mutex m_mutex; ///< Mutex for synchronizing access to pending requests.
+        ACE_Condition_Thread_Mutex m_condition; ///< Condition variable for signaling when requests are processed.
+        size_t pending_requests; ///< Number of pending update requests.
+
+        /**
+         * @brief Called when a map update is finished.
+         */
+        void update_finished();
+};
+
+#endif //_MAP_UPDATER_H_INCLUDED

--- a/src/game/WorldHandlers/MapManager.cpp
+++ b/src/game/WorldHandlers/MapManager.cpp
@@ -77,6 +77,12 @@ MapManager::Initialize()
     }
 #endif /* ENABLE_ELUNA */
 
+    // Start mtmaps if needed.
+    if (num_threads > 0 && m_updater.activate(num_threads) == -1)
+    {
+        abort();
+    }
+
     InitStateMachine();
 }
 
@@ -208,7 +214,19 @@ void MapManager::Update(uint32 diff)
 
     for (MapMapType::iterator iter = i_maps.begin(); iter != i_maps.end(); ++iter)
     {
-        iter->second->Update((uint32)i_timer.GetCurrent());
+        if (m_updater.activated())
+        {
+            m_updater.schedule_update(*iter->second, (uint32)i_timer.GetCurrent());
+        }
+        else
+        {
+            iter->second->Update((uint32)i_timer.GetCurrent());
+        }
+    }
+
+    if (m_updater.activated())
+    {
+        m_updater.wait();
     }
 
     for (TransportSet::iterator iter = m_Transports.begin(); iter != m_Transports.end(); ++iter)
@@ -278,6 +296,11 @@ void MapManager::UnloadAll()
     }
 
     TerrainManager::Instance().UnloadAll();
+
+    if (m_updater.activated())
+    {
+        m_updater.deactivate();
+    }
 }
 
 uint32 MapManager::GetNumInstances()

--- a/src/game/WorldHandlers/MapManager.h
+++ b/src/game/WorldHandlers/MapManager.h
@@ -31,6 +31,7 @@
 #include "ace/Recursive_Thread_Mutex.h"
 #include "Map.h"
 #include "GridStates.h"
+#include "MapUpdater.h"
 
 class Transport;
 class BattleGround;
@@ -183,6 +184,7 @@ class MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::ClassLevelLockab
         uint32 i_gridCleanUpDelay;
         MapMapType i_maps;
         IntervalTimer i_timer;
+        MapUpdater m_updater;
 };
 
 template<typename Do>

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -128,7 +128,11 @@ BindIP                       = "0.0.0.0"
 #        Default: 100
 #
 #    MapUpdateThreads
-#        Number of map update threads to run
+#        Number of threads used to tick maps in parallel via MapUpdater.
+#          0 or 1 = serial (pre-port behavior; force this to restore
+#                   single-threaded map ticking).
+#          >= 2   = parallel map ticking via MapUpdater. Matches mangostwo's
+#                   long-standing production default.
 #        Default: 2
 #
 #    ChangeWeatherInterval


### PR DESCRIPTION
## Summary
- Ports the MapUpdater subsystem from mangostwo (`src/game/Maps/MapUpdater.{cpp,h}` + MapManager hookup) so mangosthree can finally tick maps in parallel.
- The `MapUpdateThreads` config option has been visible to admins for years but did nothing — the value was read in `MapManager::Initialize` and silently dropped. This PR makes the option actually do what its name and pre-port default of 2 claimed.
- Default is kept at **2** in `World.cpp` and `mangosd.conf.dist.in`, matching mangostwo's long-standing shipping default. Setting `MapUpdateThreads = 0` or `1` falls through to the pre-port direct-`Map::Update()` code path, so the toggle is a clean escape hatch.

The only intentional source-level divergence from mangostwo's class is `m_executor.activate()` (mangosthree's `DelayExecutor` API) instead of mangostwo's `_activate()`.

## Test plan
- [x] Release build with the project's warnings-as-errors gate enabled — no new warnings on the added code. (Pre-existing Eluna `C4063` warnings are inside the submodule and out of scope.)
- [x] Serial path: `MapUpdateThreads = 0` — server starts, world init complete, login + world entry + play + logout to character select + full quit all clean. Confirms the new branching is a no-op when disabled.
- [x] Parallel path: `MapUpdateThreads = 2` — server starts, world init complete, two clients on separate continents (two world maps ticking in parallel), dungeon entry (instance map ticking alongside world maps), distance-crossing on both clients. No asserts, aborts, or threading anomalies in `world-server.log` after the session.
- [ ] Not exercised in this smoke: LFR matchmaking, cross-realm zones, BG queue dispatch. These rely on the same threading model mangostwo ships at `default = 2` and inherit that production track record.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/103)
<!-- Reviewable:end -->
