### PR TITLE
[Server] Enable Cata pet stable opcodes (5 free slots)

### DIFF
--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -70,7 +70,7 @@ enum PetType
     MAX_PET_TYPE            = 5
 };
 
-#define MAX_PET_STABLES         4
+#define MAX_PET_STABLES         5   ///< Cata 4.0.1 unified hunter stable to 5 free slots; was 4 in WotLK.
 
 // Pet storage location
 /// @brief Pet save mode enumeration.

--- a/src/game/Object/PetMgr.cpp
+++ b/src/game/Object/PetMgr.cpp
@@ -31,12 +31,15 @@
 
 void PetMgr::LoadStableSlotsFromField(uint32 raw)
 {
-    m_stableSlots = raw;
-    if (m_stableSlots > MAX_PET_STABLES)
+    // Cata 4.0.1 gave every hunter MAX_PET_STABLES free slots and removed
+    // CMSG_BUY_STABLE_SLOT, so any row holding a lower value (typically
+    // the pre-Cata default of 0) is upgraded silently on load. A higher
+    // value indicates DB tampering and is clamped down with a log line.
+    if (raw > MAX_PET_STABLES)
     {
-        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(m_stableSlots));
-        m_stableSlots = MAX_PET_STABLES;
+        sLog.outError("Player can have not more %u stable slots, but have in DB %u", MAX_PET_STABLES, uint32(raw));
     }
+    m_stableSlots = MAX_PET_STABLES;
 }
 
 void PetMgr::Remove(PetSaveMode mode)

--- a/src/game/Object/PetMgr.h
+++ b/src/game/Object/PetMgr.h
@@ -58,19 +58,22 @@ class PetMgr
 {
     public:
         explicit PetMgr(Player* owner)
-            : m_owner(owner), m_stableSlots(0), m_temporaryUnsummonedPetNumber(0)
+            : m_owner(owner), m_stableSlots(MAX_PET_STABLES), m_temporaryUnsummonedPetNumber(0)
         {
         }
 
-        /// Number of paid stable slots the character has unlocked.
-        /// Persisted to `characters`.stable_slots; clamped to
-        /// MAX_PET_STABLES on load.
+        /// Number of stable slots the character can use. Cata 4.0.1 gave
+        /// every hunter MAX_PET_STABLES (5) for free and removed the
+        /// CMSG_BUY_STABLE_SLOT purchase flow, so this is effectively a
+        /// constant in this fork. Persisted to `characters`.stable_slots
+        /// for forward-compat; clamped UP to MAX_PET_STABLES on load.
         uint32 GetStableSlots() const { return m_stableSlots; }
         void SetStableSlots(uint32 slots) { m_stableSlots = slots; }
 
         /// Called from Player::LoadFromDB with the raw column value.
-        /// Clamps to MAX_PET_STABLES and logs a server error on
-        /// out-of-range data so an operator can detect a tampered row.
+        /// Clamps to MAX_PET_STABLES on either side so a character row
+        /// carried over from a pre-Cata default (stable_slots=0) still
+        /// gets the Cata 5 free slots without a DB migration.
         void LoadStableSlotsFromField(uint32 raw);
 
         /// Pet number that was active before a temporary unsummon (e.g.

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -736,12 +736,16 @@ void InitializeOpcodes()
     OPCODE(CMSG_CANCEL_AUTO_REPEAT_SPELL,                STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleCancelAutoRepeatSpellOpcode);
     //OPCODE(MSG_GM_ACCOUNT_ONLINE,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     OPCODE(MSG_LIST_STABLED_PETS,                        STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleListStabledPetsOpcode     );
-    //OPCODE(CMSG_STABLE_PET,                              STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStablePet                 );
-    //OPCODE(CMSG_UNSTABLE_PET,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleUnstablePet               );
+    OPCODE(CMSG_STABLE_PET,                              STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStablePet                 );
+    OPCODE(CMSG_UNSTABLE_PET,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleUnstablePet               );
+    // CMSG_BUY_STABLE_SLOT stays disabled: Cata 4.0.1 made all 5 stable
+    // slots free and the retail client stopped sending this opcode. TC's
+    // 4.3.4 reference also leaves it commented (Opcodes.cpp line ~1442).
+    // HandleBuyStableSlot in NPCHandler.cpp is a CheckStableMaster stub.
     //OPCODE(CMSG_BUY_STABLE_SLOT,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleBuyStableSlot             );
     OPCODE(SMSG_STABLE_RESULT,                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(CMSG_STABLE_REVIVE_PET,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableRevivePet           );
-    //OPCODE(CMSG_STABLE_SWAP_PET,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableSwapPet             );
+    OPCODE(CMSG_STABLE_REVIVE_PET,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableRevivePet           );
+    OPCODE(CMSG_STABLE_SWAP_PET,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableSwapPet             );
     OPCODE(MSG_QUEST_PUSH_RESULT,                        STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleQuestPushResult           );
     OPCODE(SMSG_PLAY_MUSIC,                              STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_PLAY_OBJECT_SOUND,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );


### PR DESCRIPTION
## Summary

Re-enables 4 of the 5 `CMSG_STABLE_*` opcode registrations that were left commented in the initial mangosthree import. Cata hunters were silently losing the entire pet-stable UI.

- `CMSG_STABLE_PET` / `CMSG_UNSTABLE_PET` / `CMSG_STABLE_REVIVE_PET` / `CMSG_STABLE_SWAP_PET` — uncommented. Handlers in `NPCHandler.cpp` are complete, not stubs.
- `CMSG_BUY_STABLE_SLOT` stays commented: Cata 4.0.1 made all 5 slots free, the retail client stopped sending it, TC-Preservation 4.3.4 also leaves it commented (`Opcodes.cpp` ~1442), and `HandleBuyStableSlot` is a `CheckStableMaster` stub.
- `MAX_PET_STABLES` 4 → 5 (Cata behaviour: 5 free slots).
- `PetMgr::LoadStableSlotsFromField` now clamps `m_stableSlots` UP to `MAX_PET_STABLES` so the `characters.stable_slots` column (`DEFAULT 0`, pre-Cata schema) doesn't lock new hunters out of stabling any pet. The column is effectively vestigial in Cata; no DB schema change or migration needed.

## Test plan

- [x] Build clean (warnings-as-errors)
- [x] Server boots clean — `World Initialization Complete`
- [x] Stable UI shows 5 slot panes (was 4)
- [x] Store / withdraw / swap pet at stable master
- [ ] Revive dead pet at stable master (deferred)

Pre-existing pet-system bugs surfaced during testing (pet name falling back to "Unknown's Pet"; devilsaur tame shows wrong model) are separate concerns; investigation continues in a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/134)
<!-- Reviewable:end -->
