### PR TITLE
[Server] LogoutPlayer: don't kill the player for PvE-only attackers

### DIFF
--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -528,11 +528,15 @@ void WorldSession::LogoutPlayer(bool Save)
         }
         else if (!_player->getAttackers().empty())
         {
-            _player->CombatStop();
-            _player->GetHostileRefManager().setOnlineOfflineState(false);
-            _player->RemoveAllAurasOnDeath();
-
-            // build set of player who attack _player or who have pet attacking of _player
+            // Build the set of player (or player-pet) attackers first; the
+            // kill-on-logout cascade below only runs when real players are
+            // involved (PvP-style honor death). PvE-only attackers — training
+            // dummies, neutral mobs that briefly grabbed aggro, anything whose
+            // owner isn't a player — get the cheap CombatStop and then continue
+            // into the normal save-and-logout path. Without this guard, just
+            // attacking a PACIFIED training dummy and typing /logout would
+            // KillPlayer, save the character to DB with 0 HP, and force a
+            // graveyard revive on the next login.
             std::set<Player*> aset;
             for (Unit::AttackerSet::const_iterator itr = _player->getAttackers().begin(); itr != _player->getAttackers().end(); ++itr)
             {
@@ -550,24 +554,30 @@ void WorldSession::LogoutPlayer(bool Save)
                 }
             }
 
-            _player->SetPvPDeath(!aset.empty());
-            _player->KillPlayer();
-            _player->BuildPlayerRepop();
-            _player->RepopAtGraveyard();
+            _player->CombatStop();
+            _player->GetHostileRefManager().setOnlineOfflineState(false);
 
-            // give honor to all attackers from set like group case
-            for (std::set<Player*>::const_iterator itr = aset.begin(); itr != aset.end(); ++itr)
-            {
-                (*itr)->RewardHonor(_player, aset.size());
-            }
-
-            // give bg rewards and update counters like kill by first from attackers
-            // this can't be called for all attackers.
             if (!aset.empty())
+            {
+                _player->RemoveAllAurasOnDeath();
+                _player->SetPvPDeath(true);
+                _player->KillPlayer();
+                _player->BuildPlayerRepop();
+                _player->RepopAtGraveyard();
+
+                // give honor to all attackers from set like group case
+                for (std::set<Player*>::const_iterator itr = aset.begin(); itr != aset.end(); ++itr)
+                {
+                    (*itr)->RewardHonor(_player, aset.size());
+                }
+
+                // give bg rewards and update counters like kill by first from attackers
+                // this can't be called for all attackers.
                 if (BattleGround* bg = _player->GetBattleGround())
                 {
                     bg->HandleKillPlayer(_player, *aset.begin());
                 }
+            }
         }
         else if (_player->HasAuraType(SPELL_AURA_SPIRIT_OF_REDEMPTION))
         {


### PR DESCRIPTION
## Summary

`WorldSession::LogoutPlayer` ran `KillPlayer` + `RepopAtGraveyard` whenever the player's `attackerSet` was non-empty — even when every attacker was a creature. The PvP-aware `aset` was built but only consulted for `SetPvPDeath()` and honor distribution; the death cascade itself ran outside the gate.

## Reproduction

1. Attack `Raider's Training Dummy` (entry 31146).
2. Dummy enters `attackerSet`; `CombatStop` alone doesn't remove the reference.
3. `/logout`. After the in-combat timer, `LogoutPlayer` runs.
4. `attackerSet` non-empty → `KillPlayer` → `SaveToDB` persists health = 0 → on next login the character loads dead at the graveyard.

## Fix

Move `aset` construction to the top of the `attackerSet` branch, then wrap the whole kill / repop / honor / BG cascade in `if (!aset.empty())`. `CombatStop` and `setOnlineOfflineState` still run unconditionally so threat refs are cleaned. PvE-only attackers fall through to the normal save-and-logout path.

## Test

- [x] Hit a training dummy, `/logout`, log back in — character is alive at the original location
- [x] PvP kill on logout still awards honor and BG counters as before

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/112)
<!-- Reviewable:end -->
