### PR TITLE
Wire 5 Cata mastery passives + fix CAST_END double-proc

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14371,6 +14371,7 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                                         // see the case comment for context. The SD3
                                         // mastery migration will move it back into
                                         // its semantically-correct location.)
+                            case 77222: // Elemental Overload (Elemental Shaman)
                                 isCoreHandledMasteryProc = true;
                                 break;
                         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14365,6 +14365,12 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                         {
                             case 76672: // Hand of Light (Retribution Paladin)
                             case 76659: // Wild Quiver (Marksmanship Hunter)
+                            case 76838: // Strikes of Opportunity (Arms Warrior; cased
+                                        // under SPELLFAMILY_ROGUE in the dummy-aura
+                                        // handler due to a DBC family-name quirk —
+                                        // see the case comment for context. The SD3
+                                        // mastery migration will move it back into
+                                        // its semantically-correct location.)
                                 isCoreHandledMasteryProc = true;
                                 break;
                         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14363,6 +14363,7 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                         switch (triggeredByHolder->GetId())
                         {
                             case 76672: // Hand of Light (Retribution Paladin)
+                            case 76659: // Wild Quiver (Marksmanship Hunter)
                                 isCoreHandledMasteryProc = true;
                                 break;
                         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14355,8 +14355,9 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                         // CanProcFrom's generic mask check would silently drop
                         // every mastery proc. Bypass the check for spells we
                         // have a dedicated case for in HandleProcTriggerSpell-
-                        // AuraProc; the per-spell case is the dispatch
-                        // authority, mirroring Blizzard's design.
+                        // AuraProc or HandleDummyAuraProc (depending on the
+                        // aura's effect type); the per-spell case is the
+                        // dispatch authority, mirroring Blizzard's design.
                         // See MASTERY_SD3_ROADMAP.md for the planned SD3
                         // AuraScript migration that supersedes this list.
                         bool isCoreHandledMasteryProc = false;
@@ -14369,6 +14370,34 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                         }
                         if (!isCoreHandledMasteryProc
                             && !triggeredByAura->CanProcFrom(procSpell, procFlag, PROC_EX_NONE, procExtra, damage != 0, true))
+                        {
+                            continue;
+                        }
+                        // CAST_END suppression for core-handled mastery
+                        // procs. Spell::cast() at Spell.cpp:4371/4375 fires
+                        // ProcDamageAndSpell unconditionally with procExtra=
+                        // PROC_EX_CAST_END and m_procAttacker matching the
+                        // hit's procFlag — so for every spell cast there
+                        // are TWO proc events on the caster: one at cast
+                        // end (procEx=CAST_END) and one at hit delivery
+                        // (procEx=NORMAL_HIT). Without filtering, a mastery
+                        // matching by procFlag alone rolls twice per cast,
+                        // doubling its effective rate and producing wasted
+                        // 0-damage triggered casts (because CAST_END is
+                        // called with damage=0). The standard procEx-
+                        // unspecified path in the if (spellProcEvent)
+                        // branch above filters this at Unit.cpp:14378
+                        // ("if procEx is unspecified and event is CAST_END
+                        // only, skip"); masteries that bypass CanProcFrom
+                        // miss that guard, so mirror it here. Verified via
+                        // [DIAG WQ] in world-server.log 2026-05-17 16:28:
+                        // every successful auto-shot produced two proc
+                        // events with procFlag=0x40 (RANGED_HIT) and
+                        // procEx alternating 0x80000 (CAST_END) / 0x1
+                        // (NORMAL_HIT), explaining the ~30% observed Wild
+                        // Quiver rate against ~16% Cata baseline.
+                        if (isCoreHandledMasteryProc
+                            && procExtra == PROC_EX_CAST_END)
                         {
                             continue;
                         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14347,9 +14347,30 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                             continue;
                         }
                     }
