### PR TITLE
Wire 3 Cata contextual masteries + bypass cast-time on overload spells

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -9017,6 +9017,27 @@ uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, u
         }
     }
 
+    // Mastery: Unshackled Fury (Fury Warrior 76856) — applies to non-
+    // melee-class warrior damage spells (rare; most warrior abilities
+    // go through MeleeDamageBonusDone instead). Same direct-aura-read
+    // pattern as the melee-path version. See MeleeDamageBonusDone for
+    // the canonical implementation comment.
+    if (GetPowerType() == POWER_RAGE)
+    {
+        if (SpellAuraHolder* ufHolder = GetSpellAuraHolder(76856))
+        {
+            if (Aura* uf = ufHolder->GetAuraByEffectIndex(EFFECT_INDEX_0))
+            {
+                if (uf->GetModifier()->m_amount > 0)
+                {
+                    uint32 maxPower = GetMaxPower(POWER_RAGE);
+                    float powerPct = maxPower ? std::min(float(GetPower(POWER_RAGE)) / maxPower, 1.0f) : 0.0f;
+                    DoneTotalMod *= (100.0f + uf->GetModifier()->m_amount * powerPct) / 100.0f;
+                }
+            }
+        }
+    }
+
     // Mastery: Frostburn (Frost Mage 76613) — increases damage dealt to
     // frozen targets by mastery%. Cata mechanic: the bonus only applies
     // when the victim is in AURA_STATE_FROZEN (Frostbite / Freeze /
@@ -10433,6 +10454,32 @@ uint32 Unit::MeleeDamageBonusDone(Unit* pVictim, uint32 pdamage, WeaponAttackTyp
 
     // ..done pct (by creature type mask)
     DonePercent *= GetTotalAuraMultiplierByMiscMask(SPELL_AURA_MOD_DAMAGE_DONE_VERSUS, creatureTypeMask);
+
+    // Mastery: Unshackled Fury (Fury Warrior 76856) — applies to all
+    // damage dealt scaled by current rage%. Warrior abilities like
+    // Bloodthirst / Raging Blow are SPELL_DAMAGE_CLASS_MELEE and route
+    // through MeleeDamageBonusDone (not SpellDamageBonusDone). Read the
+    // 76856 aura holder directly instead of by aura type because
+    // mangosthree's DBC routes Unshackled Fury through a different aura
+    // type than Mana Adept's 356 (SPELL_AURA_MOD_DAMAGE_DONE_FROM_PCT_POWER);
+    // observed in-game with a temporary diagnostic on 2026-05-17.
+    // m_amount > 0 guard avoids the DBC placeholder bleeding through
+    // when SPELL_AURA_MASTERY isn't yet active on the caster.
+    if (GetPowerType() == POWER_RAGE)
+    {
+        if (SpellAuraHolder* ufHolder = GetSpellAuraHolder(76856))
+        {
+            if (Aura* uf = ufHolder->GetAuraByEffectIndex(EFFECT_INDEX_0))
+            {
+                if (uf->GetModifier()->m_amount > 0)
+                {
+                    uint32 maxPower = GetMaxPower(POWER_RAGE);
+                    float powerPct = maxPower ? std::min(float(GetPower(POWER_RAGE)) / maxPower, 1.0f) : 0.0f;
+                    DonePercent *= (100.0f + uf->GetModifier()->m_amount * powerPct) / 100.0f;
+                }
+            }
+        }
+    }
 
     // special dummys/class scripts and other effects
     // =============================================

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -14487,6 +14487,7 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* pTarget, uint32 procFlag, 
                                         // mastery migration will move it back into
                                         // its semantically-correct location.)
                             case 77222: // Elemental Overload (Elemental Shaman)
+                            case 76669: // Illuminated Healing (Holy Paladin)
                                 isCoreHandledMasteryProc = true;
                                 break;
                         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -9017,6 +9017,35 @@ uint32 Unit::SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, u
         }
     }
 
