### PR TITLE
[Pet] Use creature name for rare tames + fall back when family empty

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -937,14 +937,34 @@ bool Pet::CreateBaseAtCreature(Creature* creature)
     SetUInt32Value(UNIT_FIELD_PETNEXTLEVELEXP, sObjectMgr.GetXPForPetLevel(creature->getLevel()));
     SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
 
-    if (CreatureFamilyEntry const* cFamily = sCreatureFamilyStore.LookupEntry(cInfo->Family))
+    // Cata 4.3.4 tame-name rules:
+    //  - Rare and rare-elite creatures (e.g. King Mosh, Loque'nahak)
+    //    keep their NPC name when tamed, instead of being replaced by
+    //    the family name. Players use Pet Rename (or a Certificate of
+    //    Ownership for second+ renames) if they want a custom name.
+    //  - Everything else inherits the pet-family name ("Wolf", "Cat",
+    //    "Devilsaur"), so identical-species pets share a default.
+    //  - Either path can hand back an empty string when the source DBC
+    //    row is missing the localized name (some Cata-added families
+    //    have empty Name[locale] entries on certain client builds);
+    //    when that happens the WoW client falls back to rendering the
+    //    pet as "Unknown's Pet" in unit frames. Fall through to the
+    //    creature name so the pet always carries a usable label.
+    std::string petName;
+    bool const isRare = cInfo->Rank == CREATURE_ELITE_RARE
+                     || cInfo->Rank == CREATURE_ELITE_RAREELITE;
+    if (!isRare)
     {
-        SetName(cFamily->Name[sWorld.GetDefaultDbcLocale()]);
+        if (CreatureFamilyEntry const* cFamily = sCreatureFamilyStore.LookupEntry(cInfo->Family))
+        {
+            petName = cFamily->Name[sWorld.GetDefaultDbcLocale()];
+        }
     }
-    else
+    if (petName.empty())
     {
-        SetName(creature->GetNameForLocaleIdx(sObjectMgr.GetDBCLocaleIndex()));
+        petName = creature->GetNameForLocaleIdx(sObjectMgr.GetDBCLocaleIndex());
     }
+    SetName(petName);
 
     SetByteValue(UNIT_FIELD_BYTES_0, 1, CLASS_WARRIOR);
     SetByteValue(UNIT_FIELD_BYTES_0, 2, GENDER_NONE);


### PR DESCRIPTION
## Summary

Two paired hardenings of `Pet::CreateBaseAtCreature` so a freshly tamed pet always carries a non-empty name:

1. **Rare and rare-elite tames** (`Rank == CREATURE_ELITE_RARE` / `CREATURE_ELITE_RAREELITE`) now keep their NPC name (e.g. "King Mosh", "Loque'nahak") instead of being overwritten with the pet-family name. Matches retail Cata 4.3.4: rares preserve their unique name on tame; players use Pet Rename (or a Certificate of Ownership for subsequent renames) to change it.

2. **Empty-string fallback**: if the chosen name source returns an empty string for the active locale — for example a Cata-added pet family with no localized DBC entry, or any malformed-target path that bypasses the normal lookups — fall back to the creature name so the pet is never nameless. An empty `m_name` renders as "Unknown's Pet" in unit frames client-side.

Logic also restructured so the rare branch and the empty fallback share one assignment-and-`SetName` at the bottom, removing the if/else duplication.

## Test plan

- [x] Build clean (warnings-as-errors)
- [x] Tame a normal beast (wolf, bear) → pet name is the family name ("Wolf", "Bear")
- [x] Tame a rare → pet name is the NPC name verbatim, not the family name
- [x] Tame an entry whose family DBC has empty `Name[locale]` → creature name fallback fires
- [x] Logout/login: pet name persists from `character_pet` row
- [x] First Pet Rename works (free first rename per retail Cata)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/135)
<!-- Reviewable:end -->