-                    else if (!triggeredByAura->CanProcFrom(procSpell, procFlag, PROC_EX_NONE, procExtra, damage != 0, true))
+                    else
                     {
-                        continue;
+                        // Cata mastery proc auras: Blizzard left the DBC
+                        // EffectSpellClassMask deliberately narrow for these
+                        // (their server-side scripts owned the filter), so
+                        // CanProcFrom's generic mask check would silently drop
+                        // every mastery proc. Bypass the check for spells we
+                        // have a dedicated case for in HandleProcTriggerSpell-
+                        // AuraProc; the per-spell case is the dispatch
+                        // authority, mirroring Blizzard's design.
+                        // See MASTERY_SD3_ROADMAP.md for the planned SD3
+                        // AuraScript migration that supersedes this list.
+                        bool isCoreHandledMasteryProc = false;
+                        switch (triggeredByHolder->GetId())
+                        {
+                            case 76672: // Hand of Light (Retribution Paladin)
+                                isCoreHandledMasteryProc = true;
+                                break;
+                        }
+                        if (!isCoreHandledMasteryProc
+                            && !triggeredByAura->CanProcFrom(procSpell, procFlag, PROC_EX_NONE, procExtra, damage != 0, true))
+                        {
+                            continue;
+                        }
                     }
                 }
 

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -2038,6 +2038,47 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                     CastSpell(this, 59628, true);           // Tricks of the Trade (caster timer)
                     break;
                 }
+                // Main Gauche (Combat Rogue mastery — spell 76806).
+                // Procs on main-hand auto-attack only; triggered spell
+                // 86392 is an off-hand weapon-percent damage hit. The
+                // proc chance is the mastery-scaled aura amount written
+                // by Player::UpdateMasteryAuras (StatSystem.cpp:899) on
+                // EFFECT_0, matching TC-Preservation's spell_rog_main_-
+                // gauche at scripts/Spells/spell_rogue.cpp:784 which
+                // hooks EFFECT_0 only. The DBC has a second SPELL_AURA_-
+                // DUMMY effect with a non-zero placeholder base value
+                // (200) that UpdateMasteryAuras skips per its
+                // CalculateSimpleValue guard; without this gate the
+                // handler would fire twice per hit and a 200%-clamped
+                // roll would proc 100% of the time. No CanProcFrom
+                // bypass needed in Unit::ProcDamageAndSpellFor because
+                // auto-attack procs pass procSpell=NULL and skip the
+                // bypass site entirely.
+                case 76806:
+                {
+                    if (effIndex != EFFECT_INDEX_0)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    if (GetTypeId() != TYPEID_PLAYER)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    // main-hand auto-attack only (exclude off-hand)
+                    if (!(procFlag & PROC_FLAG_SUCCESSFUL_MELEE_HIT)
+                        || (procFlag & PROC_FLAG_SUCCESSFUL_OFFHAND_HIT))
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    // Roll the mastery-scaled proc chance
+                    if (!roll_chance_i(triggerAmount))
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    triggered_spell_id = 86392;
+                    target = pVictim;
+                    break;
+                }
             }
             // Cut to the Chase
             if (dummySpell->SpellIconID == 2909)

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -2202,6 +2202,34 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                 target = this;
                 break;
             }
+            // Wild Quiver (Marksmanship Hunter mastery — spell 76659).
+            // Procs from auto-shot (PROC_FLAG_SUCCESSFUL_RANGED_HIT
+            // carried on the auto-repeat spell's DBC) and triggers
+            // 76663 for an extra ranged hit with its own weapon-damage
+            // formula. Proc chance is the mastery-scaled aura amount
+            // written by Player::UpdateMasteryAuras (StatSystem.cpp:899)
+            // on EFFECT_0, matching TC-Preservation's spell_hun_wild_-
+            // quiver at scripts/Spells/spell_hunter.cpp:893 which hooks
+            // EFFECT_0 only. EFFECT_INDEX_0 gate prevents double-firing
+            // if the DBC carries additional SPELL_AURA_DUMMY effects
+            // (Main Gauche pattern). A CanProcFrom bypass for 76659 is
+            // added in Unit::ProcDamageAndSpellFor because auto-shot
+            // passes procSpell=m_spellInfo (non-NULL), so the upstream
+            // mask check would otherwise drop the proc.
+            if (dummySpell->Id == 76659)
+            {
+                if (effIndex != EFFECT_INDEX_0)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                if (!roll_chance_i(triggerAmount))
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                triggered_spell_id = 76663;
+                target = pVictim;
+                break;
+            }
             break;
         }
         case SPELLFAMILY_PALADIN:

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -3005,6 +3005,77 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                 }
                 break;
             }
