### PR TITLE
[Decomp] Extract HonorMgr from Player.cpp

### DIFF
--- a/src/game/Object/HonorMgr.cpp
+++ b/src/game/Object/HonorMgr.cpp
@@ -1,0 +1,216 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "HonorMgr.h"
+#include "Player.h"
+#include "Creature.h"
+#include "WorldSession.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "Opcodes.h"
+#include "ObjectGuid.h"
+#include "Object/UpdateFields.h"
+#include "Formulas.h"
+
+void HonorMgr::UpdateKills()
+{
+    /// called when rewarding honor and at each save
+    time_t now = time(NULL);
+    time_t today = (time(NULL) / DAY) * DAY;
+
+    if (m_lastUpdateTime < today)
+    {
+        time_t yesterday = today - DAY;
+
+        uint16 kills_today = m_owner->GetUInt16Value(PLAYER_FIELD_KILLS, 0);
+
+        // update yesterday's contribution
+        if (m_lastUpdateTime >= yesterday)
+        {
+            // this is the first update today, reset today's contribution
+            m_owner->SetUInt16Value(PLAYER_FIELD_KILLS, 0, 0);
+            m_owner->SetUInt16Value(PLAYER_FIELD_KILLS, 1, kills_today);
+        }
+        else
+        {
+            // no honor/kills yesterday or today, reset
+            m_owner->SetUInt32Value(PLAYER_FIELD_KILLS, 0);
+        }
+    }
+
+    m_lastUpdateTime = now;
+}
+
+/// Calculate the amount of honor gained based on the victim
+/// and the size of the group for which the honor is divided
+/// An exact honor value can also be given (overriding the calcs)
+bool HonorMgr::Reward(Unit* uVictim, uint32 groupsize, float honor)
+{
+    // do not reward honor in arenas, but enable onkill spellproc
+    if (m_owner->InArena())
+    {
+        if (!uVictim || uVictim == m_owner || uVictim->GetTypeId() != TYPEID_PLAYER)
+        {
+            return false;
+        }
+
+        if (m_owner->GetBGTeam() == ((Player*)uVictim)->GetBGTeam())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    // 'Inactive' this aura prevents the player from gaining honor points and battleground tokens
+    if (m_owner->GetDummyAura(SPELL_AURA_PLAYER_INACTIVE))
+    {
+        return false;
+    }
+
+    ObjectGuid victim_guid;
+    uint32 victim_rank = 0;
+
+    // need call before fields update to have chance move yesterday data to appropriate fields before today data change.
+    UpdateKills();
+
+    if (honor <= 0)
+    {
+        if (!uVictim || uVictim == m_owner || uVictim->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
+        {
+            return false;
+        }
+
+        victim_guid = uVictim->GetObjectGuid();
+
+        if (uVictim->GetTypeId() == TYPEID_PLAYER)
+        {
+            Player* pVictim = (Player*)uVictim;
+
+            if (m_owner->GetTeam() == pVictim->GetTeam() && !sWorld.IsFFAPvPRealm())
+            {
+                return false;
+            }
+
+            float f = 1;                                    // need for total kills (?? need more info)
+            uint32 k_grey = 0;
+            uint32 k_level = m_owner->getLevel();
+            uint32 v_level = pVictim->getLevel();
+
+            {
+                // PLAYER_CHOSEN_TITLE VALUES DESCRIPTION
+                //  [0]      Just name
+                //  [1..14]  Alliance honor titles and player name
+                //  [15..28] Horde honor titles and player name
+                //  [29..38] Other title and player name
+                //  [39+]    Nothing
+                uint32 victim_title = pVictim->GetUInt32Value(PLAYER_CHOSEN_TITLE);
+                // Get Killer titles, CharTitlesEntry::bit_index
+                // Ranks:
+                //  title[1..14]  -> rank[5..18]
+                //  title[15..28] -> rank[5..18]
+                //  title[other]  -> 0
+                if (victim_title == 0)
+                {
+                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
+                }
+                else if (victim_title < 15)
+                {
+                    victim_rank = victim_title + 4;
+                }
+                else if (victim_title < 29)
+                {
+                    victim_rank = victim_title - 14 + 4;
+                }
+                else
+                {
+                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
+                }
+            }
+
+            k_grey = MaNGOS::XP::GetGrayLevel(k_level);
+
+            if (v_level <= k_grey)
+            {
+                return false;
+            }
+
+            float diff_level = (k_level == k_grey) ? 1 : ((float(v_level) - float(k_grey)) / (float(k_level) - float(k_grey)));
+
+            int32 v_rank = 1;                               // need more info
+
+            honor = ((f * diff_level * (190 + v_rank * 10)) / 6);
+            honor *= float(k_level) / 70.0f;                // factor of dependence on levels of the killer
+
+            // count the number of playerkills in one day
+            m_owner->ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
+            // and those in a lifetime
+            m_owner->ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
+            m_owner->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL);
+            m_owner->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS, pVictim->getClass());
+            m_owner->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, pVictim->getRace());
+        }
+        else
+        {
+            Creature* cVictim = (Creature*)uVictim;
+
+            if (!cVictim->IsRacialLeader())
+            {
+                return false;
+            }
+
+            honor = 100;                                    // ??? need more info
+            victim_rank = 19;                               // HK: Leader
+        }
+    }
+
+    if (uVictim != NULL)
+    {
+        honor *= sWorld.getConfig(CONFIG_FLOAT_RATE_HONOR);
+        honor *= (m_owner->GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN) + 100.0f) / 100.0f;
+
+        if (groupsize > 1)
+        {
+            honor /= groupsize;
+        }
+
+        honor *= (((float)urand(8, 12)) / 10);              // approx honor: 80% - 120% of real honor
+    }
+
+    // honor - for show honor points in log
+    // victim_guid - for show victim name in log
+    // victim_rank [1..4]  HK: <dishonored rank>
+    // victim_rank [5..19] HK: <alliance\horde rank>
+    // victim_rank [0,20+] HK: <>
+    WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
+    data << uint32(honor);
+    data << ObjectGuid(victim_guid);
+    data << uint32(victim_rank);
+    m_owner->GetSession()->SendPacket(&data);
+
+    // add honor points
+    m_owner->ModifyCurrencyCount(CURRENCY_HONOR_POINTS, int32(honor));
+
+    return true;
+}

