### PR TITLE
Thread-safety batch: LockedQueue + ChannelMgr + GuildMgr

### DIFF
--- a/src/game/WorldHandlers/ChannelMgr.cpp
+++ b/src/game/WorldHandlers/ChannelMgr.cpp
@@ -113,6 +113,8 @@ Channel* ChannelMgr::GetJoinChannel(const std::string& name, uint32 channel_id)
     Utf8toWStr(name, wname);
     wstrToLower(wname);
 
+    std::lock_guard<std::mutex> guard(channels_lock);
+
     if (channels.find(wname) == channels.end())
     {
         Channel* nchan = new Channel(name, channel_id);
@@ -142,9 +144,17 @@ Channel* ChannelMgr::GetChannel(const std::string& name, Player* p, bool pkt)
     Utf8toWStr(name, wname);
     wstrToLower(wname);
 
-    ChannelMap::const_iterator i = channels.find(wname);
+    Channel* found = NULL;
+    {
+        std::lock_guard<std::mutex> guard(channels_lock);
+        ChannelMap::const_iterator i = channels.find(wname);
+        if (i != channels.end())
+        {
+            found = i->second;
+        }
+    }
 
-    if (i == channels.end())
+    if (!found)
     {
         if (pkt)
         {
@@ -155,10 +165,8 @@ Channel* ChannelMgr::GetChannel(const std::string& name, Player* p, bool pkt)
 
         return NULL;
     }
-    else
-    {
-        return i->second;
-    }
+
+    return found;
 }
 
 /**
@@ -171,6 +179,8 @@ void ChannelMgr::LeftChannel(const std::string& name)
     std::wstring wname;
     Utf8toWStr(name, wname);
     wstrToLower(wname);
+
+    std::lock_guard<std::mutex> guard(channels_lock);
 
     ChannelMap::const_iterator i = channels.find(wname);
 

--- a/src/game/WorldHandlers/ChannelMgr.h
+++ b/src/game/WorldHandlers/ChannelMgr.h
@@ -29,6 +29,7 @@
 #include "Channel.h"
 
 #include <map>
+#include <mutex>
 
 class ChannelMgr
 {
@@ -42,6 +43,14 @@ class ChannelMgr
         void LeftChannel(const std::string& name);
     private:
         ChannelMap channels;
+        // Serializes structural access to `channels`. Required because the
+        // singleton is shared across all players of a faction and is
+        // touched concurrently from MapUpdateThreads >= 2 workers (via
+        // Player::Update -> Player::UpdateZone -> UpdateLocalChannels).
+        // Note: this protects only the map itself; Channel* lifetime
+        // across concurrent GetChannel/LeftChannel callers is a separate,
+        // unaddressed concern.
+        std::mutex channels_lock;
         void MakeNotOnPacket(WorldPacket* data, const std::string& name);
 };
 

--- a/src/game/WorldHandlers/GuildMgr.cpp
+++ b/src/game/WorldHandlers/GuildMgr.cpp
@@ -85,6 +85,7 @@ GuildMgr::~GuildMgr()
  */
 void GuildMgr::AddGuild(Guild* guild)
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     m_GuildMap[guild->GetId()] = guild;
 }
 
@@ -99,6 +100,7 @@ void GuildMgr::AddGuild(Guild* guild)
  */
 void GuildMgr::RemoveGuild(uint32 guildId)
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     m_GuildMap.erase(guildId);
 }
 