+            // Elemental Overload (Elemental Shaman mastery — spell 77222).
+            // procSpell-filtered: triggers an "overload" copy of Lightning
+            // Bolt (any rank), Chain Lightning (any rank), or Lava Burst.
+            // Chain Lightning's chance is reduced to 33% of the base mastery
+            // rate, matching TC-Preservation's spell_sha_elemental_overload
+            // at scripts/Spells/spell_shaman.cpp:1032 which applies
+            // CalculatePct(GetEffect(EFFECT_0)->GetAmount(), 33) for the
+            // Chain Lightning branch only.
+            //
+            // Lightning Bolt and Chain Lightning are matched by shaman
+            // SpellFamilyFlags (bit 0x1 and 0x2 respectively) rather than
+            // by procSpell ID so we transparently cover all ranks; Lava
+            // Burst is matched by ID 51505 directly (no rank progression).
+            //
+            // EFFECT_INDEX_0 gate handles any DBC placeholder on a later
+            // SPELL_AURA_DUMMY effect (Main Gauche pattern). CanProcFrom
+            // bypass entry is required because all three triggering spells
+            // pass procSpell != NULL. Self-chain via the triggered overload
+            // spells' CAST_END event (overload spells are themselves
+            // SPELL_DAMAGE_CLASS_MAGIC and would re-raise the matching proc
+            // flag) is caught by the framework-level CAST_END suppression
+            // added earlier in this series.
+            //
+            // The pre-existing WotLK "Lightning Overload" talent handler at
+            // SpellIconID==2018 below in this same SPELLFAMILY_SHAMAN block
+            // covers a different aura (the removed Cata-era WotLK talent
+            // with multiple ranks). This handler runs before the IconID
+            // fallback (Id-match takes priority) and returns early via
+            // break, so there is no double-dispatch risk.
+            if (dummySpell->Id == 77222)
+            {
+                if (effIndex != EFFECT_INDEX_0)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                if (!procSpell)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                int32 chance = triggerAmount;
+                uint32 overloadSpell = 0;
+                if (procClassOptions
+                    && (procClassOptions->SpellFamilyFlags & UI64LIT(0x0000000000000001)))
+                {
+                    // Lightning Bolt (Shaman family bit 0x1 — all ranks)
+                    overloadSpell = 45284;
+                }
+                else if (procClassOptions
+                    && (procClassOptions->SpellFamilyFlags & UI64LIT(0x0000000000000002)))
+                {
+                    // Chain Lightning (Shaman family bit 0x2 — all ranks)
+                    overloadSpell = 45297;
+                    chance = chance * 33 / 100;
+                }
+                else if (procSpell->Id == 51505)
+                {
+                    // Lava Burst (no rank progression)
+                    overloadSpell = 77451;
+                }
+                else
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                if (!roll_chance_i(chance))
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                triggered_spell_id = overloadSpell;
+                target = pVictim;
+                break;
+            }
             // Earth Shield
             if (dummyClassOptions && dummyClassOptions->SpellFamilyFlags & UI64LIT(0x0000040000000000))
             {

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -2079,6 +2079,67 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                     target = pVictim;
                     break;
                 }
