### PR TITLE
[Code DOCS] vmap: align @param names with method signatures

### DIFF
--- a/src/game/vmap/BIHWrap.h
+++ b/src/game/vmap/BIHWrap.h
@@ -51,7 +51,8 @@ class BIHWrap
              * @brief
              *
              * @param callback
-             * @param constobjects_array
+             * @param obj_array
+             * @param obj_size
              */
             MDLCallback(RayCallback& callback, const T* const* obj_array, uint32 obj_size ) : cb(callback), objects(obj_array), objects_size(obj_size) {}
 
@@ -61,7 +62,7 @@ class BIHWrap
              * @param r
              * @param Idx
              * @param MaxDist
-             * @param bool
+             * @param stopAtFirst
              * @return bool operator
              */
             bool operator()(const Ray& r, uint32 Idx, float& MaxDist, bool /*stopAtFirst*/)

--- a/src/game/vmap/GameObjectModel.h
+++ b/src/game/vmap/GameObjectModel.h
@@ -101,7 +101,7 @@ class GameObjectModel
         /**
          * @brief
          *
-         * @param enabled
+         * @param ph_mask
          */
         void enable(uint32 ph_mask) { phasemask = ph_mask;}
 
@@ -111,6 +111,7 @@ class GameObjectModel
          * @param Ray
          * @param MaxDist
          * @param StopAtFirstHit
+         * @param phaseMask
          * @return bool
          */
         bool IntersectRay(const G3D::Ray& Ray, float& MaxDist, bool StopAtFirstHit, uint32 phaseMask) const;

--- a/src/game/vmap/RegularGrid.h
+++ b/src/game/vmap/RegularGrid.h
@@ -48,8 +48,8 @@ struct NodeCreator
     /**
      * @brief
      *
-     * @param int
-     * @param int
+     * @param x
+     * @param y
      * @return Node
      */
     static Node* makeNode(int /*x*/, int /*y*/) { return new Node();}

--- a/src/game/vmap/TileAssembler.h
+++ b/src/game/vmap/TileAssembler.h
@@ -145,7 +145,6 @@ namespace VMAP
          * @brief Reads the world model data from a file
          *
          * @param path The path to the file
-         * @param RAW_VMAP_MAGIC The validation string to verify the file header
          * @return bool True if successful, false otherwise
          */
         bool Read(const char* path);
@@ -218,7 +217,7 @@ namespace VMAP
             /**
              * @brief
              *
-             * @param )
+             * @param pFilterMethod
              */
             void setModelNameFilterMethod(bool (*pFilterMethod)(char* pName)) { iFilterMethod = pFilterMethod; }
             /**

--- a/src/game/vmap/VMapManager2.h
+++ b/src/game/vmap/VMapManager2.h
@@ -266,7 +266,6 @@ namespace VMAP
          *
          * @param basepath The base path to the model files.
          * @param filename The name of the model file.
-         * @param flags The flags for the model.
          * @return WorldModel* The acquired model instance.
          */
         WorldModel* acquireModelInstance(const std::string& basepath, const std::string& filename);


### PR DESCRIPTION
## Changes
- `BIHWrap.h` `MDLCallback` ctor and `operator()`: rename legacy/placeholder `@param constobjects_array` and `@param bool` to `@param obj_array` and `@param stopAtFirst` matching the actual params; add the missing `@param obj_size`.
- `GameObjectModel.h` `enable()`: `@param enabled` → `@param ph_mask`. `IntersectRay`: add the missing `@param phaseMask` line.
- `RegularGrid.h` `NodeCreator::makeNode`: replace duplicate type-as-name `@param int` × 2 with `@param x` / `@param y` matching the `/*x*/`, `/*y*/` commented-name convention already used in the sig.
- `TileAssembler.h` `Read()`: drop phantom `@param RAW_VMAP_MAGIC` (the sig takes only `path`). `setModelNameFilterMethod`: replace malformed `@param )` with `@param pFilterMethod`.
- `VMapManager2.h` `acquireModelInstance`: drop phantom `@param flags` (no such parameter on the sig).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/123)
<!-- Reviewable:end -->
