### PR TITLE
[Mount] Use EffectMiscValueB on aura unapply (fixes flying-mount drift)

### DIFF
--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -4015,8 +4015,15 @@ void Aura::HandleAuraMounted(bool apply, bool Real)
     {
         target->Unmount(true);
 
-        // remove speed aura
-        if (MountCapabilityEntry const* mountCapability = target->GetMountCapability(m_modifier.m_amount))
+        // Remove the per-capability speed-mod spell cast on apply. Look the
+        // capability up the same way the apply branch did — via the aura's
+        // EffectMiscValueB (mount type). Using a different field here meant
+        // the lookup returned null, RemoveAurasByCasterSpell was never called,
+        // SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED stayed on the player, and
+        // SetCanFly(false) never propagated to the client on dismount.
+        // Compare Spell.cpp:7924 and MovementHandler.cpp:259, which also
+        // feed GetMountCapability with EffectMiscValueB.
+        if (MountCapabilityEntry const* mountCapability = target->GetMountCapability(uint32(GetMiscBValue())))
         {
             target->RemoveAurasByCasterSpell(mountCapability->SpeedModSpell, target->GetObjectGuid());
         }


### PR DESCRIPTION
Fixes #53.

## Summary

`Aura::HandleAuraMounted` looks up the per-mount speed-mod spell to remove on unapply using `m_modifier.m_amount`, but that field doesn't match any value `GetMountCapability` recognises. The apply branch correctly uses `GetMiscBValue()` (EffectMiscValueB = mount type), matching every other call site (`Spell.cpp`, `MovementHandler.cpp`).

When the unapply lookup returns null, `RemoveAurasByCasterSpell` is never called, the linked `SPELL_AURA_MOD_FLIGHT_SPEED_MOUNTED` aura stays on the player, and `SetCanFly(false)` never sends `SMSG_MOVE_UNSET_CAN_FLY`. On a flying-mount dismount the client keeps fly mode and drifts horizontally at altitude instead of falling.

This is what issue #53 reports: the player is stuck in fly mode after dismounting from a flying mount, with no way to deactivate it.

## Fix

Align the unapply lookup to `GetMiscBValue()` — symmetric with apply, matches the rest of the codebase. One line changed in `SpellAuras.cpp`.

## Test

- [x] Mount a flying mount at altitude, dismount — character falls correctly
- [x] Repeated mount/dismount cycle leaves no leftover speed-mod auras
- [x] Verified in-game by the reporter's scenario (issue #53)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/110)
<!-- Reviewable:end -->
