### PR TITLE
[Code DOCS] ChatCommands/AuctionHouseBot: align @param names with method signatures

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.h
@@ -479,7 +479,7 @@ class AuctionHouseBot
         /**
          * @brief Sets the items amount.
          *
-         * @param (vals)[] The vals.
+         * @param vals The vals.
          */
         void SetItemsAmount(uint32(&vals) [MAX_AUCTION_QUALITY]);
         /**

--- a/src/game/ChatCommands/DebugCommands.cpp
+++ b/src/game/ChatCommands/DebugCommands.cpp
@@ -1084,7 +1084,10 @@ bool ChatHandler::HandleDebugSetAuraStateCommand(char* args)
 /**
  * @brief Handler for HandleSetValueHelper command.
  *
- * @param args Command arguments.
+ * @param target Object whose field should be set.
+ * @param field Field index within the object's data array.
+ * @param typeStr Field type token (int, hex, float).
+ * @param valStr New value parsed according to typeStr.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::HandleSetValueHelper(Object* target, uint32 field, char* typeStr, char* valStr)
@@ -1233,7 +1236,9 @@ bool ChatHandler::HandleDebugSetValueCommand(char* args)
 /**
  * @brief Handler for HandleGetValueHelper command.
  *
- * @param args Command arguments.
+ * @param target Object whose field should be read.
+ * @param field Field index within the object's data array.
+ * @param typeStr Field type token used to format the printed value.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::HandleGetValueHelper(Object* target, uint32 field, char* typeStr)
@@ -1381,7 +1386,10 @@ bool ChatHandler::HandleDebugGetValueCommand(char* args)
 /**
  * @brief Handler for HandlerDebugModValueHelper command.
  *
- * @param args Command arguments.
+ * @param target Object whose field should be modified.
+ * @param field Field index within the object's data array.
+ * @param typeStr Field type token (int, hex, float).
+ * @param valStr Modification value parsed according to typeStr.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::HandlerDebugModValueHelper(Object* target, uint32 field, char* typeStr, char* valStr)

--- a/src/game/ChatCommands/LookupCommands.cpp
+++ b/src/game/ChatCommands/LookupCommands.cpp
@@ -45,7 +45,8 @@
 /**
  * @brief Handler for LookupPlayerSearchCommand command.
  *
- * @param args Command arguments.
+ * @param result Query result set to walk; consumed and freed by this call.
+ * @param limit Optional pointer to a remaining-results counter; decremented as rows are printed.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::LookupPlayerSearchCommand(QueryResult* result, uint32* limit)
@@ -662,7 +663,10 @@ bool ChatHandler::HandleLookupAccountNameCommand(char* args)
 /**
  * @brief Handler for ShowAccountListHelper command.
  *
- * @param args Command arguments.
+ * @param result Query result set to walk; consumed and freed by this call.
+ * @param limit Optional pointer to a remaining-results counter; decremented as rows are printed.
+ * @param title Whether to print the column header row.
+ * @param error Whether to emit an "empty list" message when result is NULL.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::ShowAccountListHelper(QueryResult* result, uint32* limit, bool title, bool error)

--- a/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
+++ b/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
@@ -91,7 +91,12 @@ static char const* const areatriggerKeys[] =
 /**
  * @brief Handler for HandleGoHelper command.
  *
- * @param args Command arguments.
+ * @param player Player to teleport.
+ * @param mapid Destination map id.
+ * @param x Destination X coordinate.
+ * @param y Destination Y coordinate.
+ * @param zPtr Optional destination Z; if NULL the map height is sampled.
+ * @param ortPtr Optional destination orientation; if NULL the player's current orientation is reused.
  * @returns True if the command executed successfully, false otherwise.
  */
 bool ChatHandler::HandleGoHelper(Player* player, uint32 mapid, float x, float y, float const* zPtr, float const* ortPtr)


### PR DESCRIPTION
## Changes
`ChatCommands/`:
- `DebugCommands.cpp` `HandleSetValueHelper`, `HandleGetValueHelper`, `HandlerDebugModValueHelper`: each carried a `@param args Command arguments.` header but takes `(Object* target, uint32 field, char* typeStr, [char* valStr])`. Replace with real per-param tags.
- `LookupCommands.cpp` `LookupPlayerSearchCommand`, `ShowAccountListHelper`: same pattern; replace `@param args` with `@param result`, `@param limit`, plus `@param title` and `@param error` on the latter.
- `TeleportationAndPositionCommands.cpp` `HandleGoHelper`: same pattern; replace `@param args` with `@param player`, `@param mapid`, `@param x`, `@param y`, `@param zPtr`, `@param ortPtr`.

`AuctionHouseBot/`:
- `AuctionHouseBot.h` `SetItemsAmount`: `@param (vals)[]` → `@param vals` (the `(vals)[]` form was auto-generated from the ref-to-array type syntax `uint32(&vals)[MAX_AUCTION_QUALITY]`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/122)
<!-- Reviewable:end -->
