### PR TITLE
[Decomp] Extract GlyphMgr from Player.cpp

### DIFF
--- a/src/game/Object/GlyphMgr.cpp
+++ b/src/game/Object/GlyphMgr.cpp
@@ -1,0 +1,172 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "GlyphMgr.h"
+#include "Player.h"
+#include "DBCStores.h"
+#include "Database/DatabaseEnv.h"
+#include "Log.h"
+#include "Object/UpdateFields.h"
+
+void GlyphMgr::InitGlyphsForLevel()
+{
+    uint32 slot = 0;
+    for (uint32 i = 0; i < sGlyphSlotStore.GetNumRows() && slot < MAX_GLYPH_SLOT_INDEX; ++i)
+        if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(i))
+        {
+            m_owner->SetGlyphSlot(slot++, gs->Id);
+        }
+
+    uint32 level = m_owner->getLevel();
+    uint32 value = 0;
+
+    // 0x3F = 0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 for 80 level
+    if (level >= 25)
+    {
+        value |= 0x01 | 0x02 | 0x40;
+    }
+    if (level >= 50)
+    {
+        value |= 0x04 | 0x08 | 0x80;
+    }
+    if (level >= 75)
+    {
+        value |= 0x10 | 0x20 | 0x100;
+    }
+
+    m_owner->SetUInt32Value(PLAYER_GLYPHS_ENABLED, value);
+}
+
+void GlyphMgr::ApplyGlyph(uint8 slot, bool apply)
+{
+    if (uint32 glyph = GetGlyph(m_owner->GetActiveSpec(), slot))
+    {
+        if (GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph))
+        {
+            if (apply)
+            {
+                m_owner->CastSpell(m_owner, gp->SpellId, true);
+                m_owner->SetUInt32Value(PLAYER_FIELD_GLYPHS_1 + slot, glyph);
+            }
+            else
+            {
+                m_owner->RemoveAurasDueToSpell(gp->SpellId);
+                m_owner->SetUInt32Value(PLAYER_FIELD_GLYPHS_1 + slot, 0);
+            }
+        }
+    }
+}
+
+void GlyphMgr::ApplyAll(bool apply)
+{
+    for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
+    {
+        ApplyGlyph(i, apply);
+    }
+}
+
+void GlyphMgr::Load(QueryResult* result)
+{
+    if (!result)
+    {
+        return;
+    }
+
+    //         0     1     2
+    // "SELECT spec, slot, glyph FROM character_glyphs WHERE guid='%u'"
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint8 spec = fields[0].GetUInt8();
+        uint8 slot = fields[1].GetUInt8();
+        uint32 glyph = fields[2].GetUInt32();
+
+        GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph);
+        if (!gp)
+        {
+            sLog.outError("Player %s has not existing glyph entry %u on index %u, spec %u", m_owner->GetName(), glyph, slot, spec);
+            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `glyph` = %u", glyph);
+            continue;
+        }
+
+        GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(m_owner->GetGlyphSlot(slot));
+        if (!gs)
+        {
+            sLog.outError("Player %s has not existing glyph slot entry %u on index %u, spec %u", m_owner->GetName(), m_owner->GetGlyphSlot(slot), slot, spec);
+            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `slot` = %u AND `spec` = %u AND `guid` = %u", slot, spec, m_owner->GetGUIDLow());
+            continue;
+        }
+
+        if (gp->TypeFlags != gs->TypeFlags)
+        {
+            sLog.outError("Player %s has glyph with typeflags %u in slot with typeflags %u, removing.", m_owner->GetName(), gp->TypeFlags, gs->TypeFlags);
+            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `slot` = %u AND `spec` = %u AND `guid` = %u", slot, spec, m_owner->GetGUIDLow());
+            continue;
+        }
+
+        m_glyphs[spec][slot].id = glyph;
+    }
+    while (result->NextRow());
+
+    delete result;
+}
+
+void GlyphMgr::Save()
+{
+    static SqlStatementID insertGlyph;
+    static SqlStatementID updateGlyph;
+    static SqlStatementID deleteGlyph;
+
+    for (uint8 spec = 0; spec < m_owner->GetSpecsCount(); ++spec)
+    {
+        for (uint8 slot = 0; slot < MAX_GLYPH_SLOT_INDEX; ++slot)
+        {
+            switch (m_glyphs[spec][slot].uState)
+            {
+                case GLYPH_NEW:
+                {
+                    SqlStatement stmt = CharacterDatabase.CreateStatement(insertGlyph, "INSERT INTO `character_glyphs` (`guid`, `spec`, `slot`, `glyph`) VALUES (?, ?, ?, ?)");
+                    stmt.PExecute(m_owner->GetGUIDLow(), spec, slot, m_glyphs[spec][slot].GetId());
+                }
+                break;
+                case GLYPH_CHANGED:
+                {
+                    SqlStatement stmt = CharacterDatabase.CreateStatement(updateGlyph, "UPDATE `character_glyphs` SET `glyph` = ? WHERE `guid` = ? AND `spec` = ? AND `slot` = ?");
+                    stmt.PExecute(m_glyphs[spec][slot].GetId(), m_owner->GetGUIDLow(), spec, slot);
+                }
+                break;
+                case GLYPH_DELETED:
+                {
+                    SqlStatement stmt = CharacterDatabase.CreateStatement(deleteGlyph, "DELETE FROM `character_glyphs` WHERE `guid` = ? AND `spec` = ? AND `slot` = ?");
+                    stmt.PExecute(m_owner->GetGUIDLow(), spec, slot);
+                }
+                break;
+                case GLYPH_UNCHANGED:
+                    break;
+            }
+            m_glyphs[spec][slot].uState = GLYPH_UNCHANGED;
+        }
+    }
+}

