### PR TITLE
[Combat] Cata-correct glancing-blow chance/damage and restore melee miss check

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -3534,6 +3534,8 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
     DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: rolled %d, miss %d, dodge %d, parry %d, block %d, crit %d",
                      roll, miss_chance, dodge_chance, parry_chance, block_chance, crit_chance);
 
+    tmp = miss_chance;
+
     if (tmp > 0 && roll < (sum += tmp))
     {
         DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: MISS");

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2323,63 +2323,18 @@ void Unit::CalculateMeleeDamage(Unit* pVictim, CalcDamageInfo* damageInfo, Weapo
             damageInfo->HitInfo |= HITINFO_GLANCING;
             damageInfo->TargetState = VICTIMSTATE_NORMAL;
             damageInfo->procEx |= PROC_EX_NORMAL_HIT;
-            float reducePercent = 1.0f;                     // damage factor
-            // calculate base values and mods
-            float baseLowEnd = 1.3f;
-            float baseHighEnd = 1.2f;
-            switch (getClass())                             // lowering base values for casters
-            {
-                case CLASS_SHAMAN:
-                case CLASS_PRIEST:
-                case CLASS_MAGE:
-                case CLASS_WARLOCK:
-                case CLASS_DRUID:
-                    baseLowEnd  -= 0.7f;
-                    baseHighEnd -= 0.3f;
-                    break;
-            }
 
-            float maxLowEnd = 0.6f;
-            switch (getClass())                             // upper for melee classes
+            // Cata 4.0.1: flat 10%-per-level-diff reduction, capped at 3 levels (boss = -30%).
+            // Class- and weapon-skill-agnostic; the random damage window was removed in 4.0.1.
+            int32 leveldif = int32(damageInfo->target->getLevel()) - int32(getLevel());
+            if (leveldif > 3)
             {
-                case CLASS_WARRIOR:
-                case CLASS_ROGUE:
-                    maxLowEnd = 0.91f;                      // If the attacker is a melee class then instead the lower value of 0.91
+                leveldif = 3;
             }
+            float reducePercent = 1.0f - leveldif * 0.1f;
 
-            // calculate values
-            int32 diff = damageInfo->target->GetMaxSkillValueForLevel() - GetMaxSkillValueForLevel();
-            float lowEnd  = baseLowEnd - (0.05f * diff);
-            float highEnd = baseHighEnd - (0.03f * diff);
-
-            // apply max/min bounds
-            if (lowEnd < 0.01f)                             // the low end must not go bellow 0.01f
-            {
-                lowEnd = 0.01f;
-            }
-            else if (lowEnd > maxLowEnd)                    // the smaller value of this and 0.6 is kept as the low end
-            {
-                lowEnd = maxLowEnd;
-            }
-
-            if (highEnd < 0.2f)                             // high end limits
-            {
-                highEnd = 0.2f;
-            }
-            if (highEnd > 0.99f)
-            {
-                highEnd = 0.99f;
-            }
-
-            if (lowEnd > highEnd)                           // prevent negative range size
-            {
-                lowEnd = highEnd;
-            }
-
-            reducePercent = lowEnd + rand_norm_f() * (highEnd - lowEnd);
-
-            damageInfo->cleanDamage += damageInfo->damage - uint32(reducePercent *  damageInfo->damage);
-            damageInfo->damage   = uint32(reducePercent *  damageInfo->damage);
+            damageInfo->cleanDamage += damageInfo->damage - uint32(reducePercent * damageInfo->damage);
+            damageInfo->damage = uint32(reducePercent * damageInfo->damage);
             break;
         }
         case MELEE_HIT_CRUSHING:
@@ -3614,7 +3569,9 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
         }
     }
 
-    // Max 25% chance to score a glancing blow against mobs that are higher level (can do only players and pets and not with ranged weapon)
+    // Cata 4.0.1: glancing chance = 6% + 1.2% per skill point of (victim_max_skill - attacker_max_skill),
+    // capped at 40%. Yields 6%/12%/18%/24% at +0/+1/+2/+3 levels and 40% at the +6 NPC ceiling.
+    // Only white melee from a player/pet attacker against a higher-level mob can glance.
     if (attType != RANGED_ATTACK &&
         (GetTypeId() == TYPEID_PLAYER || ((Creature*)this)->IsPet()) &&
         pVictim->GetTypeId() != TYPEID_PLAYER && !((Creature*)pVictim)->IsPet() &&
@@ -3623,11 +3580,11 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
         // cap possible value (with bonuses > max skill)
         int32 skill = attackerMaxSkillValueForLevel;
 
-        tmp = (10 + (victimMaxSkillValueForLevel - skill)) * 100;
-        tmp = tmp > 2500 ? 2500 : tmp;
+        tmp = 600 + (victimMaxSkillValueForLevel - skill) * 120;
+        tmp = tmp > 4000 ? 4000 : tmp;
         if (roll < (sum += tmp))
         {
-            DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: GLANCING <%d, %d)", sum - 2500, sum);
+            DEBUG_FILTER_LOG(LOG_FILTER_COMBAT, "RollMeleeOutcomeAgainst: GLANCING <%d, %d)", sum - tmp, sum);
             return MELEE_HIT_GLANCING;
         }
     }


