### PR TITLE
[Decomp] Extract PetMgr from Player.cpp

### DIFF
--- a/src/game/Object/PetMgr.cpp
+++ b/src/game/Object/PetMgr.cpp
@@ -1,0 +1,109 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "PetMgr.h"
+#include "Player.h"
+#include "Pet.h"
+#include "WorldPacket.h"
+#include "Opcodes.h"
+#include "Log.h"
+
+void PetMgr::LoadStableSlotsFromField(uint32 raw)
+{
+    m_stableSlots = raw;
+    if (m_stableSlots > MAX_PET_STABLES)
+    {
+        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(m_stableSlots));
+        m_stableSlots = MAX_PET_STABLES;
+    }
+}
+
+void PetMgr::Remove(PetSaveMode mode)
+{
+    if (Pet* pet = m_owner->GetPet())
+    {
+        pet->Unsummon(mode, m_owner);
+    }
+}
+
+void PetMgr::RemoveActionBar()
+{
+    WorldPacket data(SMSG_PET_SPELLS, 8);
+    data << ObjectGuid();
+    m_owner->SendDirectMessage(&data);
+}
+
+void PetMgr::UnsummonTemporaryIfAny()
+{
+    Pet* pet = m_owner->GetPet();
+    if (!pet)
+    {
+        return;
+    }
+
+    if (!m_temporaryUnsummonedPetNumber && pet->isControlled() && !pet->isTemporarySummoned())
+    {
+        m_temporaryUnsummonedPetNumber = pet->GetCharmInfo()->GetPetNumber();
+    }
+
+    pet->Unsummon(PET_SAVE_AS_CURRENT, m_owner);
+}
+
+void PetMgr::UnsummonIfAny()
+{
+    Pet* pet = m_owner->GetPet();
+    if (!pet)
+    {
+        return;
+    }
+
+    pet->Unsummon(PET_SAVE_NOT_IN_SLOT, m_owner);
+}
+
+void PetMgr::ResummonTemporaryUnsummonedIfAny()
+{
+    if (!m_temporaryUnsummonedPetNumber)
+    {
+        return;
+    }
+
+    // not resummon in not appropriate state
+    if (m_owner->IsPetNeedBeTemporaryUnsummoned())
+    {
+        return;
+    }
+
+    if (m_owner->GetPetGuid())
+    {
+        return;
+    }
+
+    Pet* NewPet = new Pet;
+    if (!NewPet->LoadPetFromDB(m_owner, 0, m_temporaryUnsummonedPetNumber, true))
+    {
+        delete NewPet;
+    }
+
+    m_temporaryUnsummonedPetNumber = 0;
+}

