### PR TITLE
[Vmap] Guard WmoLiquid against zero-dimension allocation

### DIFF
--- a/src/game/vmap/WorldModel.cpp
+++ b/src/game/vmap/WorldModel.cpp
@@ -166,8 +166,16 @@ namespace VMAP
     WmoLiquid::WmoLiquid(uint32 width, uint32 height, const Vector3& corner, uint32 type) :
         iTilesX(width), iTilesY(height), iCorner(corner), iType(type)
     {
-        iHeight = new float[(width + 1) * (height + 1)];
-        iFlags = new uint8[width * height];
+        if (width && height)
+        {
+            iHeight = new float[(width + 1) * (height + 1)];
+            iFlags = new uint8[width * height];
+        }
+        else
+        {
+            iHeight = new float[1];
+            iFlags = nullptr;
+        }
     }
 
     /**
@@ -336,7 +344,7 @@ namespace VMAP
             result = false;
         }
         size = iTilesX * iTilesY;
-        if (result && fwrite(iFlags, sizeof(uint8), size, wf) != size)
+        if (result && size && fwrite(iFlags, sizeof(uint8), size, wf) != size)
         {
             result = false;
         }


### PR DESCRIPTION
## Summary

Align `WmoLiquid`'s zero-dimension handling with TrinityCore's pattern: when `width == 0 || height == 0`, store `iFlags = nullptr` (rather than `new uint8[0]`) and short-circuit the flag write so we never call `fwrite(nullptr, ...)`.

The current behavior is technically defined in C++ (zero-length `new[]` is valid, `fwrite` with count 0 is a no-op per C99), but MSVC's debug CRT can assert on `fwrite` with a null buffer regardless of count. TC's pattern avoids that footgun and makes the "no flags" state explicit and readable.

Ported from TrinityCore `src/common/Collision/Models/WorldModel.cpp:104-117` (constructor guard) and `:221-240` (write-path structure).

**No change to on-disk vmap format.** The 0-dim case wrote `(0+1)*(0+1) = 1` height float + 0 flag bytes before this change, and writes exactly the same now. Existing extracted vmaps load identically.

## What this is not

This is not fixing an observed crash — mangosthree's `GetLiquidHeight` bounds checks at `WorldModel.cpp:245,251` already prevent dereferencing `iFlags` when `iTilesX/iTilesY == 0`. The PR is for safety against future code paths that might dereference `iFlags` without a bounds guard, and for MSVC debug-CRT friendliness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/131)
<!-- Reviewable:end -->
