### PR TITLE
[Tests] Add Cata 4.0.1 crushing-blow spec tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
     test_AuraSystem.cpp
     test_ThreatSystem.cpp
     test_CombatFormulas.cpp
+    test_CataCombatFormulas.cpp
     test_InventorySystem.cpp
     test_MovementSystem.cpp
     test_GridSystem.cpp
@@ -95,6 +96,7 @@ add_test(NAME SpellEffectsTests    COMMAND mangos_tests WORKING_DIRECTORY ${CMAK
 add_test(NAME AuraSystemTests      COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME ThreatSystemTests    COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME CombatFormulasTests  COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME CataCombatFormulasTests COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME InventorySystemTests COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME MovementSystemTests  COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 add_test(NAME GridSystemTests      COMMAND mangos_tests WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/test_CataCombatFormulas.cpp
+++ b/tests/test_CataCombatFormulas.cpp
@@ -24,122 +24,89 @@
 // (the Cataclysm pre-expansion patch) and must behave per the new rules in
 // any 4.3.4-build-15595 server.
 //
-// Canonical reference: https://www.wowhead.com/guide=4.0.1
-//
-// Tests in this file verify STRUCTURAL Cata-correctness only (i.e. "when can
-// outcome X happen"). Exact magnitudes (chance percentages, damage multipliers)
-// are intentionally not asserted yet — they need to be looked up on Wowhead
-// and cross-checked against TC-Preservation 4.3.4 before being pinned to a
-// specific value, per the project rule on Wowhead ID verification.
+// Canonical references:
+//   https://warcraft.wiki.gg/wiki/Crushing_blow  (2025-11-27)
+//   https://wowpedia.fandom.com/wiki/Crushing_blow
+//   https://www.wowhead.com/guide=4.0.1
 // ============================================================================
 
 namespace CataCombatTest
 {
 
 // ----------------------------------------------------------------------------
-// Crushing blow (post-Patch 4.0.1)
+// Crushing blow (post-Patch 3.0.2, retained through Cata 4.3.4)
 //
-// Rules retained from 3.0.2+: the attacker must be 4+ levels above the
-// defender to score a crushing blow. (Raid bosses were standardized to 3
-// levels above max-level players in 4.0.1, so bosses can no longer crush.)
+// Canonical Blizzard formula:
+//   chance% = max(skill_diff, 20) * 2% - 15%
+//   where  skill_diff = (attackerLevel - defenderLevel) * 5
 //
-// New in 4.0.1: properly-spec'd tanks in their tanking stance / presence /
-// form gain effective uncrushable status alongside uncrittable, regardless
-// of attacker level. This replaces the WotLK defense-cap mechanic.
+// Rules:
+// - Attacker must be 4+ levels above defender to crush
+//   (skill_diff >= 20 in the formula's floor).
+// - Raid bosses in 4.0+ are standardized to +3 levels above max-level
+//   players; they fail the floor and cannot crush. This is the entire
+//   reason tanks are "effectively uncrushable" in raids — it's emergent
+//   from the level rule, not a separate stance/aura mechanism.
 // ----------------------------------------------------------------------------
 
 // Returns crushing-blow chance as a percentage [0, 100].
-// `defenderIsProperTank` should be true when the defender is in their
-// tanking stance/presence/form (Defensive Stance, Bear Form, Blood Presence,
-// Righteous Fury active, etc.).
-//
-// Note: the non-zero return for the "can crush" branch is intentionally a
-// placeholder constant. The Cata-correct chance formula needs to be
-// confirmed against Wowhead 4.0.1 and TC-Preservation before being pinned.
-// Tests below only assert which branch is taken, not the magnitude.
-float CalculateCrushingChanceCata(int32_t attackerLevel,
-                                  int32_t defenderLevel,
-                                  bool defenderIsProperTank)
+float CalculateCrushingChanceCata(int32_t attackerLevel, int32_t defenderLevel)
 {
-    if (defenderIsProperTank)
+    const int32_t skillDiff = (attackerLevel - defenderLevel) * 5;
+    if (skillDiff < 20)
     {
         return 0.0f;
     }
-
-    const int32_t diff = attackerLevel - defenderLevel;
-    if (diff < 4)
-    {
-        return 0.0f;
-    }
-
-    // Placeholder positive chance — actual Cata value to be verified.
-    return 15.0f;
+    return float(skillDiff) * 2.0f - 15.0f;
 }
 
 } // namespace CataCombatTest
 
 // ============================================================================
-// Level-difference rule (post-3.0.2, retained in 4.0.1)
+// Below the 4-level floor: no crushing
 // ============================================================================
 
 TEST(CataCrushingBlow, EqualLevel_NoCrush)
 {
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(85, 85, false));
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(85, 85));
 }
 
 TEST(CataCrushingBlow, AttackerOneAbove_NoCrush)
 {
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(86, 85, false));
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(86, 85));
 }
 
 TEST(CataCrushingBlow, AttackerThreeAbove_BossDiff_NoCrush)
 {
-    // Raid bosses are 3 levels above max-level players in 4.0.1.
-    // They must not be able to crush.
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(88, 85, false));
-}
-
-TEST(CataCrushingBlow, AttackerFourAbove_CanCrush)
-{
-    // Trash mobs 4+ levels above retain the ability to crush in Cata.
-    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(85, 81, false), 0.0f);
-}
-
-TEST(CataCrushingBlow, AttackerTenAbove_CanCrush)
-{
-    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(85, 75, false), 0.0f);
+    // Raid bosses are standardized to +3 levels above max-level players.
+    // skill_diff = 15, below the 20 floor.
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(88, 85));
 }
 
 // ============================================================================
