### PR TITLE
[Code DOCS] shared: align @param names with method signatures

### DIFF
--- a/src/shared/Auth/AuthCrypt.h
+++ b/src/shared/Auth/AuthCrypt.h
@@ -53,6 +53,7 @@ class AuthCrypt
 
         /**
          * @brief Initialize the encryption/decryption state
+         * @param K Session key used to seed the cipher state
          */
         void Init(BigNumber* K);
         /**
@@ -60,13 +61,13 @@ class AuthCrypt
          * @param data Pointer to data buffer to decrypt
          * @param len Length of data to decrypt
          */
-        void DecryptRecv(uint8*, size_t);
+        void DecryptRecv(uint8* data, size_t len);
         /**
          * @brief Encrypt data to send to client
          * @param data Pointer to data buffer to encrypt
          * @param len Length of data to encrypt
          */
-        void EncryptSend(uint8*, size_t);
+        void EncryptSend(uint8* data, size_t len);
 
         /**
          * @brief Check if the crypt object is initialized

--- a/src/shared/Auth/BigNumber.h
+++ b/src/shared/Auth/BigNumber.h
@@ -50,9 +50,9 @@ class BigNumber
         BigNumber(const BigNumber& bn);
         /**
          * @brief Constructor from 32-bit unsigned integer
-         * @param uint32 Initial value
+         * @param val Initial value
          */
-        BigNumber(uint32);
+        BigNumber(uint32 val);
         /**
          * @brief Destructor - frees OpenSSL BIGNUM resources
          */
@@ -60,14 +60,14 @@ class BigNumber
 
         /**
          * @brief Set value from 32-bit unsigned integer
-         * @param uint32 Value to set
+         * @param val Value to set
          */
-        void SetDword(uint32);
+        void SetDword(uint32 val);
         /**
          * @brief Set value from 64-bit unsigned integer
-         * @param uint64 Value to set
+         * @param val Value to set
          */
-        void SetQword(uint64);
+        void SetQword(uint64 val);
         /**
          * @brief Set value from binary data
          * @param bytes Pointer to binary data
@@ -189,10 +189,10 @@ class BigNumber
         BigNumber ModExp(const BigNumber& bn1, const BigNumber& bn2);
         /**
          * @brief Exponentiation: this ^ bn
-         * @param Exponent value
+         * @param bn Exponent value
          * @return New BigNumber with result
          */
-        BigNumber Exp(const BigNumber&);
+        BigNumber Exp(const BigNumber& bn);
 
         /**
          * @brief Get the number of bytes needed to represent this value

--- a/src/shared/Database/Database.h
+++ b/src/shared/Database/Database.h
@@ -641,7 +641,7 @@ class Database
         /**
         * @brief Function to check that the database version matches expected core version
         *
-        * @param DatabaseTypes
+        * @param database
         * @return bool
         */
         bool CheckDatabaseVersion(DatabaseTypes database);

--- a/src/shared/Database/QueryResultMysql.h
+++ b/src/shared/Database/QueryResultMysql.h
@@ -68,7 +68,7 @@ class QueryResultMysql : public QueryResult
         /**
          * @brief
          *
-         * @param type
+         * @param mysqlType
          * @return Field::SimpleDataTypes
          */
     private:

--- a/src/shared/Database/SQLStorage.h
+++ b/src/shared/Database/SQLStorage.h
@@ -574,7 +574,6 @@ class SQLMultiStorage : public SQLStorageBase
                 /**
                  * @brief
                  *
-                 * @param std::pair<RecordMultiMap::const_iterator
                  * @param pair
                  */
                 SQLMSIteratorBounds(std::pair<RecordMultiMap::const_iterator, RecordMultiMap::const_iterator> pair) : first(pair.first), second(pair.second) {}

--- a/src/shared/Database/SQLStorageImpl.h
+++ b/src/shared/Database/SQLStorageImpl.h
@@ -34,7 +34,7 @@ template<class S, class D>
 /**
  * @brief S source-type, D destination-type
  *
- * @param uint32
+ * @param field_pos
  * @param src
  * @param dst
  */
@@ -56,7 +56,7 @@ template<class DerivedLoader, class StorageClass>
 /**
  * @brief
  *
- * @param uint32
+ * @param field_pos
  * @param src
  * @param dst
  */
@@ -80,8 +80,8 @@ template<class S>
 /**
  * @brief S source-type
  *
- * @param uint32
- * @param S
+ * @param field_pos
+ * @param src
  * @param dst
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::convert_to_str(uint32 /*field_pos*/, S /*src*/, char*& dst)
@@ -95,8 +95,8 @@ template<class D>
 /**
  * @brief D destination-type
  *
- * @param uint32
- * @param
+ * @param field_pos
+ * @param src
  * @param dst
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::convert_from_str(uint32 /*field_pos*/, char const* /*src*/, D& dst)
@@ -118,7 +118,7 @@ template<class S, class D>
 /**
  * @brief S source-type, D destination-type
  *
- * @param uint32
+ * @param field_pos
  * @param src
  * @param dst
  */
