### PR TITLE
[Code DOCS] Movement: align @param names with method signatures

### DIFF
--- a/src/game/MotionGenerators/MotionMaster.cpp
+++ b/src/game/MotionGenerators/MotionMaster.cpp
@@ -498,7 +498,7 @@ void MotionMaster::MoveSeekAssistance(float x, float y, float z)
 
 /**
  * @brief Makes the unit seek assistance and then distract.
- * @param timer Time for the distraction.
+ * @param time Time for the distraction.
  */
 void MotionMaster::MoveSeekAssistanceDistract(uint32 time)
 {

--- a/src/game/MotionGenerators/MovementGenerator.h
+++ b/src/game/MotionGenerators/MovementGenerator.h
@@ -59,7 +59,7 @@ class MovementGenerator
          *
          * @param owner Reference to the unit
          */
-        virtual void Initialize(Unit&) = 0;
+        virtual void Initialize(Unit& owner) = 0;
 
         /**
          * @brief Finalize the movement generator
@@ -68,7 +68,7 @@ class MovementGenerator
          *
          * @param owner Reference to the unit
          */
-        virtual void Finalize(Unit&) = 0;
+        virtual void Finalize(Unit& owner) = 0;
 
         /**
          * @brief Interrupt the movement generator
@@ -78,7 +78,7 @@ class MovementGenerator
          *
          * @param owner Reference to the unit
          */
-        virtual void Interrupt(Unit&) = 0;
+        virtual void Interrupt(Unit& owner) = 0;
 
         /**
          * @brief Reset the movement generator
@@ -88,7 +88,7 @@ class MovementGenerator
          *
          * @param owner Reference to the unit
          */
-        virtual void Reset(Unit&) = 0;
+        virtual void Reset(Unit& owner) = 0;
 
         /**
          * @brief Update the movement generator
@@ -96,7 +96,7 @@ class MovementGenerator
          * @param time_diff Time difference in milliseconds
          * @return True if update successful, false otherwise
          */
-        virtual bool Update(Unit&, const uint32& time_diff) = 0;
+        virtual bool Update(Unit& owner, const uint32& time_diff) = 0;
 
         /**
          * @brief Get the type of the movement generator
@@ -123,7 +123,7 @@ class MovementGenerator
          * @param o Orientation output
          * @return True if reset position obtained, false otherwise
          */
-        virtual bool GetResetPosition(Unit&, float& /*x*/, float& /*y*/, float& /*z*/, float& o) const { return false; }
+        virtual bool GetResetPosition(Unit& /*owner*/, float& /*x*/, float& /*y*/, float& /*z*/, float& /*o*/) const { return false; }
 
         /**
          * @brief Check if destination is reachable

--- a/src/game/MotionGenerators/PointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/PointMovementGenerator.cpp
@@ -184,7 +184,7 @@ void AssistanceMovementGenerator::Finalize(Unit& unit)
  * @param diff Time difference.
  * @return True if the update was successful, false otherwise.
  */
-bool EffectMovementGenerator::Update(Unit& unit, const uint32&)
+bool EffectMovementGenerator::Update(Unit& unit, const uint32& /*diff*/)
 {
     return !unit.movespline->Finalized();
 }

--- a/src/game/MotionGenerators/TargetedMovementGenerator.h
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.h
@@ -114,7 +114,7 @@ class TargetedMovementGeneratorMedium
          * @param owner Reference to the unit.
          * @param updateDestination Whether to update the destination.
          */
-        void _setTargetLocation(T&, bool updateDestination);
+        void _setTargetLocation(T& owner, bool updateDestination);
 
         /**
          * @brief Checks if a new position is required.
@@ -329,7 +329,7 @@ class FollowMovementGenerator : public TargetedMovementGeneratorMedium<T, Follow
     private:
         /**
          * @brief Updates the unit's speed.
-         * @param owner Reference to the unit.
+         * @param u Reference to the unit.
          */
         void _updateSpeed(T& u);
 

--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -674,7 +674,7 @@ void FlightPathMovementGenerator::DoEventIfAny(Player& player, TaxiPathNodeEntry
  * @param o Reference to the orientation.
  * @return True if the reset position was successfully obtained, false otherwise.
  */
-bool FlightPathMovementGenerator::GetResetPosition(Player&, float& x, float& y, float& z, float& o) const
+bool FlightPathMovementGenerator::GetResetPosition(Player& /*player*/, float& x, float& y, float& z, float& o) const
 {
     const TaxiPathNodeEntry& node = (*i_path)[i_currentNode];
     x = node.x;

--- a/src/game/MotionGenerators/WaypointMovementGenerator.h
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.h
@@ -347,7 +347,7 @@ class FlightPathMovementGenerator
          * @param o Orientation output
          * @return True if reset position obtained
          */
-        bool GetResetPosition(Player&, float& x, float& y, float& z, float& o) const;
+        bool GetResetPosition(Player& player, float& x, float& y, float& z, float& o) const;
 };
 
 #endif // MANGOS_WAYPOINTMOVEMENTGENERATOR_H

--- a/src/game/movement/MoveSplineInit.h
+++ b/src/game/movement/MoveSplineInit.h
@@ -107,7 +107,6 @@ namespace Movement
              * @param destination The destination point.
              * @param generatePath Whether to generate a path.
              * @param forceDestination Whether to force the destination.
-             * @param maxPathRange The maximum path range.
              */
             void MoveTo(const Vector3& destination, bool generatePath = false, bool forceDestination = false);
 

--- a/src/game/movement/spline.cpp
+++ b/src/game/movement/spline.cpp
@@ -157,7 +157,7 @@ namespace Movement
      * @param t Parameter for interpolation (not used).
      * @param result Output vector for the evaluated derivative.
      */
-    void SplineBase::EvaluateDerivativeLinear(index_type index, float, Vector3& result) const
+    void SplineBase::EvaluateDerivativeLinear(index_type index, float /*t*/, Vector3& result) const
     {
         MANGOS_ASSERT(index >= index_lo && index < index_hi);
         result = points[index + 1] - points[index];


### PR DESCRIPTION
## Changes
- `MovementGenerator.h`: name the unnamed `Unit&` on the pure-virtual `Initialize/Finalize/Interrupt/Reset/Update` declarations as `owner`; fold the default-impl `GetResetPosition`'s first and last params into the existing `/*x*/`, `/*y*/`, `/*z*/` commented-name style.
- `MotionMaster.cpp` `MoveSeekAssistanceDistract`: `@param timer` → `@param time`.
- `TargetedMovementGenerator.h`: name the `T&` on `_setTargetLocation` as `owner` to match the `.cpp` impl; `@param owner` → `@param u` on `_updateSpeed`.
- `WaypointMovementGenerator.{h,cpp}` `FlightPathMovementGenerator::GetResetPosition`: name the `Player&` as `player` in the header decl and `/*player*/` in the `.cpp` definition.
- `PointMovementGenerator.cpp` `EffectMovementGenerator::Update`: comment-name unused `const uint32&` as `/*diff*/`.
- `spline.cpp` `SplineBase::EvaluateDerivativeLinear`: comment-name unused `float` as `/*t*/`.
- `MoveSplineInit.h` `MoveTo`: drop phantom `@param maxPathRange` (no such parameter on the sig).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/117)
<!-- Reviewable:end -->