--- a/src/game/Object/PetMgr.h
+++ b/src/game/Object/PetMgr.h
@@ -1,0 +1,116 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_PETMGR
+#define MANGOS_H_PETMGR
+
+#include "Common.h"
+#include "Pet.h"  // PetSaveMode enum + MAX_PET_STABLES constant
+
+class Player;
+
+/**
+ * PetMgr — owns a Player's pet-ownership metadata: the stable-slot
+ * count persisted with the character row and the temporary-unsummon
+ * tracking number used by transports / vehicles / mounts to bring the
+ * same pet back after a short interruption.
+ *
+ * What this DOES NOT own:
+ *  - The Pet creature itself (a Creature subclass living in the world,
+ *    managed by Object/Pet.{cpp,h}). The pet object's lifecycle, AI,
+ *    spells, leveling, and persistence to the `character_pet` table all
+ *    stay in Pet.cpp.
+ *  - The pet stable opcode handlers (`CMSG_STABLE_PET` and friends in
+ *    WorldHandlers/NPCHandler.cpp). They keep reading and updating the
+ *    slot count through Player's public accessors.
+ *
+ * What stays on Player.{cpp,h}:
+ *  - The full public pet API (RemovePet / UnsummonPetTemporaryIfAny /
+ *    ResummonPetTemporaryUnSummonedIfAny / RemovePetActionBar / temp-
+ *    summon-number get/set + the new GetStableSlots) as inline
+ *    delegates, so the ~25 external call sites in SpellAuras.cpp,
+ *    Spell.cpp, BattleGround.cpp, Vehicle.cpp, MovementHandler.cpp,
+ *    CharacterHandler.cpp, MiscHandler.cpp, WorldSession.cpp, Pet.cpp,
+ *    NPCHandler.cpp, and Unit.cpp do not need to change.
+ */
+class PetMgr
+{
+    public:
+        explicit PetMgr(Player* owner)
+            : m_owner(owner), m_stableSlots(0), m_temporaryUnsummonedPetNumber(0)
+        {
+        }
+
+        /// Number of paid stable slots the character has unlocked.
+        /// Persisted to `characters`.stable_slots; clamped to
+        /// MAX_PET_STABLES on load.
+        uint32 GetStableSlots() const { return m_stableSlots; }
+        void SetStableSlots(uint32 slots) { m_stableSlots = slots; }
+
+        /// Called from Player::LoadFromDB with the raw column value.
+        /// Clamps to MAX_PET_STABLES and logs a server error on
+        /// out-of-range data so an operator can detect a tampered row.
+        void LoadStableSlotsFromField(uint32 raw);
+
+        /// Pet number that was active before a temporary unsummon (e.g.
+        /// vehicle board / transport zone-in). Zero means no pending
+        /// resummon. Read by Pet.cpp during save-mode dispatch and
+        /// written by CharacterHandler on character creation when a
+        /// hunter starts with a deity pet.
+        uint32 GetTemporaryUnsummonedPetNumber() const { return m_temporaryUnsummonedPetNumber; }
+        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_temporaryUnsummonedPetNumber = petnumber; }
+
+        /// PET_SAVE_AS_CURRENT-style dismissal. If the owner currently
+        /// has a controlled pet, asks it to unsummon with the given
+        /// mode (see PetSaveMode in PetDefines.h).
+        void Remove(PetSaveMode mode);
+
+        /// SMSG_PET_SPELLS with an empty guid — clears the pet action
+        /// bar UI on the client.
+        void RemoveActionBar();
+
+        /// If the owner has a controlled, non-temporary pet, stash its
+        /// pet-number into m_temporaryUnsummonedPetNumber so we can
+        /// bring it back later, then unsummon with PET_SAVE_AS_CURRENT.
+        /// No-op if no eligible pet.
+        void UnsummonTemporaryIfAny();
+
+        /// Unconditional unsummon with PET_SAVE_NOT_IN_SLOT. Used by
+        /// aura code that needs the pet gone (polymorph, eyes-of-the-
+        /// beast end, etc.) without preserving it for later resummon.
+        void UnsummonIfAny();
+
+        /// Counterpart to UnsummonTemporaryIfAny: if we stashed a pet
+        /// number AND it's now appropriate to resummon (no pending
+        /// vehicle, mount, etc.), load that pet from DB. Clears the
+        /// stash either way (success or "not yet").
+        void ResummonTemporaryUnsummonedIfAny();
+
+    private:
+        Player* m_owner;
+        uint32  m_stableSlots;
+        uint32  m_temporaryUnsummonedPetNumber;
+};
+
+#endif // MANGOS_H_PETMGR

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -311,7 +311,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this), m_honorMgr(this)
+Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_petMgr(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this), m_honorMgr(this)
 {
     m_transport = 0;
 
@@ -446,8 +446,7 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
     m_canTitanGrip = false;
     m_ammoDPS = 0.0f;
 
-    // Initialize temporary unsummoned pet number to 0
-    m_temporaryUnsummonedPetNumber = 0;
+    // m_temporaryUnsummonedPetNumber now owned by m_petMgr; initialized in its ctor.
 
     //////////////////// Rest System/////////////////////
     // Initialize time of entering inn to 0
@@ -480,8 +479,7 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
         m_forced_speed_changes[i] = 0;
     }
 
-    // Initialize stable slots to 0
-    m_stableSlots = 0;
+    // m_stableSlots now owned by m_petMgr; initialized in its ctor.
 
     /////////////////// Instance System /////////////////////
     // Initialize homebind timer to 0
@@ -20083,12 +20081,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
 
     uint32 extraflags = fields[32].GetUInt32();
 
-    m_stableSlots = fields[33].GetUInt32();
-    if (m_stableSlots > MAX_PET_STABLES)
-    {
-        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(m_stableSlots));
-        m_stableSlots = MAX_PET_STABLES;
-    }
+    m_petMgr.LoadStableSlotsFromField(fields[33].GetUInt32());
 
     m_atLoginFlags = fields[34].GetUInt32();
 
@@ -21984,7 +21977,7 @@ void Player::SaveToDB()
 
     uberInsert.addUInt32(m_ExtraFlags);
 
-    uberInsert.addUInt32(uint32(m_stableSlots));            // to prevent save uint8 as char
+    uberInsert.addUInt32(uint32(m_petMgr.GetStableSlots()));   // to prevent save uint8 as char
 
     uberInsert.addUInt32(uint32(m_atLoginFlags));
 