--- a/src/game/Object/GlyphMgr.h
+++ b/src/game/Object/GlyphMgr.h
@@ -1,0 +1,196 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_GLYPHMGR
+#define MANGOS_H_GLYPHMGR
+
+#include "Common.h"
+#include "SharedDefines.h"                                  // MAX_GLYPH_SLOT_INDEX, MAX_TALENT_SPEC_COUNT
+
+class Player;
+class QueryResult;
+
+/**
+ * @brief Lifecycle state of a glyph slot's dirty flag.
+ *
+ * Used by GlyphMgr::Save to decide INSERT vs UPDATE vs DELETE on the
+ * character_glyphs row.
+ */
+enum GlyphUpdateState
+{
+    GLYPH_UNCHANGED = 0,    ///< Slot matches the persisted row, no DB work needed.
+    GLYPH_CHANGED   = 1,    ///< Slot was modified, emit UPDATE.
+    GLYPH_NEW       = 2,    ///< Slot has no persisted row yet, emit INSERT.
+    GLYPH_DELETED   = 3     ///< Slot was cleared, emit DELETE.
+};
+
+/**
+ * @brief Per-slot glyph state with dirty-tracking state machine.
+ *
+ * SetId encodes the transitions between GlyphUpdateState values and decides
+ * what DB operation Save should emit for this slot.
+ */
+struct Glyph
+{
+    uint32 id;                  ///< DBC glyph property id, 0 when slot is empty.
+    GlyphUpdateState uState;    ///< Current dirty state for DB persistence.
+
+    /**
+     * @brief Default-constructs an empty, unchanged glyph slot.
+     */
+    Glyph() : id(0), uState(GLYPH_UNCHANGED) {}
+
+    /**
+     * @brief Returns the slot's current glyph id.
+     *
+     * @return The glyph property id, or 0 if the slot is empty.
+     */
+    uint32 GetId() const { return id; }
+
+    /**
+     * @brief Sets the slot's glyph id and updates the dirty state.
+     *
+     * Encodes the transitions between glyph dirty states so that Save emits
+     * the correct INSERT / UPDATE / DELETE for this row.
+     *
+     * @param newId The new glyph property id, or 0 to clear the slot.
+     */
+    void SetId(uint32 newId)
+    {
+        if (newId == id)
+        {
+            return;
+        }
+
+        if (id == 0 && uState == GLYPH_UNCHANGED)           // not yet in db and not yet saved
+        {
+            uState = GLYPH_NEW;
+        }
+        else if (newId == 0)
+        {
+            if (uState == GLYPH_NEW)                        // delete before add new -> no change
+            {
+                uState = GLYPH_UNCHANGED;
+            }
+            else                                            // delete existing data
+            {
+                uState = GLYPH_DELETED;
+            }
+        }
+        else if (uState != GLYPH_NEW)                       // if not new data, change current data
+        {
+            uState = GLYPH_CHANGED;
+        }
+
+        id = newId;
+    }
+};
+
+/**
+ * @brief Owns a Player's per-spec glyph state and lifecycle methods.
+ *
+ * Lifecycle methods include Init / Apply / Load / Save. Player exposes
+ * the public glyph API as thin delegating accessors so external callers
+ * (CharacterHandler, SpellEffects::EffectApplyGlyph, the GM .modify
+ * command) drive glyphs through Player without referencing GlyphMgr.
+ *
+ * GlyphMgr stores a non-owning pointer to its Player. The pointer is used
+ * to read Player's level / active spec / spec count and to call Player
+ * methods that touch update fields, the spell system, or the character
+ * database. GlyphMgr fully owns m_glyphs; Player accesses it only through
+ * GlyphMgr's API.
+ */
+class GlyphMgr
+{
+    public:
+        /**
+         * @brief Constructs a GlyphMgr bound to its owning Player.
+         *
+         * @param owner The Player whose glyphs this manager owns.
+         */
+        explicit GlyphMgr(Player* owner) : m_owner(owner) {}
+
+        /**
+         * @brief Refreshes glyph slot types and unlock mask for the owner's level.
+         *
+         * Resets the slot type bitmap based on the owner's level and sets
+         * PLAYER_GLYPHS_ENABLED with the bitmask of slots unlocked at this
+         * level. Called on level change and on character creation.
+         */
+        void InitGlyphsForLevel();
+
+        /**
+         * @brief Apply or remove the spell from a single glyph slot on the owner.
+         *
+         * @param slot  The glyph slot index.
+         * @param apply True to cast and write the slot's spell, false to remove it.
+         */
+        void ApplyGlyph(uint8 slot, bool apply);
+
+        /**
+         * @brief Apply or remove all glyphs in the active spec.
+         *
+         * @param apply True to apply all slots, false to remove them.
+         */
+        void ApplyAll(bool apply);
+
+        /**
+         * @brief Load glyph rows from a SELECT result against character_glyphs.
+         *
+         * @param result The DB query result holding (spec, slot, glyph) rows.
+         */
+        void Load(QueryResult* result);
+
+        /**
+         * @brief Persist dirty glyph slots to character_glyphs.
+         *
+         * Emits INSERT / UPDATE / DELETE for each dirty slot, then clears the
+         * dirty flags.
+         */
+        void Save();
+
+        /**
+         * @brief Returns the glyph id stored in a given spec / slot.
+         *
+         * @param spec The talent spec index.
+         * @param slot The glyph slot index.
+         * @return The glyph property id in that slot, or 0 if empty.
+         */
+        uint32 GetGlyph(uint8 spec, uint8 slot) const { return m_glyphs[spec][slot].GetId(); }
+
+        /**
+         * @brief Writes a glyph id into a given spec / slot.
+         *
+         * @param spec The talent spec index.
+         * @param slot The glyph slot index.
+         * @param id   The new glyph property id, or 0 to clear the slot.
+         */
+        void   SetGlyph(uint8 spec, uint8 slot, uint32 id) { m_glyphs[spec][slot].SetId(id); }
+
+    private:
+        Player* m_owner;                                            ///< Non-owning pointer to the Player this manager belongs to.
+        Glyph   m_glyphs[MAX_TALENT_SPEC_COUNT][MAX_GLYPH_SLOT_INDEX];  ///< Per-spec, per-slot glyph state owned by this manager.
+};
+
+#endif // MANGOS_H_GLYPHMGR

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -311,7 +311,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_achievementMgr(this), m_reputationMgr(this)
+Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this)
 {
     m_transport = 0;
 
@@ -20825,52 +20825,7 @@ void Player::_LoadAuras(QueryResult* result, uint32 timediff)
     }
 }
 
