### PR TITLE
[Code DOCS] Object: align @param names with method signatures

### DIFF
--- a/src/game/Object/AuctionHouseMgr.cpp
+++ b/src/game/Object/AuctionHouseMgr.cpp
@@ -790,21 +790,7 @@ void AuctionHouseObject::BuildListOwnerItems(WorldPacket& data, Player* player, 
 }
 
 /**
- * @brief Builds the filtered public auction browse list.
- *
- * @param data The packet buffer to append to.
- * @param player The player requesting the list.
- * @param wsearchedname The search string in wide-character form.
- * @param listfrom The starting result offset.
- * @param levelmin The minimum required item level filter.
- * @param levelmax The maximum required item level filter.
- * @param usable Whether only usable items should be listed.
- * @param inventoryType The inventory type filter.
- * @param itemClass The item class filter.
- * @param itemSubClass The item subclass filter.
- * @param quality The minimum quality filter.
- * @param count Receives the number of appended entries.
- * @param totalcount Receives the total number of matching entries.
+ * @brief Comparator for sorted auction display.
  */
 int AuctionEntry::CompareAuctionEntry(uint32 column, const AuctionEntry* auc, Player* viewPlayer) const
 {
@@ -1016,6 +1002,23 @@ bool AuctionSorter::operator()(const AuctionEntry* auc1, const AuctionEntry* auc
     return false;                                           // "equal" by all sorts
 }
 
+/**
+ * @brief Builds the filtered public auction browse list.
+ *
+ * @param data The packet buffer to append to.
+ * @param player The player requesting the list.
+ * @param wsearchedname The search string in wide-character form.
+ * @param listfrom The starting result offset.
+ * @param levelmin The minimum required item level filter.
+ * @param levelmax The maximum required item level filter.
+ * @param usable Whether only usable items should be listed.
+ * @param inventoryType The inventory type filter.
+ * @param itemClass The item class filter.
+ * @param itemSubClass The item subclass filter.
+ * @param quality The minimum quality filter.
+ * @param count Receives the number of appended entries.
+ * @param totalcount Receives the total number of matching entries.
+ */
 void WorldSession::BuildListAuctionItems(std::vector<AuctionEntry*> const& auctions, WorldPacket& data, std::wstring const& wsearchedname, uint32 listfrom, uint32 levelmin,
         uint32 levelmax, uint32 usable, uint32 inventoryType, uint32 itemClass, uint32 itemSubClass, uint32 quality, uint32& count, uint32& totalcount, bool isFull)
 {

--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -149,8 +149,8 @@ VendorItem const* VendorItemData::FindItemCostPair(uint32 item_id, uint8 type, u
 /**
  * @brief Executes a delayed forced-despawn event.
  *
- * @param Unused execution time.
- * @param Unused update time.
+ * @param e_time Unused.
+ * @param p_time Unused.
  * @return Always true after despawning the owner.
  */
 bool ForcedDespawnDelayEvent::Execute(uint64 /*e_time*/, uint32 /*p_time*/)
@@ -309,8 +309,6 @@ void Creature::RemoveFromWorld()
 
 /**
  * @brief Removes the creature corpse and schedules respawn handling.
- *
- * @param inPlace true to leave the corpse in place while removing loot state.
  */
 void Creature::RemoveCorpse()
 {
@@ -382,7 +380,6 @@ void Creature::RemoveCorpse()
  * @brief Initializes creature template-dependent data for the current entry.
  *
  * @param Entry The creature entry to apply.
- * @param team Optional team override.
  * @param data Optional static spawn data.
  * @param eventData Optional active event override data.
  * @return true if initialization succeeded; otherwise, false.
@@ -1751,7 +1748,8 @@ void Creature::SelectLevel(uint32 forcedLevel /*= USE_DEFAULT_DATABASE_LEVEL*/)
 /**
  * @brief Selects the creature level and recalculates level-dependent stats.
  *
- * @param forcedLevel Optional forced level override.
+ * @param cinfo The creature template providing level bounds and base stats.
+ * @param percentHealth The starting health percentage to apply.
  */
 void Creature::SelectLevel(const CreatureInfo* cinfo, float percentHealth /*= 100.0f*/)
 {

--- a/src/game/Object/GMTicketMgr.h
+++ b/src/game/Object/GMTicketMgr.h
@@ -103,8 +103,9 @@ class GMTicket
          * Initializes this \ref GMTicket, much like the constructor would.
          * @param guid guid for the \ref Player that created the ticket
          * @param text the question text
-         * @param responsetext the response to the question if any
+         * @param responseText the response to the question if any
          * @param update the last time the ticket was updated by either \ref Player or GM
+         * @param ticketId unique identifier assigned to this ticket
          */
         void Init(ObjectGuid guid, const std::string& text, const std::string& responseText, time_t update, uint32 ticketId);
 

--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -200,10 +200,7 @@ void GameObject::RemoveFromWorld()
  * @param y The y coordinate.
  * @param z The z coordinate.
  * @param ang The facing angle.
- * @param r0 Quaternion x component.
- * @param r1 Quaternion y component.
- * @param r2 Quaternion z component.
- * @param r3 Quaternion w component.
+ * @param rotation The packed quaternion describing the object's rotation.
  * @param animprogress The initial animation progress.
  * @param go_state The initial gameobject state.
  * @return true if creation succeeded; otherwise, false.

--- a/src/game/Object/GameObjectAI.h
+++ b/src/game/Object/GameObjectAI.h
@@ -43,7 +43,7 @@ public:
     * Called at World update tick, by default every 100ms
     * This setting is dependend on CONFIG_UINT32_INTERVAL_MAPUPDATE
     * Note: Use this function to handle Timers
-    * @param uiDiff Passed time since last call
+    * @param diff Passed time since last call
     */
     virtual void UpdateAI(const uint32 /*diff*/) {}
 

--- a/src/game/Object/Object.cpp
+++ b/src/game/Object/Object.cpp
@@ -2605,13 +2605,6 @@ void WorldObject::MonsterText(MangosStringLocale const* textData, Unit const* ta
 }
 
 /**
- * @brief Send message to set
- * @param data Packet to send
- * @param bToSelf If true, send to self (unused)
- *
- * Broadcasts a packet to all players who can see this object.
- */
-/**
  * @brief Broadcasts a packet to all players in the object's visibility set.
  *
  * @param data The packet to send.
@@ -2626,15 +2619,6 @@ void WorldObject::SendMessageToSet(WorldPacket* data, bool /*bToSelf*/) const
     }
 }
 
-/**
- * @brief Send message to set in range
- * @param data Packet to send
- * @param dist Maximum distance
- * @param bToSelf If true, send to self (unused)
- *
- * Broadcasts a packet to all players within the specified distance
- * who can see this object.
- */
 /**
  * @brief Broadcasts a packet to players within a specified range.
  *
@@ -2651,14 +2635,6 @@ void WorldObject::SendMessageToSetInRange(WorldPacket* data, float dist, bool /*
     }
 }
 
-/**
- * @brief Send message to set except receiver
- * @param data Packet to send
- * @param skipped_receiver Player to skip
- *
- * Broadcasts a packet to all players who can see this object
- * except the specified player.
- */
 /**
  * @brief Broadcasts a packet to visible players except one receiver.
  *

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -3821,7 +3821,8 @@ void ObjectMgr::LoadPlayerInfo()
  *
  * @param class_ The player class id.
  * @param level The player level.
- * @param info Receives the class level info.
+ * @param baseHP Receives the base health for this class/level combination.
+ * @param baseMana Receives the base mana for this class/level combination.
  */
 void ObjectMgr::GetPlayerClassLevelInfo(uint32 class_, uint32 level, uint32& baseHP, uint32& baseMana) const
 {

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -965,7 +965,6 @@ bool Pet::CreateBaseAtCreature(Creature* creature)
  * @brief Initializes pet stats for a given level.
  *
  * @param petlevel The target pet level.
- * @param owner Optional owner override.
  * @return true if initialization succeeded; otherwise, false.
  */
 void Pet::InitStatsForLevel(uint32 petlevel)

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -1323,7 +1323,7 @@ DrunkenState Player::GetDrunkenstateByValue(uint8 value)
 /**
  * @brief Sets the player's drunk value and updates related visibility effects.
  *
- * @param newDrunkenValue The new drunk value.
+ * @param newDrunkValue The new drunk value.
  * @param itemId Unused source item identifier.
  */
 void Player::SetDrunkValue(uint8 newDrunkValue, uint32 itemId /*= 0*/)
@@ -1755,7 +1755,8 @@ void Player::SetDeathState(DeathState s)
  * @brief Builds character-enumeration data for the character selection screen.
  *
  * @param result The database row for the character.
- * @param p_data The packet being populated.
+ * @param data The packet being populated.
+ * @param buffer Secondary byte buffer for trailing variable-length fields.
  * @return true if the enum data was built successfully; otherwise, false.
  */
 bool Player::BuildEnumData(QueryResult* result, ByteBuffer* data, ByteBuffer* buffer)
@@ -2034,7 +2035,7 @@ void Player::SendTeleportPacket(float oldX, float oldY, float oldZ, float oldO)
  * @param z The destination z coordinate.
  * @param orientation The destination orientation.
  * @param options Teleport option flags.
- * @param allowNoDelay true to bypass delayed-teleport deferral when possible.
+ * @param at Optional area trigger that initiated the teleport.
  * @return true if teleport setup succeeded; otherwise, false.
  */
 bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientation, uint32 options /*=0*/, AreaTrigger const* at /*=NULL*/)
@@ -2775,7 +2776,7 @@ void Player::RegenerateHealth(uint32 diff)
  * @brief Gets an NPC the player can currently interact with.
  *
  * @param guid The target creature GUID.
- * @param npcflagmask Optional NPC flag mask that must be present on the creature.
+ * @param NpcFlagsmask Optional NPC flag mask that must be present on the creature.
  * @return The interactable creature, or null if interaction is not allowed.
  */
 Creature* Player::GetNPCIfCanInteractWith(ObjectGuid guid, uint32 NpcFlagsmask)
@@ -3124,7 +3125,6 @@ void Player::UninviteFromGroup()
  *
  * @param group The group to remove the member from.
  * @param guid The GUID of the member to remove.
- * @param removeMethod The group removal method to apply.
  */
 void Player::RemoveFromGroup(Group* group, ObjectGuid guid)
 {
@@ -11101,12 +11101,12 @@ void Player::SetSheath(SheathState sheathed)
 }
 
 /**
- * @brief Finds an appropriate equipment slot for an item prototype.
+ * @brief Populates the candidate equipment slots for a given inventory type.
  *
- * @param proto The item prototype to equip.
- * @param slot The preferred slot, or NULL_SLOT to auto-select.
- * @param swap True to allow replacing an occupied slot.
- * @return The chosen slot, or NULL_SLOT if none fits.
+ * @param invType The item inventory type (see InventoryType enum).
+ * @param slots Receives up to four candidate equipment slots; unused entries are filled with NULL_SLOT.
+ * @param subClass The item subclass, used to disambiguate cases like ranged weapon variants.
+ * @return true if at least one valid slot is produced; otherwise, false.
  */
 bool Player::GetSlotsForInventoryType(uint8 invType, uint8* slots, uint32 subClass) const
 {
@@ -13578,7 +13578,6 @@ InventoryResult Player::CanUseItem(Item* pItem, bool direct_action) const
  * @brief Checks whether an item prototype is usable by the player.
  *
  * @param pProto The item prototype to validate.
- * @param direct_action True if the check is for an immediate player action.
  * @return The inventory result for the use check.
  */
 InventoryResult Player::CanUseItem(ItemPrototype const* pProto) const
@@ -14413,8 +14412,7 @@ void Player::DestroyItem(uint8 bag, uint8 slot, bool update)
  * @param count The requested quantity to destroy.
  * @param update True to send inventory updates to the client.
  * @param unequip_check True to validate equipped items before destroying them.
- * @param delete_from_bank True to include bank storage in the search.
- * @param delete_from_buyback True to include vendor buyback slots in the search.
+ * @param inBankAlso True to include bank storage when searching for stacks to destroy.
  * @return The number of items removed.
  */
 void Player::DestroyItemCount(uint32 item, uint32 count, bool update, bool unequip_check, bool inBankAlso)
@@ -16224,7 +16222,6 @@ void Player::SendItemDurations()
  * @param received True if the item was received rather than looted.
  * @param created True if the item was created rather than simply received.
  * @param broadcast True to broadcast the message to the player's group.
- * @param showInChat True to show the gain in chat.
  */
 void Player::SendNewItem(Item* item, uint32 count, bool received, bool created, bool broadcast)
 {
@@ -23791,7 +23788,7 @@ void Player::RemovePetActionBar()
 /**
  * @brief Applies or removes a spell modifier and notifies the client.
  *
- * @param mod The modifier to add or remove.
+ * @param aura The aura whose modifier should be added or removed.
  * @param apply True to apply the modifier; false to remove it.
  */
 void Player::AddSpellMod(Aura* aura, bool apply)
@@ -25407,8 +25404,6 @@ void Player::ToggleMetaGemsActive(uint8 exceptslot, bool apply)
 
 /**
  * @brief Stores the location used to return the player after leaving a battleground.
- *
- * @param leader The group leader to mirror entry positioning from, or NULL.
  */
 void Player::SetBattleGroundEntryPoint()
 {
@@ -26029,7 +26024,6 @@ void Player::SendUpdateToOutOfRangeGroupMembers()
  * @brief Sends the appropriate transfer-aborted feedback for an area lock failure.
  *
  * @param mapEntry The destination map entry.
- * @param at The triggering area trigger, if any.
  * @param lockStatus The evaluated area lock status.
  * @param miscRequirement Extra requirement data used by some messages.
  */

--- a/src/game/Object/ReactorAI.cpp
+++ b/src/game/Object/ReactorAI.cpp
@@ -50,9 +50,9 @@ int ReactorAI::Permissible(const Creature* creature)
 /**
  * @brief Ignores passive line-of-sight reactions for reactor AI.
  *
- * @param Unused line-of-sight unit.
+ * @param pWho The unit entering line-of-sight (unused).
  */
-void ReactorAI::MoveInLineOfSight(Unit*)
+void ReactorAI::MoveInLineOfSight(Unit* /*pWho*/)
 {
 }
 
@@ -84,10 +84,10 @@ void ReactorAI::AttackStart(Unit* p)
 /**
  * @brief Checks whether a unit is visible to this AI.
  *
- * @param Unused target unit.
+ * @param pWho The candidate unit (unused).
  * @return Always false for reactor AI visibility checks here.
  */
-bool ReactorAI::IsVisible(Unit*) const
+bool ReactorAI::IsVisible(Unit* /*pWho*/) const
 {
     return false;
 }

--- a/src/game/Object/TotemAI.cpp
+++ b/src/game/Object/TotemAI.cpp
@@ -60,9 +60,9 @@ TotemAI::TotemAI(Creature* c) : CreatureAI(c)
 /**
  * @brief Ignores line-of-sight events for totems.
  *
- * @param The unit entering line of sight.
+ * @param pWho The unit entering line-of-sight.
  */
-void TotemAI::MoveInLineOfSight(Unit*)
+void TotemAI::MoveInLineOfSight(Unit* /*pWho*/)
 {
 }
 
@@ -141,10 +141,10 @@ void TotemAI::UpdateAI(const uint32 /*diff*/)
 /**
  * @brief Totems do not use generic visibility checks in this AI.
  *
- * @param The unit being tested.
+ * @param pWho The unit being tested.
  * @return false.
  */
-bool TotemAI::IsVisible(Unit*) const
+bool TotemAI::IsVisible(Unit* /*pWho*/) const
 {
     return false;
 }
@@ -152,9 +152,9 @@ bool TotemAI::IsVisible(Unit*) const
 /**
  * @brief Ignores direct attack start requests for totems.
  *
- * @param The target unit.
+ * @param pWho The target unit.
  */
-void TotemAI::AttackStart(Unit*)
+void TotemAI::AttackStart(Unit* /*pWho*/)
 {
 }
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -3733,7 +3733,6 @@ MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackT
  * @param dodge_chance The dodge chance in hundredths of a percent.
  * @param parry_chance The parry chance in hundredths of a percent.
  * @param block_chance The block chance in hundredths of a percent.
- * @param SpellCasted True when evaluating a spell-based melee hit.
  * @return The resulting melee hit outcome.
  */
 MeleeHitOutcome Unit::RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackType attType, int32 crit_chance, int32 miss_chance, int32 dodge_chance, int32 parry_chance, int32 block_chance) const
@@ -5038,8 +5037,6 @@ void Unit::FinishSpell(CurrentSpellTypes spellType, bool ok /*= true*/)
  * @param withDelayed True to treat delayed spells as active casts.
  * @param skipChanneled True to ignore channeled spells.
  * @param skipAutorepeat True to ignore auto-repeat spells.
- * @param forMovement Unused movement-specific flag.
- * @param forAutoIgnore Unused auto-ignore flag.
  * @return True if a matching non-melee spell is being cast; otherwise, false.
  */
 bool Unit::IsNonMeleeSpellCasted(bool withDelayed, bool skipChanneled, bool skipAutorepeat) const
@@ -13471,10 +13468,11 @@ void Unit::SetHealthPercent(float percent)
 }
 
 /**
- * @brief Sets a power value while clamping to its maximum.
+ * @brief Looks up the power-array index used by a given class for a power type.
  *
- * @param power The power type to set.
- * @param val The requested power value.
+ * @param powerId The power type to translate.
+ * @param classId The player or creature class id.
+ * @return The index within the unit's stored power array.
  */
 uint32 Unit::GetPowerIndexByClass(Powers powerId, uint32 classId)
 {

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -2239,7 +2239,6 @@ class Unit : public WorldObject
          * the structure. Also calculates bonus damage with Unit::MeleeDamageBonusDone and the damage
          * with Unit::CalculateDamage
          * @param pVictim the victim that was hit with damage
-         * @param damage how much damage to try to do
          * @param damageInfo this is filled with data about what kind of damage that was done
          * @param attackType type of attack, base/off/ranged
          */
@@ -2424,7 +2423,6 @@ class Unit : public WorldObject
          * @param dodge_chance victims dodge chance
          * @param parry_chance victims parry chance
          * @param block_chance victims block chance
-         * @param SpellCasted whether or not this was because of a spell of autoattack (false => autoattack)
          * @return what the hit resulted in, miss/hit etc
          */
         MeleeHitOutcome RollMeleeOutcomeAgainst(const Unit* pVictim, WeaponAttackType attType, int32 crit_chance, int32 miss_chance, int32 dodge_chance, int32 parry_chance, int32 block_chance) const;
@@ -2770,7 +2768,7 @@ class Unit : public WorldObject
          * @return true if the target can be attacked, false otherwise
          * \see UnitState
          */
-        bool IsTargetableForAttack(bool inversAlive = false) const;
+        bool IsTargetableForAttack(bool inverseAlive = false) const;
         /**
          * Simply checks if this \ref Unit has the flag (\ref Unit::HasFlag)
          * \ref UnitFlags::UNIT_FLAG_PASSIVE in \ref EUnitFields::UNIT_FIELD_FLAGS
@@ -2931,7 +2929,6 @@ class Unit : public WorldObject
          * @param triggeredByAura the \ref Aura that triggered this
          * @param originalCaster the original caster if any
          * @param triggeredBy the \ref SpellEntry that triggered this cast, if any
-         * @param calculateDamage Indicates whether the damage calculation must be performed (in some cases, the calculation has already been executed).
          * \todo What's the original caster?
          */
         void CastCustomSpell(Unit* Victim, SpellEntry const* spellInfo, int32 const* bp0, int32 const* bp1, int32 const* bp2, bool triggered, Item* castItem = NULL, Aura* triggeredByAura = NULL, ObjectGuid originalCaster = ObjectGuid(), SpellEntry const* triggeredBy = NULL);


### PR DESCRIPTION
## Changes
Doc renames to match signature parameter names:
- `GameObjectAI.h` `UpdateAI`: `uiDiff` → `diff`.
- `GMTicketMgr.h` `Init`: case fix `responsetext` → `responseText`; also add the missing `@param ticketId`.
- `Player.cpp` `BuildEnumData`: `p_data` → `data`; add missing `@param buffer`.
- `Player.cpp` `GetNPCIfCanInteractWith`: casing `npcflagmask` → `NpcFlagsmask`.
- `Player.cpp` `AddSpellMod`: `mod` → `aura`.

Phantom `@param` tags removed (parameters that don't exist on the signature):
- `Creature.cpp` `RemoveCorpse` `inPlace`, `InitEntry` `team`.
- `Pet.cpp` `InitStatsForLevel` `owner`.
- `Player.cpp`: `TeleportTo` `allowNoDelay`; `RemoveFromGroup` `removeMethod`; `CanUseItem(ItemPrototype)` `direct_action` (belonged to the other overload); `DestroyItemCount` `delete_from_bank`/`delete_from_buyback` (and add missing `@param inBankAlso`); `SendNewItem` `showInChat`; `SetBattleGroundEntryPoint` `leader`; `SendTransferAbortedByLockStatus` `at`.
- `Unit.h`: `CalculateMeleeDamage` `damage`; `RollMeleeOutcomeAgainst` (7-param overload) `SpellCasted`; `CastCustomSpell` `calculateDamage`.
- `Unit.cpp`: `IsNonMeleeSpellCasted` `forMovement` and `forAutoIgnore`.

Sig change (typo correction, zero call-site impact):
- `Unit.h` `IsTargetableForAttack`: rename parameter `inversAlive` → `inverseAlive` so it matches the doc. `grep` across `src/` confirms no callers used the misspelled name.

Misplaced / duplicated doc blocks:
- `Object.cpp`: `SendMessageToSet`, `SendMessageToSetInRange` and `SendMessageToSetExcept` each had a duplicate doc block — drop the duplicates.
- `AuctionHouseMgr.cpp`: move the orphaned `BuildListAuctionItems` doc block from above `CompareAuctionEntry` down to its actual function; write a fresh one-line brief for `CompareAuctionEntry`.
- `Unit.cpp` `GetPowerIndexByClass`: rewrite a doc block that described a different `(power, val)` setter; the new block matches the actual `(powerId, classId)` signature.

Rewrites / completions:
- `Creature.cpp` `ForcedDespawnDelayEvent::Execute`: `@param Unused execution time` / `@param Unused update time` were parsed as `@param "Unused"`; rewrite as `@param e_time` / `@param p_time`.
- `Creature.cpp` `Creature::SelectLevel`: replace bogus `@param forcedLevel` with `@param cinfo`, `@param percentHealth`.
- `GameObject.cpp` `Create`: four leftover `@param r0/r1/r2/r3` (from a past quaternion-as-4-floats sig) collapsed into one `@param rotation`.
- `ObjectMgr.cpp` `GetPlayerClassLevelInfo`: replace phantom `@param info` with the actual `@param baseHP`, `@param baseMana`.
- `Player.cpp` `GetSlotsForInventoryType`: replace a doc block describing a different function with `@param invType`, `@param slots`, `@param subClass`.
- `ReactorAI.cpp` / `TotemAI.cpp` `MoveInLineOfSight`, `IsVisible`, `AttackStart`: name the previously-unnamed `Unit*` impl params as `/*pWho*/` so the `@param pWho` docs resolve.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/120)
<!-- Reviewable:end -->