@@ -23170,19 +23163,6 @@ void Player::UpdateDuelFlag(time_t currTime)
 }
 
 /**
- * @brief Unsummons the player's current pet using the requested save mode.
- *
- * @param mode The persistence mode to use when removing the pet.
- */
-void Player::RemovePet(PetSaveMode mode)
-{
-    if (Pet* pet = GetPet())
-    {
-        pet->Unsummon(mode, this);
-    }
-}
-
-/**
  * @brief Sends a say chat message from the player to nearby listeners.
  *
  * @param text The message text.
@@ -23515,16 +23495,6 @@ void Player::CharmSpellInitialize()
     data << uint8(0);                                       // cooldowns count
 
     GetSession()->SendPacket(&data);
-}
-
-/**
- * @brief Clears the pet action bar on the client.
- */
-void Player::RemovePetActionBar()
-{
-    WorldPacket data(SMSG_PET_SPELLS, 8);
-    data << ObjectGuid();
-    SendDirectMessage(&data);
 }
 
 /**
@@ -28838,66 +28808,6 @@ void Player::UpdateFallInformationIfNeed(MovementInfo const& minfo, uint16 opcod
     {
         SetFallInformation(minfo.GetFallTime(), minfo.GetPos()->z);
     }
-}
-
-/**
- * @brief Temporarily unsummons the current pet when the player's state requires it.
- */
-void Player::UnsummonPetTemporaryIfAny()
-{
-    Pet* pet = GetPet();
-    if (!pet)
-    {
-        return;
-    }
-
-    if (!m_temporaryUnsummonedPetNumber && pet->isControlled() && !pet->isTemporarySummoned())
-    {
-        m_temporaryUnsummonedPetNumber = pet->GetCharmInfo()->GetPetNumber();
-    }
-
-    pet->Unsummon(PET_SAVE_AS_CURRENT, this);
-}
-
-void Player::UnsummonPetIfAny()
-{
-    Pet* pet = GetPet();
-    if (!pet)
-    {
-        return;
-    }
-
-    pet->Unsummon(PET_SAVE_NOT_IN_SLOT, this);
-}
-
-/**
- * @brief Resummons a pet that was temporarily unsummoned earlier.
- */
-void Player::ResummonPetTemporaryUnSummonedIfAny()
-{
-    if (!m_temporaryUnsummonedPetNumber)
-    {
-        return;
-    }
-
-    // not resummon in not appropriate state
-    if (IsPetNeedBeTemporaryUnsummoned())
-    {
-        return;
-    }
-
-    if (GetPetGuid())
-    {
-        return;
-    }
-
-    Pet* NewPet = new Pet;
-    if (!NewPet->LoadPetFromDB(this, 0, m_temporaryUnsummonedPetNumber, true))
-    {
-        delete NewPet;
-    }
-
-    m_temporaryUnsummonedPetNumber = 0;
 }
 
 /**

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -66,6 +66,7 @@
 #include "Bag.h"
 #include "WorldSession.h"
 #include "Pet.h"
+#include "PetMgr.h"
 #include "MapReference.h"
 #include "Util.h"                                           // for Tokens typedef
 #include "AchievementMgr.h"
@@ -1394,7 +1395,7 @@ class Player : public Unit
         }
 
         // Remove the player's pet
-        void RemovePet(PetSaveMode mode);
+        void RemovePet(PetSaveMode mode) { m_petMgr.Remove(mode); }
 
         uint32 GetPhaseMaskForSpawn() const;                // used for proper set phase for DB at GM-mode creature/GO spawn
 
@@ -1780,7 +1781,7 @@ class Player : public Unit
         // Load the player's pet
         void LoadPet();
 
-        uint32 m_stableSlots; // Number of stable slots
+        // m_stableSlots now owned by m_petMgr; access via GetStableSlots() / SetStableSlots().
 
         uint32 GetEquipGearScore(bool withBags = true, bool withBank = false);
         void ResetCachedGearScore() { m_cachedGS = 0; }
@@ -2290,7 +2291,7 @@ class Player : public Unit
         void PossessSpellInitialize();
 
         // Remove the pet action bar
-        void RemovePetActionBar();
+        void RemovePetActionBar() { m_petMgr.RemoveActionBar(); }
 
         // Check if the player has a specific spell
         bool HasSpell(uint32 spell) const override;
@@ -3660,12 +3661,20 @@ class Player : public Unit
         // Remove an at-login flag for the player
         void RemoveAtLoginFlag(AtLoginFlags f, bool in_db_also = false);
 
-        // Temporarily removed pet cache
-        uint32 GetTemporaryUnsummonedPetNumber() const { return m_temporaryUnsummonedPetNumber; }
-        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_temporaryUnsummonedPetNumber = petnumber; }
-        void UnsummonPetTemporaryIfAny();
-        void UnsummonPetIfAny();
-        void ResummonPetTemporaryUnSummonedIfAny();
+        // Pet ownership API — thin delegating wrappers around m_petMgr.
+        // State (temporary-unsummon pet number, stable slot count) and
+        // lifecycle live on PetMgr; these forward unchanged signatures
+        // so external callers (SpellAuras.cpp, Spell.cpp, BattleGround.cpp,
+        // Vehicle.cpp, MovementHandler.cpp, CharacterHandler.cpp,
+        // MiscHandler.cpp, WorldSession.cpp, Pet.cpp, Unit.cpp) compile
+        // without changes.
+        uint32 GetTemporaryUnsummonedPetNumber() const { return m_petMgr.GetTemporaryUnsummonedPetNumber(); }
+        void SetTemporaryUnsummonedPetNumber(uint32 petnumber) { m_petMgr.SetTemporaryUnsummonedPetNumber(petnumber); }
+        void UnsummonPetTemporaryIfAny() { m_petMgr.UnsummonTemporaryIfAny(); }
+        void UnsummonPetIfAny() { m_petMgr.UnsummonIfAny(); }
+        void ResummonPetTemporaryUnSummonedIfAny() { m_petMgr.ResummonTemporaryUnsummonedIfAny(); }
+        uint32 GetStableSlots() const { return m_petMgr.GetStableSlots(); }
+        void SetStableSlots(uint32 slots) { m_petMgr.SetStableSlots(slots); }
         bool IsPetNeedBeTemporaryUnsummoned() const { return !IsInWorld() || !IsAlive() || IsMounted() /*+in flight*/; }
 
         // Send cinematic start to the client
