### PR TITLE
[Combat] Stub Armor Penetration Pct to 0 for Cata 4.3.4

### DIFF
--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -3204,7 +3204,14 @@ class Player : public Unit
 
         // Remove all stat bonuses
         void _RemoveAllStatBonuses();
-        float GetArmorPenetrationPct() const { return m_armorPenetrationPct; }
+        // Cata 4.0.1 removed Armor Penetration Rating from gear; the
+        // stat conversion no longer exists in retail 4.3.4. Stubbed to
+        // return 0 so the armor-mitigation path is a no-op even if a
+        // legacy DB item still grants CR_ARMOR_PENETRATION. The cached
+        // m_armorPenetrationPct continues to track the rating value for
+        // diagnostic visibility but is intentionally unused in damage
+        // calc.
+        float GetArmorPenetrationPct() const { return 0.0f; }
         int32 GetSpellPenetrationItemMod() const { return m_spellPenetrationItemMod; }
 
         // Apply weapon-dependent aura mods


### PR DESCRIPTION
## Summary

Patch 4.0.1 removed Armor Penetration Rating from gear — the stat no longer exists on retail 4.3.4 items (Mastery replaced it as the offensive scaling stat for plate/mail/leather DPS).

mangosthree retained the full armor-pen pipeline anyway: `ITEM_MOD_ARMOR_PENETRATION_RATING` parsing, the `CR_ARMOR_PENETRATION` combat-rating slot, the cached `Player::m_armorPenetrationPct`, and a live consumer in `Unit::CalcArmorReducedDamage` that subtracts target armor by the cached pct. Net effect: any legacy DB item still tagged with the old armor pen rating silently grants a real Cata-authentic-incorrect damage boost against armored victims.

## Fix

One-line behavioural change: stub `Player::GetArmorPenetrationPct()` to return `0.0f` unconditionally. The armor-mitigation path in `Unit.cpp:2680-2691` becomes a no-op regardless of cached rating.

Retail Cata gear has no armor pen rating, so the practical effect is zero — the fix only matters for DB drift / legacy-content scenarios where pre-Cata items still grant the rating.

## What's preserved

Per investigate-before-deletion policy:
- The cached `m_armorPenetrationPct` continues to track the rating value for future diagnostic / addon visibility
- `ApplyRatingMod` call sites and the empty-case handler stay in case Blizzard ever revives the concept (similar to how `CR_RESILIENCE_DAMAGE_TAKEN` retains its empty-case handler)

## Diff

+7 / -1 in `src/game/Object/Player.h` only (comment block + single literal change in the inline getter).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/108)
<!-- Reviewable:end -->