-// Tank-stance uncrushable (new in 4.0.1)
+// At and above the 4-level floor: verified Blizzard percentages
 // ============================================================================
 
-TEST(CataCrushingBlow, TankInStance_FourAbove_Uncrushable)
+TEST(CataCrushingBlow, AttackerFourAbove_25Percent)
 {
-    // A proper tank in stance must be uncrushable even when the attacker
-    // meets the level-diff threshold.
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(85, 81, true));
+    // skill_diff = 20, at the floor. 20*2% - 15% = 25%.
+    EXPECT_FLOAT_EQ(25.0f, CataCombatTest::CalculateCrushingChanceCata(85, 81));
 }
 
-TEST(CataCrushingBlow, TankInStance_TenAbove_Uncrushable)
+TEST(CataCrushingBlow, AttackerFiveAbove_35Percent)
 {
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(95, 85, true));
+    // skill_diff = 25. 25*2% - 15% = 35%.
+    EXPECT_FLOAT_EQ(35.0f, CataCombatTest::CalculateCrushingChanceCata(85, 80));
 }
 
-TEST(CataCrushingBlow, TankInStance_BossDiff_Uncrushable)
+TEST(CataCrushingBlow, AttackerSixAbove_45Percent)
 {
-    // Both rules apply: 3-level boss diff already blocks crushing, and
-    // tank-stance must also block. Belt and braces.
-    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(88, 85, true));
+    // skill_diff = 30. 30*2% - 15% = 45%.
+    EXPECT_FLOAT_EQ(45.0f, CataCombatTest::CalculateCrushingChanceCata(85, 79));
 }
 
-// ============================================================================
-// Non-tank-player sanity (must still take crushes from 4+ above)
-// ============================================================================
-
-TEST(CataCrushingBlow, NonTankPlayer_HighDiff_CanCrush)
+TEST(CataCrushingBlow, AttackerTenAbove_85Percent)
 {
-    // A DPS/healer (no tanking stance) at level 85 attacked by a level-95
-    // elite must still be crushable.
-    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(95, 85, false), 0.0f);
+    // skill_diff = 50. 50*2% - 15% = 85%.
+    EXPECT_FLOAT_EQ(85.0f, CataCombatTest::CalculateCrushingChanceCata(85, 75));
 }

--- a/tests/test_CataCombatFormulas.cpp
+++ b/tests/test_CataCombatFormulas.cpp
@@ -60,6 +60,59 @@ float CalculateCrushingChanceCata(int32_t attackerLevel, int32_t defenderLevel)
     return float(skillDiff) * 2.0f - 15.0f;
 }
 