@@ -4237,8 +4246,7 @@ class Player : public Unit
         // Detect invisibility timer
         uint32 m_DetectInvTimer;
 
-        // Temporary removed pet cache
-        uint32 m_temporaryUnsummonedPetNumber;
+        PetMgr m_petMgr;  // owns m_stableSlots + m_temporaryUnsummonedPetNumber + 5 pet-lifecycle helpers
 
         AchievementMgr m_achievementMgr;
         ReputationMgr  m_reputationMgr;

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -688,7 +688,7 @@ void WorldSession::SendStablePet(ObjectGuid guid)
     size_t wpos = data.wpos();
     data << uint8(0);                                       // place holder for slot show number
 
-    data << uint8(GetPlayer()->m_stableSlots);
+    data << uint8(GetPlayer()->GetStableSlots());
 
     uint8 num = 0;                                          // counter for place holder
 
@@ -832,7 +832,7 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         delete result;
     }
 
-    if (free_slot > 0 && free_slot <= GetPlayer()->m_stableSlots)
+    if (free_slot > 0 && free_slot <= GetPlayer()->GetStableSlots())
     {
         pet->Unsummon(PetSaveMode(free_slot), _player);
         SendStableResult(STABLE_SUCCESS_STABLE);


### PR DESCRIPTION
## Changes

Extract Player's pet-ownership metadata (`m_stableSlots`, `m_temporaryUnsummonedPetNumber`) and five pet-lifecycle helpers (`Remove`, `RemoveActionBar`, `UnsummonTemporaryIfAny`, `UnsummonIfAny`, `ResummonTemporaryUnsummonedIfAny`) into `src/game/Object/PetMgr.{h,cpp}`.

Player retains the public API surface as inline delegates in `Player.h` so existing call sites compile unchanged. `Pet.cpp` (the actual creature class) is not touched.

Same template as PR #125 (GlyphMgr) — owned by Player by value, `m_owner` back-pointer.

## Stats

- `Player.cpp`: -76 lines (27661 → 27585)
- `Player.h`: -4 net
- `PetMgr.cpp` / `PetMgr.h`: new files

## External call sites preserved

~25 call sites across `Spell`, `SpellAuras`, `SpellEffects`, `BattleGround`, `Vehicle`, `MovementHandler`, `CharacterHandler`, `MiscHandler`, `WorldSession`, `Pet`, `Unit` continue to use Player's API.

One direct-member-access leakage: `m_stableSlots` was a public `Player` field read at `NPCHandler.cpp:577, 705`. Switched to a new `Player::GetStableSlots()` accessor.

## Verification

Release build clean on Windows MSVC 2022. Server-start smoke green; deployed locally to `server_install/`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/129)
<!-- Reviewable:end -->
