### PR TITLE
[Combat] Cata-correct PvP resilience math; remove WotLK crit-specific path

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2043,9 +2043,8 @@ void Unit::CalculateSpellDamage(SpellNonMeleeDamage* damageInfo, int32 damage, S
             {
                 damageInfo->HitInfo |= SPELL_HIT_TYPE_CRIT;
                 damage = SpellCriticalDamageBonus(spellInfo, damage, pVictim);
-                // Resilience - reduce crit damage
-                uint32 reduction_affected_damage = CalcNotIgnoreDamageReduction(damage, damageSchoolMask);
-                damage -= pVictim->GetCritDamageReduction(reduction_affected_damage);
+                // Cata 4.0.1: no separate crit-damage resilience reduction;
+                // the single GetDamageReduction call below covers crit damage.
             }
         }
         break;
@@ -2062,9 +2061,8 @@ void Unit::CalculateSpellDamage(SpellNonMeleeDamage* damageInfo, int32 damage, S
             {
                 damageInfo->HitInfo |= SPELL_HIT_TYPE_CRIT;
                 damage = SpellCriticalDamageBonus(spellInfo, damage, pVictim);
-                // Resilience - reduce crit damage
-                uint32 reduction_affected_damage = CalcNotIgnoreDamageReduction(damage, damageSchoolMask);
-                damage -= pVictim->GetCritDamageReduction(reduction_affected_damage);
+                // Cata 4.0.1: no separate crit-damage resilience reduction;
+                // the single GetDamageReduction call below covers crit damage.
             }
         }
         break;
@@ -2274,12 +2272,9 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
                 damageInfo->damage = int32((damageInfo->damage) * float((100.0f + mod) / 100.0f));
             }
 
-            // Resilience - reduce crit damage
-            uint32 reduction_affected_damage = CalcNotIgnoreDamageReduction(damageInfo->damage, damageInfo->damageSchoolMask);
-            uint32 resilienceReduction = pVictim->GetCritDamageReduction(reduction_affected_damage);
-
-            damageInfo->damage      -= resilienceReduction;
-            damageInfo->cleanDamage += resilienceReduction;
+            // Cata 4.0.1: no separate crit-damage resilience reduction; the
+            // single GetDamageReduction pass at the "// only from players"
+            // block below handles crit damage too.
             break;
         }
         case MELEE_HIT_PARRY:

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -2228,10 +2228,15 @@ class Unit : public WorldObject
          */
         void DealSpellDamage(SpellNonMeleeDamage* damageInfo, bool durabilityLoss);
 
-        // player or player's pet resilience (-1%)
+        // WotLK-era crit-specific resilience helper. Cata 4.0.1 collapsed
+        // crit-damage resilience into the single damage-reduction path; this
+        // method is retained for any legacy callers but should not be invoked
+        // from new code on a 4.3.4 server.
         uint32 GetCritDamageReduction(uint32 damage) const { return GetCombatRatingDamageReduction(CR_RESILIENCE_DAMAGE_TAKEN, 2.2f, 33.0f, damage); }