@@ -121,6 +123,7 @@ void GuildMgr::RemoveGuild(ObjectGuid guildGuid)
  */
 Guild* GuildMgr::GetGuildById(uint32 guildId) const
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     GuildMap::const_iterator itr = m_GuildMap.find(guildId);
     if (itr != m_GuildMap.end())
     {
@@ -150,6 +153,7 @@ Guild* GuildMgr::GetGuildByGuid(ObjectGuid guildGuid) const
  */
 Guild* GuildMgr::GetGuildByName(std::string const& name) const
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     for (GuildMap::const_iterator itr = m_GuildMap.begin(); itr != m_GuildMap.end(); ++itr)
         if (itr->second->GetName() == name)
         {
@@ -169,6 +173,7 @@ Guild* GuildMgr::GetGuildByName(std::string const& name) const
  */
 Guild* GuildMgr::GetGuildByLeader(ObjectGuid const& guid) const
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     for (GuildMap::const_iterator itr = m_GuildMap.begin(); itr != m_GuildMap.end(); ++itr)
         if (itr->second->GetLeaderGuid() == guid)
         {
@@ -188,6 +193,7 @@ Guild* GuildMgr::GetGuildByLeader(ObjectGuid const& guid) const
  */
 std::string GuildMgr::GetGuildNameById(uint32 guildId) const
 {
+    std::lock_guard<std::mutex> guard(m_GuildMapLock);
     GuildMap::const_iterator itr = m_GuildMap.find(guildId);
     if (itr != m_GuildMap.end())
     {

--- a/src/game/WorldHandlers/GuildMgr.h
+++ b/src/game/WorldHandlers/GuildMgr.h
@@ -28,6 +28,8 @@
 #include "Common.h"
 #include "Policies/Singleton.h"
 
+#include <mutex>
+
 class Guild;
 class ObjectGuid;
 
@@ -36,6 +38,14 @@ class GuildMgr
         typedef std::unordered_map<uint32, Guild*> GuildMap;
 
         GuildMap m_GuildMap;
+        // Serializes structural access to m_GuildMap. Required because
+        // Map workers (e.g. AchievementMgr::SendAchievementEarned during
+        // Player::Update -> Unit aura tick) read this singleton while
+        // WorldThread can erase entries via Guild::Disband ->
+        // sGuildMgr.RemoveGuild. Mutable so const Get* methods can lock.
+        // Note: protects only the map itself; Guild* lifetime across
+        // concurrent Get / RemoveGuild callers is a separate concern.
+        mutable std::mutex m_GuildMapLock;
     public:
         GuildMgr();
         ~GuildMgr();

--- a/src/shared/LockedQueue/LockedQueue.h
+++ b/src/shared/LockedQueue/LockedQueue.h
@@ -98,29 +98,40 @@ namespace ACE_Based
 
             template<class Checker>
             /**
-             * @brief
+             * @brief Pops the first queued item the checker accepts.
              *
-             * @param result
-             * @param check
-             * @return bool
+             * Walks from the front of the queue and returns the first item
+             * for which @c check.Process(item) returns true. Items the
+             * checker rejects are left in place at their original positions;
+             * this preserves FIFO order within each accepted class while
+             * allowing a caller that owns one classification to make
+             * progress without being blocked by a head-of-queue item that
+             * belongs to another classification (e.g. a Map worker draining
+             * thread-safe packets while a thread-unsafe packet sits at the
+             * head of the same queue, awaiting the World thread).
+             *
+             * @param result Out parameter; receives the popped item on success.
+             * @param check Functor with bool Process(const T&). Invoked under
+             *              the queue lock.
+             * @return true if an accepted item was popped into @c result;
+             *         false if the queue is empty or no item satisfied the
+             *         checker.
              */
             bool next(T& result, Checker& check)
             {
                 ACE_GUARD_RETURN(LockType, g, this->_lock, false);
 
-                if (_queue.empty())
+                for (typename StorageType::iterator it = _queue.begin(); it != _queue.end(); ++it)
                 {
-                    return false;
+                    if (check.Process(*it))
+                    {
+                        result = *it;
+                        _queue.erase(it);
+                        return true;
+                    }
                 }
 
-                result = _queue.front();
-                if (!check.Process(result))
-                {
-                    return false;
-                }
-
-                _queue.pop_front();
-                return true;
+                return false;
             }
 
             /**


### PR DESCRIPTION
## Summary

Head-of-line blocking in WorldSession dispatch when filter conditions mismatch, plus unsynchronized singleton-map access in `ChannelMgr` and `GuildMgr` during concurrent worker threads. Fixes entries [1], [2], [3] from the 2026-05-14 Map::Update thread-safety audit.

## Commits

- `[LockedQueue] Walk past head-of-queue filter mismatches in next()` — filtered `next()` returns false on first head-mismatch instead of walking, stalling one filter's drainage when the head belongs to the other classification. Now walks past rejects. O(1) typical / O(n) worst (n = burst size).
- `[ChannelMgr] Serialize channel-map access with std::mutex` — singleton `std::map<wstring, Channel*>` is hit concurrently from Map workers via `Player::UpdateZone` → `UpdateLocalChannels`. Concurrent insert/erase/find is UB. Adds `std::mutex` around the three structural-access entry points.
- `[GuildMgr] Serialize guild-map access with std::mutex` — singleton `std::unordered_map<uint32, Guild*>` is read from workers via `AchievementMgr::SendAchievementEarned` during aura ticks while WorldThread can erase via `Guild::Disband`. UB. Adds `mutable std::mutex` around `RemoveGuild` and the four const getters.

## Scope

Protects map structural integrity only. `Channel*` / `Guild*` lifetime race across concurrent get/erase callers is a separate, unaddressed concern (needs ref-counted ownership).

## Verification

Release build clean (warnings-as-errors). Live boot on populated mangos3 install clean — "World Initialization Complete" reached, no init regressions. Interactive client reproduction of each race is the natural follow-up smoke step.

Companion mangostwo PR: mangostwo/server#203 (opened immediately after this one).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/116)
<!-- Reviewable:end -->