--- a/src/game/Object/HonorMgr.h
+++ b/src/game/Object/HonorMgr.h
@@ -1,0 +1,98 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_HONORMGR
+#define MANGOS_H_HONORMGR
+
+#include "Common.h"
+
+class Player;
+class Unit;
+
+/**
+ * @brief Owns a Player's honor-system bookkeeping and per-kill reward calc.
+ *
+ * Scope: daily / yesterday / lifetime kill rollover, and the calculation
+ * that converts a kill into honor points + a PvP-credit packet to the
+ * client.
+ *
+ * What stays on Player and is NOT in HonorMgr:
+ *  - isHonorOrXPTarget(): a victim-eligibility filter that gates BOTH honor
+ *    and XP rewards, so it does not belong in an honor-specific module.
+ *  - The PvP-currency storage itself: honor points in Cata are currency-id
+ *    CURRENCY_HONOR_POINTS, stored via ModifyCurrencyCount on CurrencyMgr.
+ *    HonorMgr only awards honor here; it does not own the long-term
+ *    currency balance.
+ *  - The kill-count entity fields (PLAYER_FIELD_KILLS,
+ *    PLAYER_FIELD_LIFETIME_HONORABLE_KILLS) — those live on Player's
+ *    update mask, mutated via Player methods called through m_owner.
+ */
+class HonorMgr
+{
+    public:
+        /**
+         * @brief Constructs a HonorMgr bound to its owning Player.
+         *
+         * @param owner The Player whose honor bookkeeping this manager owns.
+         */
+        explicit HonorMgr(Player* owner) : m_owner(owner), m_lastUpdateTime(time(NULL)) {}
+
+        /**
+         * @brief Rolls today's kill counter over to yesterday once a calendar day has passed.
+         *
+         * Called from Reward before crediting a new kill, from SaveToDB to
+         * keep the persisted counts honest, and indirectly on character load.
+         */
+        void UpdateKills();
+
+        /**
+         * @brief Compute honor points for a kill and credit them to the player.
+         *
+         * Sends an SMSG_PVP_CREDIT packet and adds honor to CURRENCY_HONOR_POINTS
+         * when the kill is eligible. In arenas no honor flows but on-kill
+         * spell procs are still allowed to fire.
+         *
+         * @param uVictim   The killed unit (player or racial-leader creature). May be NULL.
+         * @param groupsize Number of group members to split the honor across; 1 means solo.
+         * @param honor     Explicit honor value to award; pass a non-positive value to have it computed.
+         * @return True if honor was awarded or arena on-kill procs should fire; false otherwise.
+         */
+        bool Reward(Unit* uVictim, uint32 groupsize, float honor);
+
+        /**
+         * @brief Reset the timestamp that the daily rollover compares against.
+         *
+         * Called from Player::LoadFromDB with the saved logout time so a long
+         * absence triggers the correct yesterday-shift on first save.
+         *
+         * @param t The new last-update timestamp.
+         */
+        void SetLastKillUpdate(time_t t) { m_lastUpdateTime = t; }
+
+    private:
+        Player* m_owner;            ///< Non-owning pointer to the Player this manager belongs to.
+        time_t  m_lastUpdateTime;   ///< Timestamp the daily kill rollover compares against.
+};
+
+#endif // MANGOS_H_HONORMGR

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -311,7 +311,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this)
+Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this), m_honorMgr(this)
 {
     m_transport = 0;
 
@@ -520,9 +520,7 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
     m_armorPenetrationPct = 0.0f;
     m_spellPenetrationItemMod = 0;
 
-    m_lastHonorKillsUpdateTime = time(NULL);
-    // Honor System
-    // Set last honor update time to current time
+    // Honor system kill-rollover timestamp now owned by m_honorMgr; initialized in its ctor.
 
 
     // Player summoning
@@ -8438,187 +8436,12 @@ void Player::RewardReputation(Quest const* pQuest)
     // TODO: implement reputation spillover
 }
 
