### PR TITLE
[Worgen] Reject Two Forms when gating aura is missing

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -7179,6 +7179,10 @@ SpellCastResult Spell::CheckCast(bool strict)
                     {
                         return SPELL_FAILED_AFFECTING_COMBAT;
                     }
+                    if (!m_caster->HasWorgenForm())
+                    {
+                        return SPELL_FAILED_SPELL_UNAVAILABLE;
+                    }
                 }
                 else if (m_spellInfo->SpellIconID == 156)   // Holy Shock
                 {


### PR DESCRIPTION
## Bug

Casting 68996 "Two Forms" silently no-ops when the player lacks the gating aura `SPELL_AURA_ALLOW_WORGEN_TRANSFORM` (granted on retail by spell 94293 "Enable Worgen Altered Form" via the Gilneas intro quest line).

The existing `CheckCast` for 68996 (`Spell.cpp:7176-7182`) already blocks the cast while in combat (`SPELL_FAILED_AFFECTING_COMBAT`) — matches TC's `spell_gen_two_forms::CheckCast`. The gap is the missing permission check.

## Fix

Add a second guard to the same `CheckCast` block: refuse the cast with `SPELL_FAILED_SPELL_UNAVAILABLE` when `HasWorgenForm()` returns false. The downstream precast handler (`Spell.cpp:4062-4071`) already gates on the same condition; this just surfaces the failure to the client instead of falling through silently.

Verified via DBC dump that spell 94293 is the only spell in 4.3.4 granting aura 352, matching the in-code comment at `SpellAuras.cpp:444` ("1 spells in 4.3.4 enables worgen↔human form switches").

## Why this matters

Players who skip the Gilneas intro (common in PvP-focused servers) lose access to form-switching with no diagnostic. With this change they get the proper "Spell unavailable" client message and can be directed to `.cast 94293` or the missing quest line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/128)
<!-- Reviewable:end -->