+    // Mastery: Frostburn (Frost Mage 76613) — increases damage dealt to
+    // frozen targets by mastery%. Cata mechanic: the bonus only applies
+    // when the victim is in AURA_STATE_FROZEN (Frostbite / Freeze /
+    // Frost Nova / Deep Freeze / Ice Lance vs. frozen / etc.). The
+    // aura's m_miscvalue + family flags filter the affected spells
+    // (Frostbolt, Ice Lance, Frostfire Bolt — Mage family). Mirrors
+    // TC-Preservation at tc-preservation/src/server/game/Entities/Unit/
+    // Unit.cpp:6569-6573. Guard against the DBC placeholder (negative)
+    // bleeding through when SPELL_AURA_MASTERY isn't applied yet (e.g.
+    // mid-spec-swap, talent reset). UpdateMasteryAuras only overrides
+    // m_amount to the positive mastery-scaled value once the caster has
+    // the SPELL_AURA_MASTERY aura active; before that, the negative
+    // placeholder would apply as a damage REDUCTION on frozen targets.
+    if (pVictim)
+    {
+        if (SpellAuraHolder* frostburnHolder = GetSpellAuraHolder(76613))
+        {
+            if (Aura* frostburn = frostburnHolder->GetAuraByEffectIndex(EFFECT_INDEX_0))
+            {
+                if (frostburn->GetModifier()->m_amount > 0 &&
+                    pVictim->HasAuraState(AURA_STATE_FROZEN) &&
+                    frostburn->isAffectedOnSpell(spellProto))
+                {
+                    DoneTotalMod *= (100.0f + frostburn->GetModifier()->m_amount) / 100.0f;
+                }
+            }
+        }
+    }
+
     // done scripted mod (take it from owner)
     Unit* owner = GetOwner();
     if (!owner)

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -9675,7 +9675,66 @@ bool Spell::IsNeedSendToClient() const
  */
 bool Spell::IsTriggeredSpellWithRedundentCastTime() const
 {
-    return m_IsTriggeredSpell && (m_spellInfo->GetManaCost() || m_spellInfo->GetManaCostPercentage());
+    if (m_IsTriggeredSpell && (m_spellInfo->GetManaCost() || m_spellInfo->GetManaCostPercentage()))
+    {
+        return true;
+    }
+
+    // Mastery / talent "overload" spells: zero-cost duplicates of caster
+    // spells triggered by Cata's Elemental Overload mastery (77222) and
+    // the WotLK Lightning Overload talent (SpellIconID 2018). Their DBC
+    // entries carry the source spell's cast time (so the spell preview /
+    // tooltip render correctly) but their mana cost is zero — the
+    // triggering spell already paid. The mana-cost heuristic above misses
+    // them, so the framework respects the source cast time and the
+    // triggered cast lands seconds after the proc rather than instantly,
+    // which contradicts Cata mastery design (verified in-game on
+    // 2026-05-17: source Lightning Bolt landed at 19:55:15.009 and the
+    // 45284 overload landed at 19:55:17.924 — a ~2.9s delay matching the
+    // source LB cast time, while the Lava Burst overload 77451 landed
+    // with only the expected ~0.4s projectile delay). Add an explicit
+    // allowlist of the affected spell IDs. This also fixes the latent
+    // WotLK Lightning Overload talent (preexisting issue that was never
+    // reported, presumably because the talent was rarely used at high
+    // gear levels where the delay would be most visible).
+    if (m_IsTriggeredSpell)
+    {
+        switch (m_spellInfo->Id)
+        {
+            // Lightning Bolt overload (ranks 1-14)
+            case 45284:
+            case 45286:
+            case 45287:
+            case 45288:
+            case 45289:
+            case 45290:
+            case 45291:
+            case 45292:
+            case 45293:
+            case 45294:
+            case 45295:
+            case 45296:
+            case 49239:
+            case 49240:
+            // Chain Lightning overload (ranks 1-8)
+            case 45297:
+            case 45298:
+            case 45299:
+            case 45300:
+            case 45301:
+            case 45302:
+            case 49268:
+            case 49269:
+            // Lava Burst overload (Cata; no rank progression). Listed
+            // defensively — currently lands instantly in-game, suggesting
+            // its DBC already has a non-zero mana cost or zero cast time,
+            // but the explicit entry documents the intent.
+            case 77451:
+                return true;
+        }
+    }
+
+    return false;
 }
 
 /**

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -2680,6 +2680,61 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                     }
                     break;
                 }
+                // Illuminated Healing (Holy Paladin mastery — spell 76669)
+                // On direct heals, apply an absorb shield (86273) on the
+                // heal target with amount = mastery% (triggerAmount) of
+                // the heal value. Stacks with existing 86273 aura from
+                // the same caster up to 33% of caster's max HP. Mirrors
+                // TC-Preservation's spell_pal_illuminated_healing at
+                // scripts/Spells/spell_paladin.cpp:907-941.
+                //
+                // EFFECT_INDEX_0 gate handles any DBC placeholder on a
+                // later SPELL_AURA_DUMMY effect (Main Gauche pattern).
+                // CanProcFrom bypass entry is needed because heal-cast
+                // procs pass procSpell != NULL (the heal spell), so the
+                // upstream class-mask check would otherwise drop them.
+                case 76669:
+                {
+                    if (effIndex != EFFECT_INDEX_0)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    if (!pVictim)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+                    if (damage == 0)
+                    {
+                        // damage param carries the heal amount on heal procs
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    int32 shieldAmount = int32(uint64(damage) * uint32(triggerAmount) / 100);
+                    if (shieldAmount <= 0)
+                    {
+                        return SPELL_AURA_PROC_FAILED;
+                    }
+
+                    int32 cap = int32(GetMaxHealth() * 33 / 100);
+
+                    // Stack with existing 86273 aura from this caster on target
+                    if (SpellAuraHolder* existing = pVictim->GetSpellAuraHolder(86273, GetObjectGuid()))
+                    {
+                        if (Aura* eff = existing->GetAuraByEffectIndex(EFFECT_INDEX_0))
+                        {
+                            int32 newAmount = std::min(cap, eff->GetModifier()->m_amount + shieldAmount);
+                            eff->GetModifier()->m_amount = newAmount;
+                            existing->RefreshHolder();
+                        }
+                        return SPELL_AURA_PROC_OK;
+                    }
+
+                    // No existing aura — cast 86273 fresh with shield as basepoints
+                    basepoints[0] = std::min(cap, shieldAmount);
+                    triggered_spell_id = 86273;
+                    target = pVictim;
+                    break;
+                }
                 // Heartpierce, Item - Icecrown 25 Heroic Dagger Proc
                 case 71892:
                 {


### PR DESCRIPTION
## Summary

Wires 3 contextual mastery procs (Frostburn, Unshackled Fury, Illuminated Healing) and fixes a framework-level cast-time bypass for triggered overload spells — follow-up to PR #114.

Four commits. The cast-time fix extends `Spell::IsTriggeredSpellWithRedundentCastTime()` with an explicit allowlist of zero-mana mastery overload spell IDs (Lightning Bolt 45284 / 45286-96 / 49239-40, Chain Lightning 45297-302 / 49268-69, Lava Burst 77451). In-game: Lightning Bolt overload latency drops ~2.9s → ~0.4s. Also clears the latent WotLK Lightning Overload talent bug shipping since the original import.

**Frostburn** (Frost Mage 76613): reads the aura holder directly in `Unit::SpellDamageBonusDone`, gates on `AURA_STATE_FROZEN` + `isAffectedOnSpell`. `m_amount > 0` guard avoids the negative DBC placeholder bleeding through pre-mastery-learn.

**Unshackled Fury** (Fury Warrior 76856): hooks in both `SpellDamageBonusDone` and `MeleeDamageBonusDone` (warrior abilities route through the melee path). Reads 76856 directly — mangosthree's DBC routes it through a different aura type than Mana Adept's 356, verified at runtime. Multiplier: `1 + (m_amount/100 × ragePct)`.

**Illuminated Healing** (Holy Paladin 76669 → 86273): case in `Unit::HandleDummyAuraProc` SPELLFAMILY_PALADIN block + `isCoreHandledMasteryProc` switch entry. Direct heal applies absorb shield (`heal × triggerAmount / 100`), stacks with existing 86273 from same caster, capped at 33% caster max HP. Mirrors TC `spell_paladin.cpp:907-941`.

## Verification

All four fixes verified in-game on 2026-05-17 with temporary log-line diagnostics (stripped before this PR):

- LB overload now lands 0.40-0.41s after source (was 2.9s)
- Frostburn: `+5%` on frozen Frostbolt at base mastery 8 / DBC coef ~63
- Unshackled Fury: `+1.1%` at 10% rage → `+8.8%` at 80% rage; fires on Bloodthirst, Slam, auto-attacks
- Illuminated Healing: math exact for Holy Light, Flash of Light, Divine Light, Word of Glory; stacking and 33%-max-HP cap both correct

## Notes

DBC coefficients for Frostburn (~63) and Unshackled Fury (~11) yield smaller bonuses than retail Wowhead values (~250 and ~57 respectively). Mechanic is structurally correct; tuning is a separate concern.

Mana Adept (76547) and Deep Healing (77226) were initially planned but verified already working via existing aura handlers `SPELL_AURA_MOD_DAMAGE_DONE_FROM_PCT_POWER` and `SPELL_AURA_MOD_HEALING_DONE_FROM_PCT_HEALTH`; no code change needed.

## SD3 migration

Per-spell cases in `HandleDummyAuraProc` are stop-gaps; the long-term migration moves each mastery to a per-spell `AuraScript` in `spell_<class>.cpp` (TC's structure). The cast-time-bypass fix in `IsTriggeredSpellWithRedundentCastTime()` is portable across that refactor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/115)
<!-- Reviewable:end -->
