### PR TITLE
[Vmap] Use std::isfinite for LoS distance guard

### DIFF
--- a/src/game/vmap/MapTree.cpp
+++ b/src/game/vmap/MapTree.cpp
@@ -45,6 +45,7 @@
 #include "VMapManager2.h"
 #include "VMapDefinitions.h"
 
+#include <cmath>
 #include <string>
 #include <sstream>
 #include <iomanip>
@@ -250,8 +251,7 @@ namespace VMAP
     {
         float maxDist = (pos2 - pos1).magnitude();
         // Return false if distance is over max float, in case of cheater teleporting to the end of the universe
-        if (maxDist == std::numeric_limits<float>::max() ||
-            maxDist == std::numeric_limits<float>::infinity())
+        if (maxDist == std::numeric_limits<float>::max() || !std::isfinite(maxDist))
         {
             return false;
         }


### PR DESCRIPTION
## Summary

Replace the exact-infinity check in `StaticMapTree::isInLineOfSight` with `!std::isfinite(maxDist)` so the early-exit guard also catches NaN values. The current code only catches `std::numeric_limits<float>::infinity()` by exact equality; an NaN-valued `maxDist` (from any caller passing NaN coordinates) slips past the guard and propagates into `G3D::Ray::fromOriginAndDirection(pos1, (pos2 - pos1) / maxDist)`, which can cause the BIH ray traversal to enter an infinite loop on NaN direction.

Ported from TrinityCore `src/common/Collision/Maps/MapTree.cpp:159`.

`!std::isfinite(maxDist)` returns true for positive infinity, negative infinity, and any NaN. The existing `< 1e-10f` check at line 262 already handles denormal/zero cases.

Added `#include <cmath>` (not transitively guaranteed despite G3D usage).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/132)
<!-- Reviewable:end -->