-        // player or player's pet resilience (-1%), cap 100%
-        uint32 GetDamageReduction(uint32 damage) const { return GetCombatRatingDamageReduction(CR_RESILIENCE_DAMAGE_TAKEN, 2.0f, 100.0f, damage); }
+        // Cata 4.0.1: linear rate of 1.0 against the DBC-driven rating bonus
+        // (gtCombatRatings.dbc, ~95.79 rating per 1% at L85). The WotLK-era
+        // 2.0f multiplier double-counted the conversion table.
+        uint32 GetDamageReduction(uint32 damage) const { return GetCombatRatingDamageReduction(CR_RESILIENCE_DAMAGE_TAKEN, 1.0f, 100.0f, damage); }
 
         float  MeleeSpellMissChance(Unit* pVictim, WeaponAttackType attType, int32 skillDiff, SpellEntry const* spell);
         /**

--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -8467,8 +8467,8 @@ void Aura::PeriodicTick()
             if (isCrit)
             {
                 cleanDamage.hitOutCome = MELEE_HIT_CRIT;
-                // Resilience - reduce crit damage
-                pdamage -= target->GetCritDamageReduction(pdamage);
+                // Cata 4.0.1: no separate crit-damage resilience reduction;
+                // the GetDamageReduction call below covers crit damage.
             }
 
             // only from players
@@ -8573,8 +8573,8 @@ void Aura::PeriodicTick()
             if (isCrit)
             {
                 cleanDamage.hitOutCome = MELEE_HIT_CRIT;
-                // Resilience - reduce crit damage
-                pdamage -= target->GetCritDamageReduction(pdamage);
+                // Cata 4.0.1: no separate crit-damage resilience reduction;
+                // the GetDamageReduction call below covers crit damage.
             }
 
             // only from players
@@ -8815,11 +8815,8 @@ void Aura::PeriodicTick()
 
             int32 drain_amount = target->GetPower(power) > pdamage ? pdamage : target->GetPower(power);
 
-            // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
-            if (power == POWER_MANA)
-            {
-                drain_amount -= target->GetCritDamageReduction(drain_amount);
-            }
+            // Cata 4.0.1: TBC-era crit-resilience mana-drain reduction removed
+            // (resilience no longer has a separate crit-specific path).
 
             target->ModifyPower(power, -drain_amount);
 
@@ -8987,11 +8984,8 @@ void Aura::PeriodicTick()
                 return;
             }
 
-            // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
-            if (powerType == POWER_MANA)
-            {
-                pdamage -= target->GetCritDamageReduction(pdamage);
-            }
+            // Cata 4.0.1: TBC-era crit-resilience mana-drain reduction removed
+            // (resilience no longer has a separate crit-specific path).
 
             uint32 gain = uint32(-target->ModifyPower(powerType, -pdamage));
 

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -5393,12 +5393,9 @@ void Spell::EffectPowerDrain(SpellEffectEntry const* effect)
     damage = m_caster->SpellDamageBonusDone(unitTarget, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
     damage = unitTarget->SpellDamageBonusTaken(m_caster, m_spellInfo, uint32(damage), SPELL_DIRECT_DAMAGE);
 
-    // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
+    // Cata 4.0.1: TBC-era crit-resilience mana-drain reduction removed
+    // (resilience no longer has a separate crit-specific path).
     uint32 power = damage;
-    if (drain_power == POWER_MANA)
-    {
-        power -= unitTarget->GetCritDamageReduction(power);
-    }
 
     int32 new_damage;
     if (curPower < power)
@@ -5481,12 +5478,9 @@ void Spell::EffectPowerBurn(SpellEffectEntry const* effect)
 
     int32 curPower = int32(unitTarget->GetPower(powertype));
 
-    // resilience reduce mana draining effect at spell crit damage reduction (added in 2.4)
+    // Cata 4.0.1: TBC-era crit-resilience mana-drain reduction removed
+    // (resilience no longer has a separate crit-specific path).
     int32 power = damage;
-    if (powertype == POWER_MANA)
-    {
-        power -= unitTarget->GetCritDamageReduction(power);
-    }
 
     int32 new_damage = (curPower < power) ? curPower : power;
 


### PR DESCRIPTION
## Summary

Fixes mangosthree's PvP resilience math which was applying **double** the intended Cata damage reduction and a redundant **crit-specific second pass** — both WotLK-era behaviours that Patch 4.0.1 collapsed into a single linear damage-reduction path.

## The bugs

1. **Wrong rate multiplier.** `Unit::GetDamageReduction` passes `2.0f` to `GetCombatRatingDamageReduction`, which double-counts the DBC conversion. The DBC `gtCombatRatings.dbc` already encodes the canonical Cata factor (~95.79 rating per 1% at L85). Rate should be `1.0f` for linear single-application math.

2. **WotLK-era second pass.** `GetCritDamageReduction` (rate `2.2f`, cap 33%) was called from 9 sites to apply a second, crit-specific resilience reduction on crit hits. In Cata 4.0.1, the separate crit-damage resilience reduction was removed; crits get exactly one resilience reduction, the same as non-crits.

Net effect in mangosthree PvP: non-crit damage to players is reduced by ~2× the intended amount; crit damage is reduced by even more. Players are noticeably over-tanky against PvP damage compared to retail 4.3.4.

## Fixes

- `Unit::GetDamageReduction` rate `2.0f` → `1.0f`
- Remove all 9 `GetCritDamageReduction` call sites:
  - `Unit.cpp`: 3 (`CalculateSpellDamage` melee/magic crit, `CalculateMeleeDamage::MELEE_HIT_CRIT`)
  - `SpellAuras.cpp`: 4 (DoT periodic crit + TBC-era mana-drain reductions)
  - `SpellEffects.cpp`: 2 (drain-spell `POWER_MANA` paths)
- Retain `GetCritDamageReduction` as a no-op helper in `Unit.h` for forward source compatibility; comment annotates its WotLK-era origin

## Verification

- [warcraft.wiki.gg/wiki/PvP_Resilience](https://warcraft.wiki.gg/wiki/PvP_Resilience)"Resilience scaling has been modified for linear returns, as opposed to increasing returns. Under the new formula, going from 30 resilience to 40 resilience gives players the same increase to survivability as going from 0 to 10. Resilience now scales in the same way armor and magic resistances do. A player with 32.5% damage reduction from resilience in 4.0.6 should see their damage reduction unchanged in 4.1. Those with less than 32.5% will gain slightly. Those with more will lose some damage reduction, increasingly so as their resilience climbs.Resilience can no longer reduce the chance to receive a critical strike, the damage done by critical strikes, and the effect of mana drains. Resilience will now only reduce damage done by players and their pets, and no longer has any effect against non-player mobs."
- TC-Preservation 4.3.4 reference impl (`Unit::ApplyResilience` → `GetCombatRatingDamageReduction` with `rate=1.0f`)
- Spec tests in #105 (`CataResilience` suite) document the application math

Worked example (4000 resilience rating, L85, canonical 95.79 rating per 1%): ~41.76% damage reduction applied once to all incoming player+pet damage including crits and DoTs.

## Known limitations (mirroring TC-Preservation; separate concerns)

- Mind-controlled player damage: no special-case to skip resilience (the `Player::CanApplyResilience` override returns true regardless of charm state).
- Self-damage: not explicitly excluded at this layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/107)
<!-- Reviewable:end -->