+// ----------------------------------------------------------------------------
+// Armor damage reduction (Cata 4.3.4)
+//
+// Canonical wiki formula:
+//   DR% = armor / (armor + K), capped at 75%
+//
+// where K depends on the attacker's level L:
+//   K(L) = 400 + 85*L              for L < 60
+//   K(L) = 467.5*L - 22167.5       for L >= 60
+//
+// Equivalent expanded form used in production code:
+//   denom         = 8.5 * levelModifier + 40
+//   levelModifier = L                       for L < 60
+//   levelModifier = L + 4.5*(L - 59)        for L >= 60
+//   K             = 10 * denom
+//
+// Specific K values:
+//   60: 5882.5     70: 10557.5    80: 15232.5
+//   83 (raid boss vs L80): 16635  85 (max): 17570
+//
+// NOTE: TC-Preservation includes an additional `+20*(L-80)` term in the
+// level modifier for L > 80 (giving K=26070 at L=85), citing the client's
+// Paperdollframe.lua. That file is the tooltip-display calculation and may
+// not reflect the server-side damage math. The Wowpedia / Warcraft Wiki /
+// WoWWiki sources consistently document the no-kicker formula, and
+// mangosthree's `Unit::CalcArmorReducedDamage` already implements it
+// correctly. These tests lock that in as a regression guard.
+// ----------------------------------------------------------------------------
+
+float CalculateArmorDRCata(float armor, int32_t attackerLevel)
+{
+    if (armor < 0.0f)
+    {
+        return 0.0f;
+    }
+
+    float levelModifier = float(attackerLevel);
+    if (attackerLevel > 59)
+    {
+        levelModifier += 4.5f * (levelModifier - 59.0f);
+    }
+
+    const float denom = 8.5f * levelModifier + 40.0f;
+    const float temp = 0.1f * armor / denom;
+    float dr = temp / (1.0f + temp);
+
+    if (dr > 0.75f)
+    {
+        dr = 0.75f;
+    }
+    return dr * 100.0f;
+}
+
 } // namespace CataCombatTest
 
 // ============================================================================
@@ -109,4 +162,69 @@ TEST(CataCrushingBlow, AttackerTenAbove_85Percent)
 {
     // skill_diff = 50. 50*2% - 15% = 85%.
     EXPECT_FLOAT_EQ(85.0f, CataCombatTest::CalculateCrushingChanceCata(85, 75));
+}
+
+// ============================================================================
+// Armor DR: zero / negative / cap behaviour
+// ============================================================================
+
+TEST(CataArmorDR, ZeroArmor_NoReduction)
+{
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateArmorDRCata(0.0f, 85));
+}
+
+TEST(CataArmorDR, NegativeArmor_ClampedToZero)
+{
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateArmorDRCata(-100.0f, 85));
+}
+
+TEST(CataArmorDR, MassiveArmor_CappedAt75Percent)
+{
+    EXPECT_FLOAT_EQ(75.0f, CataCombatTest::CalculateArmorDRCata(1000000.0f, 85));
+}
+
+// ============================================================================
+// 50% reduction is reached at armor == K(level)
+// ============================================================================
+
+TEST(CataArmorDR, Level60_AtK_50Percent)
+{
+    // K = 467.5*60 - 22167.5 = 5882.5
+    EXPECT_FLOAT_EQ(50.0f, CataCombatTest::CalculateArmorDRCata(5882.5f, 60));
+}
+
+TEST(CataArmorDR, Level70_AtK_50Percent)
+{
+    // K = 467.5*70 - 22167.5 = 10557.5
+    EXPECT_FLOAT_EQ(50.0f, CataCombatTest::CalculateArmorDRCata(10557.5f, 70));
+}
+
+TEST(CataArmorDR, Level80_AtK_50Percent)
+{
+    // K = 467.5*80 - 22167.5 = 15232.5
+    EXPECT_FLOAT_EQ(50.0f, CataCombatTest::CalculateArmorDRCata(15232.5f, 80));
+}
+
+TEST(CataArmorDR, Level83_RaidBoss_AtK_50Percent)
+{
+    // K = 467.5*83 - 22167.5 = 16635.0. Raid bosses are +3 levels above
+    // max-level players; this is the value seen by an L80 tank in WotLK
+    // raids and an L82 tank vs Cata heroic-mode +1 trash.
+    EXPECT_FLOAT_EQ(50.0f, CataCombatTest::CalculateArmorDRCata(16635.0f, 83));
+}
+
+TEST(CataArmorDR, Level85_MaxLevel_AtK_50Percent)
+{
+    // K = 467.5*85 - 22167.5 = 17570
+    EXPECT_FLOAT_EQ(50.0f, CataCombatTest::CalculateArmorDRCata(17570.0f, 85));
+}
+
+// ============================================================================
+// 75% cap is reached exactly at armor == 3 * K
+// ============================================================================
+
+TEST(CataArmorDR, Level85_ThreeXK_HitsCapExactly)
+{
+    // armor/K = 3 -> DR = 3/(3+1) = 0.75 = cap.
+    EXPECT_FLOAT_EQ(75.0f, CataCombatTest::CalculateArmorDRCata(52710.0f, 85));
 }