+                // Strikes of Opportunity (Arms Warrior mastery — spell 76838).
+                // Cased under SPELLFAMILY_ROGUE despite being a warrior
+                // mastery because mangosthree's DBC reports the spell with
+                // SpellFamilyName=8 (SPELLFAMILY_ROGUE). The outer
+                // switch(dummySpell->GetSpellFamilyName()) routes by that
+                // field, so the case must live wherever the dispatcher
+                // sends it — diagnosed in-game on 2026-05-17 with a
+                // temporary [DIAG HDA] log line that printed spellFamily=8
+                // for spell 76838 every time the handler was entered.
+                //
+                // The classification is plausibly Blizzard's choice
+                // (mechanic-by-family — the proc shape mirrors Main Gauche
+                // above) but may also be a DBC-extraction quirk. TC's
+                // canonical proc table lists 76838 with SpellFamilyName=4
+                // (WARRIOR), but that's a TC-maintained DB row and not a
+                // direct echo of the client DBC, so it's not conclusive.
+                // Either way, modifying SpellFamilyName via a runtime
+                // const_cast would risk corrupting any other spell that
+                // shares the same SpellClassOptions row, so we follow the
+                // data instead of patching it.
+                //
+                // **Future:** the SD3 mastery migration (see
+                // MASTERY_SD3_ROADMAP.md at workspace root) replaces this
+                // family-block dispatch with per-spell AuraScript hooks,
+                // identical to how TC structures the same handler. Once
+                // that lands the spell will live in spell_warrior.cpp
+                // where it semantically belongs, regardless of the DBC
+                // family-name value.
+                //
+                // Mechanics: procs on melee swings and melee abilities
+                // (PROC_FLAG_SUCCESSFUL_MELEE_HIT | _MELEE_SPELL_HIT) per
+                // the DBC procFlags=0x14. Triggered spell 76858
+                // ("Opportunity Strike") deals an extra melee weapon
+                // hit. Proc chance is the mastery-scaled aura amount
+                // written by Player::UpdateMasteryAuras on EFFECT_0,
+                // matching TC's spell_warr_strikes_of_opportunity at
+                // scripts/Spells/spell_warrior.cpp:828. EFFECT_INDEX_0
+                // gate handles the DBC's placeholder second SPELL_AURA_-
+                // DUMMY effect (Main Gauche pattern).
+                //
+                // CanProcFrom bypass entry IS needed in Unit::ProcDamage-
+                // AndSpellFor for 76838: melee ability casts (Mortal
+                // Strike, Slam, etc.) pass procSpell=m_spellInfo
+                // (non-NULL), so the upstream class-mask check would
+                // otherwise drop them. Self-chain via the triggered
+                // 76858's CAST_END event is caught by the framework-level
+                // CAST_END suppression added earlier in this series.
+                case 76838:
+                {
+                    if (effIndex != EFFECT_INDEX_0)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    if (!roll_chance_i(triggerAmount))
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    triggered_spell_id = 76858;
+                    target = pVictim;
+                    break;
+                }
             }
             // Cut to the Chase
             if (dummySpell->SpellIconID == 2909)

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -3982,6 +3982,37 @@ SpellAuraProcResult Unit::HandleProcTriggerSpellAuraProc(Unit* pVictim, uint32 d
                 target = pVictim;
                 break;
             }
+            // Hand of Light (Retribution Paladin mastery — spell 76672).
+            // Procs on Templar's Verdict (85256), Crusader Strike (35395),
+            // and Divine Storm (53385). Triggered spell 96172 deals Holy
+            // damage as a % of the triggering hit; the % is the mastery-
+            // scaled aura amount written by Player::UpdateMasteryAuras on
+            // EFFECT_0, matching TC-Preservation's spell_pal_hand_of_light
+            // at scripts/Spells/spell_paladin.cpp:944 which hooks EFFECT_0
+            // only. EFFECT_INDEX_0 gate prevents double-firing if the DBC
+            // carries additional SPELL_AURA_PROC_TRIGGER_SPELL effects
+            // (defensive parity with the Main Gauche / Wild Quiver
+            // pattern; mangosthree's dispatcher iterates every aura
+            // effect and any placeholder on a later effect would silently
+            // double the proc).
+            else if (auraSpellInfo->Id == 76672)
+            {
+                if (triggeredByAura->GetEffIndex() != EFFECT_INDEX_0)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                if (!procSpell)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                if (procSpell->Id != 85256 && procSpell->Id != 35395 && procSpell->Id != 53385)
+                {
+                    return SPELL_AURA_PROC_FAILED;
+                }
+                trigger_spell_id = 96172;
+                basepoints[0] = int32(triggerAmount * damage / 100);
+                target = pVictim;
+            }
             break;
         }
         case SPELLFAMILY_SHAMAN:


