### PR TITLE
[Vmap] Cast BIH::ReadFromFile check to uint64

### DIFF
--- a/src/game/vmap/BIH.cpp
+++ b/src/game/vmap/BIH.cpp
@@ -379,7 +379,7 @@ bool BIH::ReadFromFile(FILE* rf)
     check += fread(&objects[0], sizeof(uint32), count, rf);
 
     // Return true if all reads were successful
-    return check == (3 + 3 + 2 + treeSize + count);
+    return uint64(check) == uint64(3 + 3 + 1 + 1 + uint64(treeSize) + uint64(count));
 }
 
 /**


### PR DESCRIPTION
## Summary

Cast the `BIH::ReadFromFile` success check to `uint64` to prevent silent uint32 overflow when `treeSize + count + 8 >= 2^32`. Without the cast, a corrupt or oversized BIH file can produce a wrapped check value that matches the expected sum, making a failed read appear successful.

Ported from TrinityCore's matching fix in `src/common/Collision/BoundingIntervalHierarchy.cpp:274`.

## Change

`src/game/vmap/BIH.cpp:382`:

```diff
-    return check == (3 + 3 + 2 + treeSize + count);
+    return uint64(check) == uint64(3 + 3 + 1 + 1 + uint64(treeSize) + uint64(count));
```

The `1 + 1` instead of `2` matches TC's form exactly — arithmetically identical, reads as "treeSize header + count header" rather than a magic `2`.

The symmetric write path (`WriteToFile` at line 355) is **not** changed: TC's `writeToFile` also uses plain uint32 there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/130)
<!-- Reviewable:end -->
