### PR TITLE
[Code DOCS] BattleGround: align @param names with method signatures

### DIFF
--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -225,10 +225,13 @@ bool BattleGroundQueue::SelectionPool::AddGroup(GroupQueueInfo* ginfo, uint32 de
  *
  * @param leader The group leader or solo player joining the queue.
  * @param grp The group joining (NULL for solo players).
- * @param bracketEntry
- * @param bracketId The level bracket for this group.
+ * @param BgTypeId The battleground type id.
+ * @param bracketEntry The PvP difficulty bracket entry; the local bracketId is derived from it.
  * @param arenaType The Arena Type for this group.
+ * @param isRated Whether the queue is rated.
  * @param isPremade Whether this is a premade group (rated, etc.).
+ * @param arenaRating Arena team rating for rated queues.
+ * @param arenateamid Arena team id (0 for non-arena).
  * @return GroupQueueInfo* Pointer to the created group queue info structure.
  */
 GroupQueueInfo* BattleGroundQueue::AddGroup(Player* leader, Group* grp, BattleGroundTypeId BgTypeId, PvPDifficultyEntry const*  bracketEntry, ArenaType arenaType, bool isRated, bool isPremade, uint32 arenaRating, uint32 arenateamid)
@@ -2319,7 +2322,7 @@ BattleGround* BattleGroundMgr::CreateNewBattleGround(BattleGroundTypeId bgTypeId
  * New instances are created by copying this template.
  *
  * @param bgTypeId The battleground type.
- * @param isArena
+ * @param IsArena Whether the template is an arena.
  * @param MinPlayersPerTeam Minimum players required per team.
  * @param MaxPlayersPerTeam Maximum players allowed per team.
  * @param LevelMin Minimum level to queue for this battleground.
@@ -2334,7 +2337,6 @@ BattleGround* BattleGroundMgr::CreateNewBattleGround(BattleGroundTypeId bgTypeId
  * @param Team2StartLocY Horde spawn location Y coordinate.
  * @param Team2StartLocZ Horde spawn location Z coordinate.
  * @param Team2StartLocO Horde spawn location orientation.
- * @param StartMaxDist Maximum distance from spawn location for initial positioning.
  * @return The instance ID of the created template battleground.
  */
 uint32 BattleGroundMgr::CreateBattleGround(BattleGroundTypeId bgTypeId, bool IsArena, uint32 MinPlayersPerTeam, uint32 MaxPlayersPerTeam, uint32 LevelMin, uint32 LevelMax, char const* BattleGroundName, uint32 MapID, float Team1StartLocX, float Team1StartLocY, float Team1StartLocZ, float Team1StartLocO, float Team2StartLocX, float Team2StartLocY, float Team2StartLocZ, float Team2StartLocO)

--- a/src/game/BattleGround/BattleGroundMgr.h
+++ b/src/game/BattleGround/BattleGroundMgr.h
@@ -158,9 +158,9 @@ class BattleGroundQueue
          * @brief Updates the battleground queue.
          * @param bgTypeId The battleground type id.
          * @param bracket_id The bracket id.
-         * @param ArenaType
-         * @param isRated
-         * @param minRating
+         * @param arenaType The arena type.
+         * @param isRated Whether the queue is rated.
+         * @param minRating Minimum rating filter.
          */
         void Update(BattleGroundTypeId bgTypeId, BattleGroundBracketId bracket_id, ArenaType arenaType = ARENA_TYPE_NONE, bool isRated = false, uint32 minRating = 0);
 
@@ -195,10 +195,12 @@ class BattleGroundQueue
          * @param leader The group leader.
          * @param group The group.
          * @param bgTypeId The battleground type id.
-         * @param bracketId The bracket id.
-         * @return arenaType
-         * @return isRated
+         * @param bracketEntry The PvP difficulty bracket entry.
+         * @param arenaType The arena type.
+         * @param isRated Whether the queue is rated.
          * @param isPremade True if the group is premade, false otherwise.
+         * @param ArenaRating Arena team rating for rated queues.
+         * @param ArenaTeamId Arena team id (0 for non-arena).
          * @return GroupQueueInfo* Pointer to the group queue info.
          */
         GroupQueueInfo* AddGroup(Player* leader, Group* group, BattleGroundTypeId bgTypeId, PvPDifficultyEntry const*  bracketEntry, ArenaType arenaType, bool isRated, bool isPremade, uint32 ArenaRating, uint32 ArenaTeamId = 0);
@@ -487,13 +489,12 @@ class BattleGroundMgr
          * @brief Builds a packet for battleground status.
          * @param data The packet data.
          * @param bg The battleground.
-         * @param player
+         * @param player The recipient player.
          * @param QueueSlot The queue slot.
          * @param StatusID The status ID.
          * @param Time1 The first time value.
          * @param Time2 The second time value.
-         * @param arenaType
-         * @param arenaTeam
+         * @param arenatype The arena type.
          */
         void BuildBattleGroundStatusPacket(WorldPacket* data, BattleGround* bg, Player* player, uint8 QueueSlot, uint8 StatusID, uint32 Time1, uint32 Time2, ArenaType arenatype);
         void BuildBattleGroundStatusFailedPacket(WorldPacket* data, BattleGround* bg, Player* player, uint8 QueueSlot, GroupJoinBattlegroundResult result);
@@ -533,9 +534,9 @@ class BattleGroundMgr
          * @brief Creates a new battleground instance.
          *
          * @param bgTypeId The battleground type id.
-         * @param bracket_id The bracket id.
-         * @param arenaType
-         * @param isRated
+         * @param bracketEntry The PvP difficulty bracket entry.
+         * @param arenaType The arena type.
+         * @param isRated Whether the instance is rated.
          * @return BattleGround* Pointer to the created battleground instance.
          */
         BattleGround* CreateNewBattleGround(BattleGroundTypeId bgTypeId, PvPDifficultyEntry const* bracketEntry, ArenaType arenaType, bool isRated);


### PR DESCRIPTION
## Changes
`BattleGroundMgr.h`:
- `BattleGroundQueue::Update`: rename `@param ArenaType` → `@param arenaType` (case match) and fill the empty `isRated` / `minRating` descriptions.
- `BattleGroundQueue::AddGroup` (decl): rename `@param bracketId` → `@param bracketEntry`; convert stray `@return arenaType` / `@return isRated` lines into `@param`; add missing `@param ArenaRating` and `@param ArenaTeamId`.
- `BuildBattleGroundStatusPacket`: rename `@param arenaType` → `@param arenatype` to match the (lowercase) sig parameter; drop the phantom `@param arenaTeam`.
- `CreateNewBattleGround`: rename `@param bracket_id` → `@param bracketEntry`.

`BattleGroundMgr.cpp`:
- `BattleGroundQueue::AddGroup` (impl): drop phantom `@param bracketId` (a local variable derived inside the body, not a parameter); describe the existing `@param bracketEntry`; add missing `@param BgTypeId`, `@param isRated`, `@param arenaRating`, `@param arenateamid`.
- `BattleGroundMgr::CreateBattleGround`: rename `@param isArena` → `@param IsArena` to match the sig parameter; drop the phantom `@param StartMaxDist`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/121)
<!-- Reviewable:end -->