### PR DESCRIPTION
## Summary

Wires five Cata mastery passives (Hand of Light, Main Gauche, Wild Quiver, Strikes of Opportunity, Elemental Overload) that had no case in `HandleDummyAuraProc` / `HandleProcTriggerSpellAuraProc` and were silently dropped by the proc dispatcher. Adds a framework-level fix that prevents mastery procs from rolling twice per source cast via the CAST_END proc-event leak.

Each mastery is a single commit, in order: Ret Paladin (76672) → Combat Rogue (76806) → MM Hunter (76659) → Arms Warrior (76838) → Elemental Shaman (77222). All five spell IDs are added to the existing `isCoreHandledMasteryProc` switch in `Unit::ProcDamageAndSpellFor` to bypass the generic `CanProcFrom` mask check — Cata mastery passives have deliberately narrow DBC `EffectSpellClassMask` values that would otherwise filter them out.

The framework fix mirrors the existing `spellProcEvent` CAST_END filter at `Unit.cpp:14378` into the mastery-bypass branch. `Spell::cast()` fires `ProcDamageAndSpell(..., PROC_EX_CAST_END, ...)` unconditionally with `m_procAttacker` carrying the same procFlag as the hit-time event, so every cast produces two proc dispatches on the caster. Auras matching by procFlag alone rolled twice per source spell; the new guard skips dispatch when `procExtra == PROC_EX_CAST_END`. Scoped to `isCoreHandledMasteryProc` to keep blast radius tight.

## Verification

Level 85 on training dummies, default base mastery (~16%), no mastery rating gear:

- **Hand of Light:** 9 procs / 10 qualifying Templar's Verdict / Crusader Strike / Divine Storm casts; damage ≈ 16% of source hit; no double-fires.
- **Main Gauche:** 3 procs / ~30 main-hand auto-attacks (≈10%, within noise); off-hand swings correctly filtered.
- **Wild Quiver:** 6 procs / 37 auto-shots = 16.2% (expected ~16%); flight-time distribution unimodal after the CAST_END fix (bimodal before — the second cluster was the leak).
- **Strikes of Opportunity:** 4 procs / ~24 events (~17%, expected ~17.6% at DBC coef 220); fires from auto-attacks, Mortal Strike, and Slam. Note: mangosthree's DBC reports spell 76838 with `SpellFamilyName=8` (SPELLFAMILY_ROGUE), not WARRIOR — diagnosed via temporary log line. The case lives in the rogue family block accordingly. Patching `SpellFamilyName` via `const_cast` would risk corrupting any other spell sharing that `SpellClassOptions` row, so the data is followed rather than rewritten.
- **Elemental Overload:** 2 procs / 22 events (~9%, expected ~12% across the Lightning Bolt / Chain Lightning / Lava Burst mix). Lightning Bolt and Lava Burst overloads confirmed; Chain Lightning's reduced-rate (33% of base) branch not observed in this sample.

Build passes warnings-as-errors. Server boots cleanly.

## Known follow-up

In one verification sample the Lightning Bolt overload (45284) landed ~2.9 s after its source hit, while the Lava Burst overload (77451) fired with only the expected ~0.4 s projectile delay. The overload mechanic functions correctly but 45284 may not be fully bypassing its source spell's cast time when triggered. Worth a separate investigation; not blocking.

## SD3 migration

This is a stop-gap. The per-spell case approach is intended to be superseded by per-spell `AuraScript` hooks in the appropriate `spell_<class>.cpp` files, matching TC's structure. The framework CAST_END fix here is portable across that refactor — when the SD3 migration lands, each mastery moves out of `UnitAuraProcHandler.cpp` and the `isCoreHandledMasteryProc` switch contracts in step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/114)
<!-- Reviewable:end -->