-void Player::UpdateHonorKills()
-{
-    /// called when rewarding honor and at each save
-    time_t now = time(NULL);
-    time_t today = (time(NULL) / DAY) * DAY;
-
-    if (m_lastHonorKillsUpdateTime < today)
-    {
-        time_t yesterday = today - DAY;
-
-        uint16 kills_today = GetUInt16Value(PLAYER_FIELD_KILLS, 0);
-
-        // update yesterday's contribution
-        if (m_lastHonorKillsUpdateTime >= yesterday)
-        {
-            // this is the first update today, reset today's contribution
-            SetUInt16Value(PLAYER_FIELD_KILLS, 0, 0);
-            SetUInt16Value(PLAYER_FIELD_KILLS, 1, kills_today);
-        }
-        else
-        {
-            // no honor/kills yesterday or today, reset
-            SetUInt32Value(PLAYER_FIELD_KILLS, 0);
-        }
-    }
-
-    m_lastHonorKillsUpdateTime = now;
-}
+// Player::UpdateHonorKills moved to HonorMgr::UpdateKills (2026-05-12); thin delegating wrapper lives inline in Player.h.
 
 /// Calculate the amount of honor gained based on the victim
 /// and the size of the group for which the honor is divided
 /// An exact honor value can also be given (overriding the calcs)