-void Player::_LoadGlyphs(QueryResult* result)
-{
-    if (!result)
-    {
-        return;
-    }
-
-    //         0     1     2
-    // "SELECT spec, slot, glyph FROM character_glyphs WHERE guid='%u'"
-
-    do
-    {
-        Field* fields = result->Fetch();
-        uint8 spec = fields[0].GetUInt8();
-        uint8 slot = fields[1].GetUInt8();
-        uint32 glyph = fields[2].GetUInt32();
-
-        GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph);
-        if (!gp)
-        {
-            sLog.outError("Player %s has not existing glyph entry %u on index %u, spec %u", m_name.c_str(), glyph, slot, spec);
-            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `glyph` = %u", glyph);
-            continue;
-        }
-
-        GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(GetGlyphSlot(slot));
-        if (!gs)
-        {
-            sLog.outError("Player %s has not existing glyph slot entry %u on index %u, spec %u", m_name.c_str(), GetGlyphSlot(slot), slot, spec);
-            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `slot` = %u AND `spec` = %u AND `guid` = %u", slot, spec, GetGUIDLow());
-            continue;
-        }
-
-        if (gp->TypeFlags != gs->TypeFlags)
-        {
-            sLog.outError("Player %s has glyph with typeflags %u in slot with typeflags %u, removing.", m_name.c_str(), gp->TypeFlags, gs->TypeFlags);
-            CharacterDatabase.PExecute("DELETE FROM `character_glyphs` WHERE `slot` = %u AND `spec` = %u AND `guid` = %u", slot, spec, GetGUIDLow());
-            continue;
-        }
-
-        m_glyphs[spec][slot].id = glyph;
-    }
-    while (result->NextRow());
-
-    delete result;
-}
+// Player::_LoadGlyphs moved to GlyphMgr::Load (2026-05-12); thin delegating wrapper lives inline in Player.h.
 
 /**
  * @brief Restores corpse state for a dead player or cleans it up for a living one.
@@ -22471,43 +22426,7 @@ void Player::_SaveAuras()
     }
 }
 
-void Player::_SaveGlyphs()
-{
-    static SqlStatementID insertGlyph ;
-    static SqlStatementID updateGlyph ;
-    static SqlStatementID deleteGlyph ;
-
-    for (uint8 spec = 0; spec < m_specsCount; ++spec)
-    {
-        for (uint8 slot = 0; slot < MAX_GLYPH_SLOT_INDEX; ++slot)
-        {
-            switch (m_glyphs[spec][slot].uState)
-            {
-                case GLYPH_NEW:
-                {
-                    SqlStatement stmt = CharacterDatabase.CreateStatement(insertGlyph, "INSERT INTO `character_glyphs` (`guid`, `spec`, `slot`, `glyph`) VALUES (?, ?, ?, ?)");
-                    stmt.PExecute(GetGUIDLow(), spec, slot, m_glyphs[spec][slot].GetId());
-                }
-                break;
-                case GLYPH_CHANGED:
-                {
-                    SqlStatement stmt = CharacterDatabase.CreateStatement(updateGlyph, "UPDATE `character_glyphs` SET `glyph` = ? WHERE `guid` = ? AND `spec` = ? AND `slot` = ?");
-                    stmt.PExecute(m_glyphs[spec][slot].GetId(), GetGUIDLow(), spec, slot);
-                }
-                break;
-                case GLYPH_DELETED:
-                {
-                    SqlStatement stmt = CharacterDatabase.CreateStatement(deleteGlyph, "DELETE FROM `character_glyphs` WHERE `guid` = ? AND `spec` = ? AND `slot` = ?");
-                    stmt.PExecute(GetGUIDLow(), spec, slot);
-                }
-                break;
-                case GLYPH_UNCHANGED:
-                    break;
-            }
-            m_glyphs[spec][slot].uState = GLYPH_UNCHANGED;
-        }
-    }
-}
+// Player::_SaveGlyphs moved to GlyphMgr::Save (2026-05-12); thin delegating wrapper lives inline in Player.h.
 
 /**
  * @brief Saves inventory state changes and queued item records to the database.
@@ -27861,62 +27780,8 @@ uint32 Player::GetBarberShopCost(uint8 newhairstyle, uint8 newhaircolor, uint8 n
     return uint32(cost);
 }
 
-void Player::InitGlyphsForLevel()
-{
-    uint32 slot = 0;
-    for (uint32 i = 0; i < sGlyphSlotStore.GetNumRows() && slot < MAX_GLYPH_SLOT_INDEX; ++i)
-        if (GlyphSlotEntry const* gs = sGlyphSlotStore.LookupEntry(i))
-        {
-            SetGlyphSlot(slot++, gs->Id);
-        }
-
-    uint32 level = getLevel();
-    uint32 value = 0;
-
-    // 0x3F = 0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20 for 80 level
-    if (level >= 25)
-    {
-        value |= 0x01 | 0x02 | 0x40;
-    }
-    if (level >= 50)
-    {
-        value |= 0x04 | 0x08 | 0x80;
-    }
-    if (level >= 75)
-    {
-        value |= 0x10 | 0x20 | 0x100;
-    }
-
-    SetUInt32Value(PLAYER_GLYPHS_ENABLED, value);
-}
-
-void Player::ApplyGlyph(uint8 slot, bool apply)
-{
-    if (uint32 glyph = GetGlyph(slot))
-    {
-        if (GlyphPropertiesEntry const* gp = sGlyphPropertiesStore.LookupEntry(glyph))
-        {
-            if (apply)
-            {
-                CastSpell(this, gp->SpellId, true);
-                SetUInt32Value(PLAYER_FIELD_GLYPHS_1 + slot, glyph);
-            }
-            else
-            {
-                RemoveAurasDueToSpell(gp->SpellId);
-                SetUInt32Value(PLAYER_FIELD_GLYPHS_1 + slot, 0);
-            }
-        }
-    }
-}
-
-void Player::ApplyGlyphs(bool apply)
-{
-    for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
-    {
-        ApplyGlyph(i, apply);
-    }
-}
+// Player::InitGlyphsForLevel, ApplyGlyph, ApplyGlyphs moved to GlyphMgr (2026-05-12);
+// thin delegating wrappers live inline in Player.h.
 
 /**
  * @brief Checks whether the player is immune to all spell schools.
@@ -29297,7 +29162,7 @@ void Player::BuildPlayerTalentsInfoData(WorldPacket* data)
             // GlyphProperties.dbc
             for (uint8 i = 0; i < MAX_GLYPH_SLOT_INDEX; ++i)
             {
-                *data << uint16(m_glyphs[specIdx][i].GetId());
+                *data << uint16(m_glyphMgr.GetGlyph(specIdx, i));
             }
         }
     }

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -56,6 +56,7 @@
 #include "Common.h"
 #include "ItemPrototype.h"
 #include "Item.h"
+#include "GlyphMgr.h"   // GlyphMgr is held by value on Player; brings in Glyph struct + GlyphUpdateState enum
 
 #include "Database/DatabaseEnv.h"
 #include "NPCHandler.h"
@@ -281,53 +282,7 @@ enum ActionButtonIndex
 
 typedef std::map<uint8, ActionButton> ActionButtonList;
 
-enum GlyphUpdateState
-{
-    GLYPH_UNCHANGED             = 0,
-    GLYPH_CHANGED               = 1,
-    GLYPH_NEW                   = 2,
-    GLYPH_DELETED               = 3
-};
-
-struct Glyph
-{
-    uint32 id;
-    GlyphUpdateState uState;
-
-    Glyph() : id(0), uState(GLYPH_UNCHANGED) { }
-
-    uint32 GetId() { return id; }
-
-    void SetId(uint32 newId)
-    {
-        if (newId == id)
-        {
-            return;
-        }
-
-        if (id == 0 && uState == GLYPH_UNCHANGED)           // not exist yet in db and already saved
-        {
-            uState = GLYPH_NEW;
-        }
-        else if (newId == 0)
-        {
-            if (uState == GLYPH_NEW)                        // delete before add new -> no change
-            {
-                uState = GLYPH_UNCHANGED;
-            }
-            else                                            // delete existing data
-            {
-                uState = GLYPH_DELETED;
-            }
-        }
-        else if (uState != GLYPH_NEW)                       // if not new data, change current data
-        {
-            uState = GLYPH_CHANGED;
-        }
-
-        id = newId;
-    }
-};
+// GlyphUpdateState and Glyph struct moved to GlyphMgr.h (2026-05-12).
 
 struct PlayerCreateInfoItem
 {
@@ -2413,13 +2368,16 @@ class Player : public Unit
         void ActivateSpec(uint8 specNum);
         void UpdateSpecCount(uint8 count);
 
-        void InitGlyphsForLevel();
+        // Glyph API — thin delegating wrappers around m_glyphMgr (extracted 2026-05-12).
+        // SetGlyphSlot / GetGlyphSlot stay here because they touch entity update fields,
+        // not per-spec glyph state owned by GlyphMgr.
         void SetGlyphSlot(uint8 slot, uint32 slottype) { SetUInt32Value(PLAYER_FIELD_GLYPH_SLOTS_1 + slot, slottype); }
         uint32 GetGlyphSlot(uint8 slot) const { return GetUInt32Value(PLAYER_FIELD_GLYPH_SLOTS_1 + slot); }
-        void SetGlyph(uint8 slot, uint32 glyph) { m_glyphs[m_activeSpec][slot].SetId(glyph); }
-        uint32 GetGlyph(uint8 slot) { return m_glyphs[m_activeSpec][slot].GetId(); }
-        void ApplyGlyph(uint8 slot, bool apply);
-        void ApplyGlyphs(bool apply);
+        void InitGlyphsForLevel() { m_glyphMgr.InitGlyphsForLevel(); }
+        void SetGlyph(uint8 slot, uint32 glyph) { m_glyphMgr.SetGlyph(m_activeSpec, slot, glyph); }
+        uint32 GetGlyph(uint8 slot) { return m_glyphMgr.GetGlyph(m_activeSpec, slot); }
+        void ApplyGlyph(uint8 slot, bool apply) { m_glyphMgr.ApplyGlyph(slot, apply); }
+        void ApplyGlyphs(bool apply) { m_glyphMgr.ApplyAll(apply); }
 
         uint32 GetFreePrimaryProfessionPoints() const { return GetUInt32Value(PLAYER_CHARACTER_POINTS); }
         void SetFreePrimaryProfessions(uint16 profs) { SetUInt32Value(PLAYER_CHARACTER_POINTS, profs); }
@@ -3963,7 +3921,7 @@ class Player : public Unit
         void _LoadArenaTeamInfo(QueryResult* result);
         void _LoadEquipmentSets(QueryResult* result);
         void _LoadBGData(QueryResult* result);
-        void _LoadGlyphs(QueryResult* result);
+        void _LoadGlyphs(QueryResult* result) { m_glyphMgr.Load(result); }
         void _LoadIntoDataField(const char* data, uint32 startOffset, uint32 count);
 
         /*********************************************************/