--- a/tests/test_CataCombatFormulas.cpp
+++ b/tests/test_CataCombatFormulas.cpp
@@ -113,6 +113,54 @@ float CalculateArmorDRCata(float armor, int32_t attackerLevel)
     return dr * 100.0f;
 }
 
+// ----------------------------------------------------------------------------
+// PvP Resilience damage reduction (Cata 4.0.1+)
+//
+// Patch 4.0.1 reworked resilience to be PvP-only damage reduction; it no
+// longer reduces critical-hit chance or critical-hit damage (those were the
+// WotLK-era functions). Patch 4.1.0 made the resilience-rating-to-percent
+// conversion linear.
+//
+// Application formula (the part testable as a pure function):
+//   damage_after = damage * (1 - reduction_pct / 100)
+//
+// where `reduction_pct` is computed from the victim's
+// CR_RESILIENCE_PLAYER_DAMAGE_TAKEN rating via gtCombatRatings.dbc
+// (data-driven, like mastery — not a hardcoded formula).
+//
+// Eligibility (NOT modeled below — separate predicate):
+//   - Damage source must be a player or player-controlled pet/minion
+//   - Victim must be a player or player-controlled pet/minion
+//   - Multi-passenger vehicles count if a player is mounted; pure NPC
+//     vehicles do not
+//
+// Reference: TC-Preservation Unit::ApplyResilience -> GetDamageReduction ->
+// GetCombatRatingDamageReduction. Numerical magnitudes intentionally NOT
+// asserted here — they live in DBC data and must be verified at runtime
+// against `gtCombatRatings.dbc` row CR_RESILIENCE_PLAYER_DAMAGE_TAKEN.
+// ----------------------------------------------------------------------------
+
+// Returns damage after resilience reduction. Reduction is given as a percent
+// in [0, 100]; values above 100 clamp to fully mitigated, negatives clamp to
+// no-op.
+uint32_t ApplyResilienceReduction(uint32_t damage, float reductionPct)
+{
+    if (reductionPct <= 0.0f)
+    {
+        return damage;
+    }
+    if (reductionPct >= 100.0f)
+    {
+        return 0;
+    }
+    const float reduction = float(damage) * reductionPct / 100.0f;
+    if (reduction >= float(damage))
+    {
+        return 0;
+    }
+    return damage - uint32_t(reduction);
+}
+
 } // namespace CataCombatTest
 
 // ============================================================================
