### PR TITLE
[Server] Enable CMSG_OBJECT_UPDATE_FAILED handler

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -1420,7 +1420,7 @@ void InitializeOpcodes()
     OPCODE(SMSG_PVP_OPTIONS_ENABLED,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_REQUEST_HOTFIX,                          STATUS_AUTHED,   PROCESS_INPLACE,      &WorldSession::HandleRequestHotfix             );
     OPCODE(SMSG_DB_REPLY,                                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(CMSG_OBJECT_UPDATE_FAILED,                    STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::HandleObjectUpdateFailedOpcode  );
+    OPCODE(CMSG_OBJECT_UPDATE_FAILED,                    STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::HandleObjectUpdateFailedOpcode  );
     OPCODE(CMSG_REFORGE_ITEM,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleReforgeItemOpcode         );
     OPCODE(SMSG_REFORGE_RESULT,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_START_TIMER,                             STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );


### PR DESCRIPTION
## Summary

Enables the `CMSG_OBJECT_UPDATE_FAILED` (0x3808) handler that has been registered-but-commented-out in mangosthree's opcode table since the initial project import (commit `9d20fe2b3` "Initial project location adjustment").

The opcode is what 4.3.4 clients send when they receive an `SMSG_UPDATE_OBJECT` they cannot construct (object not in the client's known set, deserialization mismatch, etc.). The proper server response is to look the object up by GUID on the player's map and re-send a full create-update via `SendCreateUpdateToPlayer`, allowing the client to recover and finish rendering.

The handler `WorldSession::HandleObjectUpdateFailedOpcode` at `src/game/WorldHandlers/MiscHandler.cpp:1844-1862` is **already implemented correctly** — Cata GUID byte order, `IsInWorld()` guard around the Map lookup, proper `SendCreateUpdateToPlayer` call. Only the dispatch table entry was missing, so the opcode arrived, was logged as `received not handled opcode UNKNOWN (0x3808)`, and silently dropped. Clients then retry the same recovery request indefinitely.

## What changes

One-line change in `src/game/Server/Opcodes.cpp`. Uncomments the existing `OPCODE(CMSG_OBJECT_UPDATE_FAILED, ...)` registration. No header, ABI, or signature changes.

## Empirical evidence

Reproduced 2026-05-14 by entering Blackrock Caverns (map 645) and returning to the outdoor world. After several in/out cycles, the client hung on the loading screen and `world-server.log` showed:

    16:17:19 SESSION: received not handled opcode UNKNOWN (0x3808)
    16:17:19 SESSION: received not handled opcode UNKNOWN (0x3808)
    16:17:21 SESSION: received not handled opcode UNKNOWN (0x3808)
    ... (9 occurrences in 9 seconds — client retrying once per second)

After uncommenting, an identical-setup re-test produced **exactly 1** occurrence — the server responded, client stopped retrying.

## Test plan

- [x] Release build clean on warnings-as-errors gate, no new warnings
- [x] Live verification on a populated mangosthree install (mangos3 / character3 / realmd, build 15595, Eluna + SD3 enabled, MapUpdateThreads=2): starts cleanly, world init complete, dungeon entry/exit cycles proceed, log no longer shows `received not handled opcode UNKNOWN (0x3808)` lines.

## Scope

This wires up a handler that is itself correct. The deeper question of why the client sometimes cannot construct the player's own object packet in the first place (after long instance stays under heavy session activity) is **not addressed here**; that requires a separate investigation into the player UpdateData generation path (`Map::SendInitSelf`, `Player::BuildCreateUpdateBlockForPlayer`, the `SMSG_UPDATE_OBJECT` byte serialization). What this commit does fix is the silent-drop behavior — the server now responds to the recovery request instead of ignoring it. That's enough to remove the log spam, restore the standard error-recovery handshake, and unblock some, though not all, of the stuck cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/104)
<!-- Reviewable:end -->