@@ -140,8 +140,8 @@ template<class DerivedLoader, class StorageClass>
 /**
  * @brief
  *
- * @param uint32
- * @param
+ * @param field_pos
+ * @param src
  * @param dst
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::default_fill_to_str(uint32 /*field_pos*/, char const* /*src*/, char*& dst)

--- a/src/shared/Database/SqlPreparedStatement.h
+++ b/src/shared/Database/SqlPreparedStatement.h
@@ -497,10 +497,14 @@ class SqlStatement
          */
         void addString(const char* var) { arg(var); }
         /**
+         * @brief Add a string parameter.
+         * @param var The string parameter to add.
+         */
+        void addString(const std::string& var) { arg(var.c_str()); }
+        /**
          * @brief Add a string parameter from an ostringstream.
          * @param ss The ostringstream containing the string parameter to add.
          */
-        void addString(const std::string& var) { arg(var.c_str()); }
         void addString(std::ostringstream& ss) { arg(ss.str().c_str()); ss.str(std::string()); }
 
     protected:

--- a/src/shared/Policies/Singleton.h
+++ b/src/shared/Policies/Singleton.h
@@ -74,7 +74,7 @@ namespace MaNGOS
              *
              * @param other The other instance to copy from
              */
-            Singleton(const Singleton&);
+            Singleton(const Singleton& other);
 
             /**
              * @brief Prohibited assignment operator
@@ -82,7 +82,7 @@ namespace MaNGOS
              * @param other The other instance to assign from
              * @return Singleton& Reference to this instance
              */
-            Singleton& operator=(const Singleton&);
+            Singleton& operator=(const Singleton& other);
 
             /**
              * @brief Destroy the singleton instance

--- a/src/shared/Utilities/ByteConverter.h
+++ b/src/shared/Utilities/ByteConverter.h
@@ -80,7 +80,7 @@ template<typename T> inline void EndianConvert(T& val) { ByteConverter::apply<T>
  * @brief Reverse byte order (no-op on big-endian host)
  * @param val Value to convert
  */
-template<typename T> inline void EndianConvertReverse(T&) { }
+template<typename T> inline void EndianConvertReverse(T& /*val*/) { }
 #else
 template<typename T> inline void EndianConvert(T&) { }
 template<typename T> inline void EndianConvertReverse(T& val) { ByteConverter::apply<T>(&val); }

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -95,7 +95,7 @@ tm TimeBreakdown(time_t t);
  * @brief
  *
  * @param timeInSecs
- * @param shortText
+ * @param timeFormat
  * @param hoursOnly
  * @return std::string
  */


### PR DESCRIPTION
## Commits
- `[Code DOCS] shared/{Policies,Utilities}: align @param names with method signatures` — small batch in `Singleton.h`, `ByteConverter.h`, `Util.h`.
- `[Code DOCS] shared/{Auth,Database}: align @param names with method signatures` — broader batch across `AuthCrypt.h`, `BigNumber.h`, `Database.h`, `QueryResultMysql.h`, `SQLStorage.h`, `SqlPreparedStatement.h`, `SQLStorageImpl.h`.

## Changes
`shared/Policies/`:
- `Singleton.h`: name the previously-unnamed copy-ctor and `operator=` arguments as `other` so the existing `@param other` docs resolve.

`shared/Utilities/`:
- `ByteConverter.h`: name the unused `T&` on the big-endian no-op `EndianConvertReverse` as `/*val*/` to match the `@param val` doc.
- `Util.h` `secsToTimeString`: sig has `timeFormat`; doc said `shortText` — rename doc.

`shared/Auth/`:
- `AuthCrypt.h` `Init`: add the missing `@param K`.
- `AuthCrypt.h` `DecryptRecv` and `EncryptSend`: name the previously-unnamed `(uint8*, size_t)` pairs as `(data, len)`, matching the `AuthCrypt.cpp` impl.
- `BigNumber.h`: name the previously-unnamed primitives — `BigNumber(uint32)`, `SetDword(uint32)`, `SetQword(uint64)` — as `val` to match `BigNumber.cpp`; name `Exp(const BigNumber&)` as `bn` likewise. Doc `@param` tags renamed to match.

`shared/Database/`:
- `Database.h` `CheckDatabaseVersion`: `@param DatabaseTypes` (type-as-name placeholder) → `@param database`.
- `QueryResultMysql.h` `ConvertNativeType`: `@param type` → `@param mysqlType`.
- `SQLStorage.h` `SQLMSIteratorBounds`: drop a malformed `@param` line whose type fragment had been eaten by the parser; the clean `@param pair` already exists.
- `SqlPreparedStatement.h`: split a doc block so the two `addString` overloads each carry their own `@param` tag (`var` vs `ss`).
- `SQLStorageImpl.h`: six sites with type-as-name `@param uint32` placeholders on `/*field_pos*/` parameters — rename to `@param field_pos` and fill in `@param src` / `@param dst` where they paired with `/*src*/`, `/*dst*/`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/124)
<!-- Reviewable:end -->