@@ -227,4 +275,60 @@ TEST(CataArmorDR, Level85_ThreeXK_HitsCapExactly)
 {
     // armor/K = 3 -> DR = 3/(3+1) = 0.75 = cap.
     EXPECT_FLOAT_EQ(75.0f, CataCombatTest::CalculateArmorDRCata(52710.0f, 85));
+}
+
+// ============================================================================
+// Resilience: no-op / extreme reduction values
+// ============================================================================
+
+TEST(CataResilience, ZeroPercent_NoChange)
+{
+    EXPECT_EQ(1000u, CataCombatTest::ApplyResilienceReduction(1000u, 0.0f));
+}
+
+TEST(CataResilience, NegativePercent_NoChange)
+{
+    // Defensive: negative reduction is nonsensical; clamp to no-op.
+    EXPECT_EQ(1000u, CataCombatTest::ApplyResilienceReduction(1000u, -5.0f));
+}
+
+TEST(CataResilience, FullHundredPercent_ZeroDamage)
+{
+    EXPECT_EQ(0u, CataCombatTest::ApplyResilienceReduction(1000u, 100.0f));
+}
+
+TEST(CataResilience, OverHundredPercent_ClampsToZero)
+{
+    // Defensive: > 100% should not produce negative damage.
+    EXPECT_EQ(0u, CataCombatTest::ApplyResilienceReduction(1000u, 150.0f));
+}
+
+TEST(CataResilience, ZeroDamage_StaysZero)
+{
+    EXPECT_EQ(0u, CataCombatTest::ApplyResilienceReduction(0u, 25.0f));
+}
+
+// ============================================================================
+// Resilience: standard reduction math
+// ============================================================================
+
+TEST(CataResilience, HalfReduction_HalvesDamage)
+{
+    EXPECT_EQ(500u, CataCombatTest::ApplyResilienceReduction(1000u, 50.0f));
+}
+
+TEST(CataResilience, QuarterReduction_RemovesQuarter)
+{
+    EXPECT_EQ(750u, CataCombatTest::ApplyResilienceReduction(1000u, 25.0f));
+}
+
+TEST(CataResilience, TenPercentReduction_TenPercentOff)
+{
+    EXPECT_EQ(900u, CataCombatTest::ApplyResilienceReduction(1000u, 10.0f));
+}
+
+TEST(CataResilience, FractionalReduction_TruncatesIntegerMath)
+{
+    // 100 damage * 33.3% = 33.3 -> truncated to 33; 100 - 33 = 67.
+    EXPECT_EQ(67u, CataCombatTest::ApplyResilienceReduction(100u, 33.3f));
 }

--- a/tests/test_CataCombatFormulas.cpp
+++ b/tests/test_CataCombatFormulas.cpp
@@ -1,0 +1,145 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "TestFramework.h"
+
+#include <cstdint>
+#include <cmath>
+#include <algorithm>
+
+// ============================================================================
+// Cataclysm 4.0.1+ combat-formula regressions
+//
+// This file complements test_CombatFormulas.cpp, which covers pre-Cata
+// (WotLK-era) combat math. The mechanics below were reworked in Patch 4.0.1
+// (the Cataclysm pre-expansion patch) and must behave per the new rules in
+// any 4.3.4-build-15595 server.
+//
+// Canonical reference: https://www.wowhead.com/guide=4.0.1
+//
+// Tests in this file verify STRUCTURAL Cata-correctness only (i.e. "when can
+// outcome X happen"). Exact magnitudes (chance percentages, damage multipliers)
+// are intentionally not asserted yet — they need to be looked up on Wowhead
+// and cross-checked against TC-Preservation 4.3.4 before being pinned to a
+// specific value, per the project rule on Wowhead ID verification.
+// ============================================================================
+
+namespace CataCombatTest
+{
+
+// ----------------------------------------------------------------------------
+// Crushing blow (post-Patch 4.0.1)
+//
+// Rules retained from 3.0.2+: the attacker must be 4+ levels above the
+// defender to score a crushing blow. (Raid bosses were standardized to 3
+// levels above max-level players in 4.0.1, so bosses can no longer crush.)
+//
+// New in 4.0.1: properly-spec'd tanks in their tanking stance / presence /
+// form gain effective uncrushable status alongside uncrittable, regardless
+// of attacker level. This replaces the WotLK defense-cap mechanic.
+// ----------------------------------------------------------------------------
+
+// Returns crushing-blow chance as a percentage [0, 100].
+// `defenderIsProperTank` should be true when the defender is in their
+// tanking stance/presence/form (Defensive Stance, Bear Form, Blood Presence,
+// Righteous Fury active, etc.).
+//
+// Note: the non-zero return for the "can crush" branch is intentionally a
+// placeholder constant. The Cata-correct chance formula needs to be
+// confirmed against Wowhead 4.0.1 and TC-Preservation before being pinned.
+// Tests below only assert which branch is taken, not the magnitude.
+float CalculateCrushingChanceCata(int32_t attackerLevel,
+                                  int32_t defenderLevel,
+                                  bool defenderIsProperTank)
+{
+    if (defenderIsProperTank)
+    {
+        return 0.0f;
+    }
+
+    const int32_t diff = attackerLevel - defenderLevel;
+    if (diff < 4)
+    {
+        return 0.0f;
+    }
+
+    // Placeholder positive chance — actual Cata value to be verified.
+    return 15.0f;
+}
+
+} // namespace CataCombatTest
+
+// ============================================================================
+// Level-difference rule (post-3.0.2, retained in 4.0.1)
+// ============================================================================
+
+TEST(CataCrushingBlow, EqualLevel_NoCrush)
+{
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(85, 85, false));
+}
+
+TEST(CataCrushingBlow, AttackerOneAbove_NoCrush)
+{
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(86, 85, false));
+}
+
+TEST(CataCrushingBlow, AttackerThreeAbove_BossDiff_NoCrush)
+{
+    // Raid bosses are 3 levels above max-level players in 4.0.1.
+    // They must not be able to crush.
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(88, 85, false));
+}
+
+TEST(CataCrushingBlow, AttackerFourAbove_CanCrush)
+{
+    // Trash mobs 4+ levels above retain the ability to crush in Cata.
+    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(85, 81, false), 0.0f);
+}
+
+TEST(CataCrushingBlow, AttackerTenAbove_CanCrush)
+{
+    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(85, 75, false), 0.0f);
+}
+
+// ============================================================================
+// Tank-stance uncrushable (new in 4.0.1)
+// ============================================================================
+
+TEST(CataCrushingBlow, TankInStance_FourAbove_Uncrushable)
+{
+    // A proper tank in stance must be uncrushable even when the attacker
+    // meets the level-diff threshold.
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(85, 81, true));
+}
+
+TEST(CataCrushingBlow, TankInStance_TenAbove_Uncrushable)
+{
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(95, 85, true));
+}
+
+TEST(CataCrushingBlow, TankInStance_BossDiff_Uncrushable)
+{
+    // Both rules apply: 3-level boss diff already blocks crushing, and
+    // tank-stance must also block. Belt and braces.
+    EXPECT_FLOAT_EQ(0.0f, CataCombatTest::CalculateCrushingChanceCata(88, 85, true));
+}
+
+// ============================================================================
+// Non-tank-player sanity (must still take crushes from 4+ above)
+// ============================================================================
+
+TEST(CataCrushingBlow, NonTankPlayer_HighDiff_CanCrush)
+{
+    // A DPS/healer (no tanking stance) at level 85 attacked by a level-95
+    // elite must still be crushable.
+    EXPECT_GT(CataCombatTest::CalculateCrushingChanceCata(95, 85, false), 0.0f);
+}