-bool Player::RewardHonor(Unit* uVictim, uint32 groupsize, float honor)
-{
-    // do not reward honor in arenas, but enable onkill spellproc
-    if (InArena())
-    {
-        if (!uVictim || uVictim == this || uVictim->GetTypeId() != TYPEID_PLAYER)
-        {
-            return false;
-        }
-
-        if (GetBGTeam() == ((Player*)uVictim)->GetBGTeam())
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    // 'Inactive' this aura prevents the player from gaining honor points and battleground tokens
-    if (GetDummyAura(SPELL_AURA_PLAYER_INACTIVE))
-    {
-        return false;
-    }
-
-    ObjectGuid victim_guid;
-    uint32 victim_rank = 0;
-
-    // need call before fields update to have chance move yesterday data to appropriate fields before today data change.
-    UpdateHonorKills();
-
-    if (honor <= 0)
-    {
-        if (!uVictim || uVictim == this || uVictim->HasAuraType(SPELL_AURA_NO_PVP_CREDIT))
-        {
-            return false;
-        }
-
-        victim_guid = uVictim->GetObjectGuid();
-
-        if (uVictim->GetTypeId() == TYPEID_PLAYER)
-        {
-            Player* pVictim = (Player*)uVictim;
-
-            if (GetTeam() == pVictim->GetTeam() && !sWorld.IsFFAPvPRealm())
-            {
-                return false;
-            }
-
-            float f = 1;                                    // need for total kills (?? need more info)
-            uint32 k_grey = 0;
-            uint32 k_level = getLevel();
-            uint32 v_level = pVictim->getLevel();
-
-            {
-                // PLAYER_CHOSEN_TITLE VALUES DESCRIPTION
-                //  [0]      Just name
-                //  [1..14]  Alliance honor titles and player name
-                //  [15..28] Horde honor titles and player name
-                //  [29..38] Other title and player name
-                //  [39+]    Nothing
-                uint32 victim_title = pVictim->GetUInt32Value(PLAYER_CHOSEN_TITLE);
-                // Get Killer titles, CharTitlesEntry::bit_index
-                // Ranks:
-                //  title[1..14]  -> rank[5..18]
-                //  title[15..28] -> rank[5..18]
-                //  title[other]  -> 0
-                if (victim_title == 0)
-                {
-                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
-                }
-                else if (victim_title < 15)
-                {
-                    victim_rank = victim_title + 4;
-                }
-                else if (victim_title < 29)
-                {
-                    victim_rank = victim_title - 14 + 4;
-                }
-                else
-                {
-                    victim_guid.Clear();                    // Don't show HK: <rank> message, only log.
-                }
-            }
-
-            k_grey = MaNGOS::XP::GetGrayLevel(k_level);
-
-            if (v_level <= k_grey)
-            {
-                return false;
-            }
-
-            float diff_level = (k_level == k_grey) ? 1 : ((float(v_level) - float(k_grey)) / (float(k_level) - float(k_grey)));
-
-            int32 v_rank = 1;                               // need more info
-
-            honor = ((f * diff_level * (190 + v_rank * 10)) / 6);
-            honor *= float(k_level) / 70.0f;                // factor of dependence on levels of the killer
-
-            // count the number of playerkills in one day
-            ApplyModUInt32Value(PLAYER_FIELD_KILLS, 1, true);
-            // and those in a lifetime
-            ApplyModUInt32Value(PLAYER_FIELD_LIFETIME_HONORABLE_KILLS, 1, true);
-            UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_EARN_HONORABLE_KILL);
-            UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_CLASS, pVictim->getClass());
-            UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_HK_RACE, pVictim->getRace());
-        }
-        else
-        {
-            Creature* cVictim = (Creature*)uVictim;
-
-            if (!cVictim->IsRacialLeader())
-            {
-                return false;
-            }
-
-            honor = 100;                                    // ??? need more info
-            victim_rank = 19;                               // HK: Leader
-        }
-    }
-
-    if (uVictim != NULL)
-    {
-        honor *= sWorld.getConfig(CONFIG_FLOAT_RATE_HONOR);
-        honor *= (GetMaxPositiveAuraModifier(SPELL_AURA_MOD_HONOR_GAIN) + 100.0f) / 100.0f;
-
-        if (groupsize > 1)
-        {
-            honor /= groupsize;
-        }
-
-        honor *= (((float)urand(8, 12)) / 10);              // approx honor: 80% - 120% of real honor
-    }
-
-    // honor - for show honor points in log
-    // victim_guid - for show victim name in log
-    // victim_rank [1..4]  HK: <dishonored rank>
-    // victim_rank [5..19] HK: <alliance\horde rank>
-    // victim_rank [0,20+] HK: <>
-    WorldPacket data(SMSG_PVP_CREDIT, 4 + 8 + 4);
-    data << uint32(honor);
-    data << ObjectGuid(victim_guid);
-    data << uint32(victim_rank);
-    GetSession()->SendPacket(&data);
-
-    // add honor points
-    ModifyCurrencyCount(CURRENCY_HONOR_POINTS, int32(honor));
-
-    return true;
-}
+// Player::RewardHonor moved to HonorMgr::Reward (2026-05-12); thin delegating wrapper lives inline in Player.h.
 
 void Player::SetInGuild(uint32 GuildId)
 {
@@ -20271,7 +20094,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
 
     // Honor system
     // Update Honor kills data
-    m_lastHonorKillsUpdateTime = logoutTime;
+    m_honorMgr.SetLastKillUpdate(logoutTime);
     UpdateHonorKills();
 
     m_deathExpireTime = (time_t)fields[37].GetUInt64();

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -57,6 +57,7 @@
 #include "ItemPrototype.h"
 #include "Item.h"
 #include "GlyphMgr.h"   // GlyphMgr is held by value on Player; brings in Glyph struct + GlyphUpdateState enum
+#include "HonorMgr.h"   // HonorMgr is held by value on Player; owns daily-kill rollover + RewardHonor calculation
 
 #include "Database/DatabaseEnv.h"
 #include "NPCHandler.h"
@@ -3118,8 +3119,8 @@ class Player : public Unit
         /*********************************************************/
         /***                  PVP SYSTEM                       ***/
         /*********************************************************/
-        void UpdateHonorKills();
-        bool RewardHonor(Unit *pVictim, uint32 groupsize, float honor = -1);
+        void UpdateHonorKills() { m_honorMgr.UpdateKills(); }
+        bool RewardHonor(Unit *pVictim, uint32 groupsize, float honor = -1) { return m_honorMgr.Reward(pVictim, groupsize, honor); }
         void SendPvPRewards();
         void SendRatedBGStats();
 
@@ -4002,7 +4003,7 @@ class Player : public Unit
         uint32 m_speakCount; // Speak count
         Difficulty m_dungeonDifficulty; // Dungeon difficulty
         Difficulty m_raidDifficulty;
-        time_t m_lastHonorKillsUpdateTime;
+        HonorMgr m_honorMgr;   // daily / yesterday / lifetime kill rollover + Reward calculation (extracted 2026-05-12)
 
         uint32 m_atLoginFlags; // At-login flags
 


### PR DESCRIPTION
## Summary

Extracts the honor subsystem out of `Player.cpp` into a dedicated `HonorMgr` class. Second application of the god-object decomposition campaign; follows the `GlyphMgr` pattern.

## Moves

- `m_lastHonorKillsUpdateTime` (daily rollover timestamp)
- `UpdateHonorKills` and `RewardHonor` methods
- New `HonorMgr::SetLastKillUpdate(time_t)` for `LoadFromDB` initialization

## Stays on Player

- Public API surface as thin inline delegates (no external caller changes)
- `isHonorOrXPTarget` (victim-eligibility filter gating both honor and XP)
- Honor-points currency storage via `ModifyCurrencyCount(CURRENCY_HONOR_POINTS, ...)`
- Kill-count entity fields (`PLAYER_FIELD_KILLS`, `PLAYER_FIELD_LIFETIME_HONORABLE_KILLS`)

## Diff

+323/-185 across 4 files. `Player.cpp` -185 lines, `Player.h` -2 lines. `HonorMgr.{h,cpp}` ~210 lines of relocated code.

## Smoke test

LoadFromDB initializes timestamp correctly. Log-out / log-in cycles preserve kill counts. Two-client opposite-faction PvP: honor credited, "HK: <rank>" floating message displays. `PLAYER_FIELD_KILLS` counter bumped and `ModifyCurrencyCount(CURRENCY_HONOR_POINTS, ...)` credit applied end-to-end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/126)
<!-- Reviewable:end -->