### PR DESCRIPTION
## Summary

Two unrelated bugs in `Unit.cpp`'s melee attack table, both surfaced
while auditing the combat math after PRs #106 / #107 / #108. Each is
isolated in its own commit.

### Commit 1 — `[Combat] Restore miss check in RollMeleeOutcomeAgainst`

Commit `bf5c6b1dd` ("Cleanup Style") accidentally deleted the
`tmp = miss_chance;` assignment between the DEBUG_FILTER_LOG and the
miss-roll gate. Since `tmp` is initialized to `0`, the
`if (tmp > 0 && roll < (sum += tmp))` guard short-circuited every
melee white-attack miss to `false` — dodge / parry / block / crit
slots absorbed the rolls that should have produced a `MELEE_HIT_MISS`,
silently biasing outcomes.

Mangostwo still carries the canonical line at `Unit.cpp:3163`,
confirming this is a mangosthree-only regression introduced during
whitespace cleanup, not a Cata redesign.

### Commit 2 — `[Combat] Cata-correct glancing-blow chance and damage`

Glancing-blow processing was still running on the WotLK class /
weapon-skill window for damage and a WotLK-era chance formula. Both
replaced with the canonical 4.0.1+ math from The Cataclysm
Preservation Project's TrinityCore fork
(`src/server/game/Entities/Unit/Unit.cpp`).

**Damage** (`CalculateMeleeDamage`, `MELEE_HIT_GLANCING` case):
the prior code computed a uniform-random window between a class-specific
`lowEnd` (warrior/rogue 0.91, caster classes ~0.6) and a weapon-skill-
derived `highEnd`. In practice a warrior or rogue glance against a +3
boss landed at 91–99% of normal damage — a ~5% reduction instead of
the spec'd 30%. Patch 4.0.1 removed weapon skill and the random
window in the same pass and flattened the formula to:

    leveldif       = min(3, victim_level - attacker_level)
    reducePercent  = 1.0 - leveldif * 0.1

so glances land for 100% / 90% / 80% / 70% of normal damage at
+0/+1/+2/+3, class-agnostic. The +0 case never actually executes
(the chance gate requires `victim_level > attacker_level`) but the
formula handles it correctly as a no-op.

**Chance** (`RollMeleeOutcomeAgainst`): the prior chance was
`(10 + skillDiff) * 100` basis points capped at 2500, giving
15% / 20% / 25% at +1/+2/+3. The canonical 4.x table is
`600 + skillDiff * 120` basis points capped at 4000, giving
12% / 18% / 24% at +1/+2/+3 and 40% at the +6 NPC ceiling. The boss
case is only 1pp off (25% → 24%) but +1/+2 NPCs were noticeably
over.

Also fixes a pre-existing DEBUG_FILTER_LOG that hard-coded
`sum - 2500` for the lower bound of the rolled window; now uses
`sum - tmp` so the log stays correct as the cap moves.

## Test plan

- [x] Local build clean on MSVC 2022 (warnings-as-errors gate passes)
- [x] Deployed to local install — `World Initialization Complete`,
  no version errors, login + character load OK
- [x] **In-game spec validation: level 1 warrior with 2-damage starting
  sword vs Raider's Training Dummy (level 88, rank=WORLDBOSS) — 36
  swings recorded**:
  - **Normal hits: 21 swings, all exactly 2 damage**
  - **Glancing hits: 13 swings, all exactly 1 damage** —
    `uint32(0.7 * 2) = 1` matches the 70% reduction
  - Crit: 1 swing, 4 damage (= 2 × normal, sanity check passed)
  - Misses: 2 swings (~5.5%) — confirms Commit 1's miss restore is
    producing MELEE_HIT_MISS results (prior code was incapable of
    returning MISS from the attack table)
  - Glance rate: 13/36 ≈ 36%, against the formula's 40% cap for the
    +87 effective level diff (\`600 + 87*5*120\` saturated to 4000)
- [x] Cross-checked formulas against tc-preservation
  `src/server/game/Entities/Unit/Unit.cpp:1328-1340` (damage) and
  `:2155` (chance)

## Out of scope (deliberate)

A separate audit flagged `SpellCriticalHealingBonus` as a
"WotLK regression" because mangosthree does `crit_bonus = damage`
(200% heal crit) while mangostwo does `damage / 2` (150%). After
cross-checking TC-Preservation `Unit.cpp:7056` — comment:
*"As of Patch 4.2.0 (2011-06-28): all healing spells now crit for
200% instead of 150%"* — and the 4.2.0 patch notes, the current
mangosthree behavior is the correct Cata implementation. No change.

A related minor follow-up: the new glancing damage code uses raw
`getLevel()` on both sides of the leveldif. For symmetry with the
chance gate at line 3578 (which uses `pVictim->GetLevelForTarget(this)`),
the damage formula could also use `GetLevelForTarget`. The two only
diverge in an edge case (attacker raw level ≥ worldboss victim's raw
level, where the WORLDBOSS rank's `CONFIG_WORLD_BOSS_LEVEL_DIFF` boost
matters); for all common cases including the test above, both lookups
return the same value. Left for a follow-up PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/109)
<!-- Reviewable:end -->