### PR DESCRIPTION
## Summary

Adds `tests/test_CataCombatFormulas.cpp` — a Phase-1 specification test file that complements `test_CombatFormulas.cpp` and covers post-Patch 4.0.1 crushing-blow rules.

## Cata rules being asserted

- **Level-difference rule (retained from 3.0.2):** attacker must be 4+ levels above defender to crush. Raid bosses standardized to 3 levels above max-level players in 4.0.1, so bosses can no longer crush.
- **Tank-stance uncrushable (new in 4.0.1):** properly-spec'd tanks in their tanking stance/presence/form are uncrushable regardless of attacker level. Replaces the WotLK defense-cap mechanic.

Reference: https://www.wowhead.com/guide=4.0.1

## Tests

9 tests across 3 sections in suite `CataCrushingBlow`:

- **Level rule:** `EqualLevel_NoCrush`, `AttackerOneAbove_NoCrush`, `AttackerThreeAbove_BossDiff_NoCrush`, `AttackerFourAbove_CanCrush`, `AttackerTenAbove_CanCrush`
- **Tank stance:** `TankInStance_FourAbove_Uncrushable`, `TankInStance_TenAbove_Uncrushable`, `TankInStance_BossDiff_Uncrushable`
- **Non-tank sanity:** `NonTankPlayer_HighDiff_CanCrush`

Suite count: 938 → 947, all passing in ~6.7s (Windows MSVC 2022, VS 17).

## Design notes

Tests exercise a reimplemented `CalculateCrushingChanceCata` inside the test file per this framework's existing convention. The reimplemented formula's positive-chance value is a placeholder constant — the exact Cata percentage needs Wowhead verification before being pinned, so the tests assert only structural rules (level threshold, tank-stance bypass), not magnitudes.

A future production PR (separate, branched off `master`) will extract the crushing branch from `Unit::RollMeleeOutcomeAgainst` into a pure helper and wire this spec test to the real code — turning it from Phase-1 documentation into a Phase-3 regression guard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/105)
<!-- Reviewable:end -->
