### PR TITLE
[Combat] CREATURE_FLAG_EXTRA_UNKILLABLE for training dummies

### DIFF
--- a/src/game/Object/Creature.h
+++ b/src/game/Object/Creature.h
@@ -92,6 +92,7 @@ enum CreatureFlagsExtra
     CREATURE_FLAG_EXTRA_WALK_IN_WATER = 0x00008000,          ///< creature is forced to walk in water even it can swim
     CREATURE_FLAG_EXTRA_HAVE_NO_SWIM_ANIMATION = 0x00010000, ///< we have to not set "swim" animation or creature will have "no animation"
     CREATURE_FLAG_EXTRA_NO_MELEE = 0x00020000,               ///< creature can't melee
+    CREATURE_FLAG_EXTRA_UNKILLABLE = 0x00040000,             ///< creature cannot be killed by external damage; damage that would kill is clamped to leave it at 1 HP (e.g. training dummies)
 };
 
 // GCC have alternative #pragma pack(N) syntax and old gcc version not support pack(push,N), also any gcc version not support it at some platform
@@ -613,6 +614,7 @@ class Creature : public Unit
         bool IsRacialLeader() const { return GetCreatureInfo()->RacialLeader; }
         bool IsCivilian() const { return (GetCreatureInfo()->ExtraFlags & CREATURE_FLAG_EXTRA_CIVILIAN) != 0; }
         bool IsGuard() const { return (GetCreatureInfo()->ExtraFlags & CREATURE_FLAG_EXTRA_GUARD) != 0; }
+        bool IsUnkillable() const { return (GetCreatureInfo()->ExtraFlags & CREATURE_FLAG_EXTRA_UNKILLABLE) != 0; }
 
         bool CanWalk() const { return (GetCreatureInfo()->InhabitType & INHABIT_GROUND) != 0; }
         bool CanSwim() const override { return (GetCreatureInfo()->InhabitType & INHABIT_WATER) != 0; }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -1174,6 +1174,20 @@ uint32 Unit::DealDamage(Unit* pVictim, uint32 damage, CleanDamage const* cleanDa
     uint32 health = pVictim->GetHealth();
     DEBUG_FILTER_LOG(LOG_FILTER_DAMAGE, "deal dmg:%d to health:%d ", damage, health);
 
+    // Clamp damage on unkillable creatures (training dummies, etc.) so the
+    // death cascade below never fires. Damage is clamped to (health - 1),
+    // matching the TC-Preservation pattern: the dummy stays at 1 HP after
+    // a would-be-lethal blow, and subsequent damage simply does nothing.
+    // Self-damage is NOT clamped — a creature suiciding on its own effect
+    // (Hellfire-style) should still resolve normally if the flag is ever
+    // set on such a unit.
+    if (damage >= health && pVictim != this &&
+        pVictim->GetTypeId() == TYPEID_UNIT &&
+        ((Creature*)pVictim)->IsUnkillable())
+    {
+        damage = health > 1 ? health - 1 : 0;
+    }
+
     // Rage from Damage made (only from direct weapon damage)
     if (cleanDamage && damagetype == DIRECT_DAMAGE && this != pVictim && GetTypeId() == TYPEID_PLAYER && (GetPowerType() == POWER_RAGE))
     {


### PR DESCRIPTION
## Summary

Training dummies (entries 24792, 30527, 31143, etc.) die instantly under any meaningful damage. This prevents them from functioning as combat-math test fixtures.

Adds `CREATURE_FLAG_EXTRA_UNKILLABLE` (0x00040000) to clamp incoming damage at 1 HP for flagged creatures, mirroring TC-Preservation's approach. Self-damage is not clamped so suicide effects still work.

## Changes

- **Creature.h**: Add flag enum and `IsUnkillable()` accessor
- **Unit.cpp**: Clamp damage to `health - 1` in `DealDamage()` when victim is an unkillable creature and damage would kill it

## Companion DB migration (separate PR against `mangosthree/database`)

```sql
UPDATE creature_template SET ExtraFlags = ExtraFlags | 0x00040000
 WHERE entry IN (24792, 30527, 31143, 31144, 31146, 32541, 32542);
```

Target Dummies, Practice Dummies, and scripted props (Brewfest, Honor Hold, Mortar Team, etc.) are intentionally excluded.

## Test plan

- [ ] Apply DB migration; spawn dummy 31146; deal damage exceeding its health → dummy stays at 1 HP
- [ ] Self-damage (creature damaging itself) still resolves normally
- [ ] Paired with PR #111 (PACIFIED rotation fix), dummies are usable as combat-math fixtures

Design reference: tc-preservation `Unit.cpp:845` (HasStaticFlag damage clamp). TC uses an additional AI script layer; we port only the core clamp here since SD3 is a submodule.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/113)
<!-- Reviewable:end -->
