### PR TITLE
[AI] PACIFIED creatures: stop auto-facing the attacker (3 pathways)

### DIFF
--- a/src/game/MotionGenerators/TargetedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.cpp
@@ -199,7 +199,15 @@ bool TargetedMovementGeneratorMedium<T, D>::Update(T& owner, const uint32& time_
 
     if (owner.movespline->Finalized())
     {
-        if (i_angle == 0.f && !owner.HasInArc(0.01f, i_target.getTarget()))
+        // Once the chase movespline finalizes (creature has reached melee range or
+        // is already in it), every tick where the target leaves a tiny 0.01 rad
+        // arc snaps the chaser to face them. Suppress this for PACIFIED units —
+        // training dummies, etc. — that share the same Cata "don't fight back"
+        // semantics: they still get a chase generator queued by AttackStart,
+        // but rotating to track a player walking around them is just wrong.
+        // Matches the SelectHostileTarget guard in Unit::SelectHostileTarget.
+        if (i_angle == 0.f && !owner.HasInArc(0.01f, i_target.getTarget()) &&
+            !owner.HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
         {
             owner.SetInFront(i_target.getTarget());
         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -12454,7 +12454,15 @@ bool Unit::SelectHostileTarget()
     {
         if (!hasUnitState(UNIT_STAT_STUNNED | UNIT_STAT_DIED))
         {
-            SetInFront(target);
+            // PACIFIED creatures (training dummies, etc.) keep their spawn
+            // orientation. PACIFIED already gates attack initiation, so visual
+            // auto-facing here is purely cosmetic AND it falsifies the angle-of-
+            // attack rules in RollMeleeOutcomeAgainst (the from-behind gate for
+            // parry/block) for any player testing combat against the creature.
+            if (!HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
+            {
+                SetInFront(target);
+            }
             if (oldTarget != target)
             {
                 ((Creature*)this)->AI()->AttackStart(target);

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -8040,8 +8040,25 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
         }
     }
 
-    // Set our target
-    SetTargetGuid(victim->GetObjectGuid());
+    // Set our target — but NOT for PACIFIED creatures (training dummies, etc.).
+    // The Cata 4.3.4 client auto-rotates a unit's model toward its UNIT_FIELD_TARGET
+    // (a client-rendering behavior dating back to Vanilla), so even though the
+    // server never sends an orientation packet for the dummy, the client locally
+    // tracks whatever GUID lives in that field. Setting the target here is what
+    // makes a hit-then-walked-around dummy spin to face the attacker: combat entry
+    // → AttackStart → Attack → SetTargetGuid → client sees the field update →
+    // client rotates the model. PACIFIED is supposed to mean "this unit doesn't
+    // fight back" — that includes not visually fixating on its attacker.
+    //
+    // The TYPEID_UNIT guard is required: a player with a PACIFY-bearing debuff
+    // (Sap, Polymorph, Repentance) must still get their UNIT_FIELD_TARGET set,
+    // because in retail Cata the player's selected target persists across the CC
+    // and queued attacks resume on break. Restricting the skip to creatures
+    // avoids any PvP regression.
+    if (!(GetTypeId() == TYPEID_UNIT && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED)))
+    {
+        SetTargetGuid(victim->GetObjectGuid());
+    }
 
     if (meleeAttack)
     {


### PR DESCRIPTION
## Summary

PACIFIED creatures (e.g. Raider's Training Dummy, entry 31146) rotate to face their attacker every AI tick. This breaks `Unit::RollMeleeOutcomeAgainst`'s back-arc gate (parry / block / crit-from-behind) for any combat-math test against a dummy: every swing arrives "from the front" because the dummy spun around. PACIFIED is supposed to mean "this unit doesn't fight back" — visual auto-rotation is a fight-back behaviour.

## Fix

Three independent rotation pathways needed guarding. One commit each, all gated on `UNIT_FLAG_PACIFIED`:

- **`Unit::SelectHostileTarget`** — every threat tick called `SetInFront(target)` unconditionally.
- **`TargetedMovementGeneratorMedium::Update`** — once the chase movespline finalises, snaps the chaser to face whenever the target leaves a 0.01 rad arc.
- **`Unit::Attack`** — the Cata 4.3.4 client auto-rotates a unit's model toward whatever GUID lives in `UNIT_FIELD_TARGET` (client-side rendering), so `SetTargetGuid` on first hit caused a visual pivot even after the server-side guards. The `TYPEID_UNIT` guard keeps PvP players hit by Sap / Polymorph / Repentance with their target persisted across the CC.

## Test

- [x] Attack a training dummy from front, side, back — stays in spawn orientation
- [x] Sap / Polymorph another player — caster's target persists (no PvP regression)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/111)
<!-- Reviewable:end -->
