### PR TITLE
[Server] Port MSG_LIST_STABLED_PETS payload to Cata 4.3.4 shape

### DIFF
--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -86,6 +86,34 @@ enum PetSaveMode
     PET_SAVE_REAGENTS          =  101                       // PET_SAVE_NOT_IN_SLOT with reagents return
 };
 
+/// @brief Cata Call Pet slot model used in MSG_LIST_STABLED_PETS.
+///
+/// Cata 4.3.4 lets a hunter address up to five pets via the Call Pet 1-5
+/// spell family. The client identifies each pet in the stable payload by
+/// a slot index in this range. Distinct from PetSaveMode, which is the
+/// on-disk character_pet.slot value (PET_SAVE_AS_CURRENT for the live
+/// pet, 1..MAX_PET_STABLES for stabled pets). The mapping is direct:
+/// storage slot 0 = Call Pet 1, storage slot 1 = Call Pet 2, etc.
+enum PetStableSlot
+{
+    PET_SLOT_FIRST             = 0,
+    PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
+};
+
+/// @brief Flag bits for the per-pet status field in MSG_LIST_STABLED_PETS.
+///
+/// Sent for every pet in the stable list. PET_STABLE_ACTIVE marks the
+/// pet as part of the Call Pet roster (always set in 4.3.4 since every
+/// stored slot is callable). PET_STABLE_INACTIVE is reserved for
+/// stable-only slots beyond the active range and is not produced by
+/// the current data model; the bit is kept for forward parity with TC's
+/// Cata layout, which expects the field to be present and bit-coded.
+enum PetStableFlags
+{
+    PET_STABLE_ACTIVE   = 1,
+    PET_STABLE_INACTIVE = 2
+};
+
 // There might be a lot more
 /// @brief Pet mode flags enumeration.
 ///

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -680,31 +680,46 @@ void WorldSession::SendStablePet(ObjectGuid guid)
 {
     DEBUG_LOG("WORLD: Recv MSG_LIST_STABLED_PETS Send.");
 
+    // Cata 4.3.4 MSG_LIST_STABLED_PETS payload layout (mirrors TC):
+    //   uint64  stablemaster guid
+    //   uint8   pet count (N)
+    //   uint8   slot count exposed to client (PET_SLOT_LAST_ACTIVE_SLOT + 1)
+    //   N times:
+    //     int32  petSlot              -- Call Pet 1..5 == slots 0..4
+    //     uint32 petNumber            -- character_pet.id
+    //     uint32 creatureEntry        -- character_pet.entry
+    //     uint32 petLevel             -- character_pet.level
+    //     string name                 -- character_pet.name
+    //     uint8  flags                -- PET_STABLE_ACTIVE [| PET_STABLE_INACTIVE]
+    //
+    // The pre-Cata layout (no slot field, magic status byte 1/2/3) is
+    // what the WotLK client expects; the Cata client misreads it field-
+    // for-field and renders the wrong pet name/level/entry in each pane.
     WorldPacket data(MSG_LIST_STABLED_PETS, 200);           // guess size
     data << guid;
 
     Pet* pet = _player->GetPet();
 
     size_t wpos = data.wpos();
-    data << uint8(0);                                       // place holder for slot show number
-
-    data << uint8(GetPlayer()->GetStableSlots());
+    data << uint8(0);                                       // place holder for pet count
+    data << uint8(PET_SLOT_LAST_ACTIVE_SLOT + 1);           // slots exposed to client = 5
 
     uint8 num = 0;                                          // counter for place holder
 
     // not let move dead pet in slot
     if (pet && pet->IsAlive() && pet->getPetType() == HUNTER_PET)
     {
+        data << int32(PET_SLOT_FIRST);                      // active pet always lives in slot 0 (Call Pet 1)
         data << uint32(pet->GetCharmInfo()->GetPetNumber());
         data << uint32(pet->GetEntry());
         data << uint32(pet->getLevel());
-        data << pet->GetName();                             // petname
-        data << uint8(1);                                   // 1 = current, 2/3 = in stable (any from 4,5,... create problems with proper show)
+        data << pet->GetName();
+        data << uint8(PET_STABLE_ACTIVE);
         ++num;
     }
 
-    //                                                      0        1     2        3        4
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
+    //                                                      0        1     2        3        4       5
+    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
                           _player->GetGUIDLow(), PET_SAVE_FIRST_STABLE_SLOT, PET_SAVE_LAST_STABLE_SLOT);
 
     if (result)
