### PR TITLE
[Worgen] Hoist Altered Form re-cast out of non-melee interrupt loop

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -11222,11 +11222,11 @@ void Unit::SetInCombatState(bool PvP, Unit* enemy)
                 InterruptSpell(CurrentSpellTypes(i), false);
             }
         }
+    }
 
-        if (getRace() == RACE_WORGEN && !IsInWorgenForm(true) && HasWorgenForm())
-        {
-            CastSpell(this, 97709, true);   // cast Altered Form
-        }
+    if (getRace() == RACE_WORGEN && !IsInWorgenForm(true) && HasWorgenForm())
+    {
+        CastSpell(this, 97709, true);   // cast Altered Form
     }
 
     if (creatureNotInCombat)


### PR DESCRIPTION
## Bug

`Unit::SetInCombatState` casts spell 97709 (Altered Form) up to three times per call. The worgen re-form check sits inside the non-melee interrupt loop instead of after it, so it executes once per `CurrentSpellTypes` slot (`GENERIC`, `CHANNELED`, `AUTOREPEAT`).

## Root cause

Style-cleanup commit `dcef4c114 [Sync] From Project Sync from MangosTwo` added Allman braces around the bare `for` loop and accidentally pulled the worgen block into the loop scope. MangosTwo has no equivalent code (WotLK predates Worgen) so the sync source had no reference to mirror against.

## Fix

Move the worgen `if` block out of the loop body. Restores pre-sync intent: the check fires once per `SetInCombatState` invocation.

## Note for follow-up

Reviewing this also surfaced that mangosthree defines `AURA_INTERRUPT_FLAG_ENTER_COMBAT2` (bit 28) but never wires it to `RemoveAurasWithInterruptFlags`. TC handles worgen form transitions declaratively via that bit on the Altered Form aura. The imperative `CastSpell(97709)` block here is effectively a workaround for the missing flag handler. Replacing it with the proper interrupt-flag sweep is a separate, larger PR that needs DBC verification first; out of scope here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/127)
<!-- Reviewable:end -->
