### PR TITLE
[Code DOCS] Server: align @param names with method signatures

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -409,7 +409,7 @@ template<class T>
  * @brief Loads a DBC file and its localized string tables.
  *
  * @tparam T The DBC record type.
- * @param availableDbcLocales Bitmask of still-available locales.
+ * @param localeData Locale-availability tracker shared across the DBC load.
  * @param bar The startup progress indicator.
  * @param errlist The list collecting missing or incompatible files.
  * @param storage The storage receiving loaded records.
@@ -1389,10 +1389,11 @@ ContentLevels GetContentLevelsForMapAndZone(uint32 mapId, uint32 zoneId)
 }
 
 /**
- * @brief Gets the inspect bit position for a talent within its tab.
+ * @brief Looks up the per-difficulty data row for a given map.
  *
- * @param talentId The talent id.
- * @return uint32 The bit position within inspect data.
+ * @param mapId The map id.
+ * @param difficulty The map difficulty key.
+ * @return Pointer to the MapDifficultyEntry, or NULL when no row matches.
  */
 MapDifficultyEntry const* GetMapDifficultyData(uint32 mapId, Difficulty difficulty)
 {

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -225,7 +225,7 @@ const std::string& WorldSocket::GetRemoteAddress(void) const
 /**
  * @brief Sends a packet immediately or queues it for later flush.
  *
- * @param pkt The packet to send.
+ * @param pct The packet to send.
  * @return int Zero on success; otherwise -1.
  */
 int WorldSocket::SendPacket(const WorldPacket& pct)


### PR DESCRIPTION
## Changes
- `DBCStores.cpp` `LoadDBC`: `@param availableDbcLocales` → `@param localeData` matching the `LocalData&` parameter the function actually takes.
- `DBCStores.cpp` `GetMapDifficultyData`: rewrite an orphan doc block that documented a deleted talent-inspect helper; the new block describes the `(mapId, difficulty)` signature.
- `WorldSocket.cpp` `SendPacket`: signature uses `pct`, doc said `pkt` — rename the doc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/118)
<!-- Reviewable:end -->