@@ -713,11 +728,23 @@ void WorldSession::SendStablePet(ObjectGuid guid)
         {
             Field* fields = result->Fetch();
 
+            // character_pet.slot 1..MAX_PET_STABLES maps directly onto
+            // Call Pet 2..N+1 in the Cata client. Pets stored beyond the
+            // Call Pet range get PET_STABLE_INACTIVE for forward parity,
+            // even though 4.3.4 has no such slots today.
+            uint32 petSlot = fields[5].GetUInt32();
+            uint8 flags = PET_STABLE_ACTIVE;
+            if (petSlot > uint32(PET_SLOT_LAST_ACTIVE_SLOT))
+            {
+                flags |= PET_STABLE_INACTIVE;
+            }
+
+            data << int32(petSlot);
             data << uint32(fields[1].GetUInt32());          // petnumber
             data << uint32(fields[2].GetUInt32());          // creature entry
             data << uint32(fields[3].GetUInt32());          // level
             data << fields[4].GetString();                  // name
-            data << uint8(2);                               // 1 = current, 2/3 = in stable (any from 4,5,... create problems with proper show)
+            data << uint8(flags);
 
             ++num;
         }


### PR DESCRIPTION
## Summary

Mangosthree's `SendStablePet` still emits the pre-Cata `MSG_LIST_STABLED_PETS` payload — no per-pet slot field, magic status byte `1`/`2`/`3` with a comment that literally warns "any from 4,5,... create problems with proper show". The Cata 4.3.4 client expects a six-field per-pet record with an `int32` slot at the front and a flag byte at the end. Reading the WotLK shape against the Cata parser lands every field one column to the right, surfacing in-game as garbled pet name / level / entry in each stable pane.

New layout (matches TC-Preservation 4.3.4 `Handlers/NPCHandler.cpp:321`):

```
uint64 stablemaster
uint8  pet count
uint8  slot count (PET_SLOT_LAST_ACTIVE_SLOT + 1 == 5)
for each pet:
  int32  slot                -- Call Pet 1..5 -> slots 0..4
  uint32 petNumber
  uint32 creatureEntry
  uint32 level
  string name
  uint8  flags               -- PET_STABLE_ACTIVE [| PET_STABLE_INACTIVE]
```

Active pet emits `slot = 0` (Call Pet 1). Stabled pets re-use their `character_pet.slot` value directly, which already maps 1:1 onto Call Pet 2..N+1 in the Cata client. Stored slots beyond `PET_SLOT_LAST_ACTIVE_SLOT` set `PET_STABLE_INACTIVE` for forward parity with TC, even though 4.3.4 has no stable-only slots today.

Adds `PetStableSlot` + `PetStableFlags` enums in `Pet.h` and a `SELECT character_pet.slot` in the existing query (column was already populated by `SavePetToDB`; just not previously read here). No data-model change — `PetSaveMode` semantics (`0` = active, `1..MAX_PET_STABLES` = stabled) are preserved.

## Out of scope (follow-ups)

- Cata's true multi-callable model (Call Pet 1..5 summoning any stored pet without visiting a stable master) needs a deeper refactor of the active-vs-stable storage distinction; not touched here.
- `CMSG_STABLE_PET` / `CMSG_SET_PET_SLOT` still parse with the WotLK straight-`ObjectGuid` layout; the Cata client sends a bit-packed payload. Separate PR.

## Test plan

- [x] Build clean (warnings-as-errors)
- [ ] Open stable UI at a stable master — five pets render with correct names, levels, entries
- [x] Active pet appears in slot 1
- [ ] Stabled pets appear in slots 2..N
- [ ] Logout/login round-trip preserves slot assignment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/136)
<!-- Reviewable:end -->