@@ -3993,7 +3951,7 @@ class Player : public Unit
         void _SaveSpells();
         void _SaveEquipmentSets();
         void _SaveBGData();
-        void _SaveGlyphs();
+        void _SaveGlyphs() { m_glyphMgr.Save(); }
         void _SaveTalents();
         void _SaveStats();
 
@@ -4080,7 +4038,7 @@ class Player : public Unit
 
         ActionButtonList m_actionButtons[MAX_TALENT_SPEC_COUNT];
 
-        Glyph m_glyphs[MAX_TALENT_SPEC_COUNT][MAX_GLYPH_SLOT_INDEX];
+        GlyphMgr m_glyphMgr;   // per-spec glyph state + Load/Save/Apply lifecycle (extracted 2026-05-12)
 
         float m_auraBaseMod[BASEMOD_END][MOD_END];
         int16 m_baseRatingValue[MAX_COMBAT_RATING];


### PR DESCRIPTION
## Summary

Extracts the glyph subsystem out of `Player.cpp` into a dedicated `GlyphMgr` class. First application of the god-object..

## Moves

- `GlyphUpdateState` enum and `Glyph` struct
- `m_glyphs[MAX_TALENT_SPEC_COUNT][MAX_GLYPH_SLOT_INDEX]` array
- `_LoadGlyphs`, `_SaveGlyphs`, `InitGlyphsForLevel`, `ApplyGlyph`, `ApplyGlyphs` methods

## Stays on Player

- Public API surface as thin inline delegates (no external caller changes)
- `SetGlyphSlot` / `GetGlyphSlot` (update-mask entity fields belong to Player)
- Spec selection (`m_activeSpec`, `m_specsCount`)

## Diff

+387/-196 across 4 files. `Player.cpp` -145 lines, `Player.h` -68 lines. `GlyphMgr.{h,cpp}` ~310 lines of relocated code.

## Smoke test

Server starts clean. Character load unlocks glyph slots at levels 25/50/75. Applying a glyph via Talents UI casts the glyph's passive spell. Log-out + log-in preserves applied glyphs. No regressions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/125)
<!-- Reviewable:end -->
