### PR TITLE
[Pet] Implement Cata Call Pet 1..5 multi-slot pet storage

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -43,7 +43,7 @@ Pet::Pet(PetType type) :
     Creature(CREATURE_SUBTYPE_PET),
     m_resetTalentsCost(0), m_resetTalentsTime(0), m_usedTalentCount(0),
     m_removed(false),  m_petType(type), m_duration(0),
-    m_bonusdamage(0), m_auraUpdateMask(0), m_loading(false),
+    m_bonusdamage(0), m_petSlot(-1), m_auraUpdateMask(0), m_loading(false),
     m_declinedname(NULL), m_petModeFlags(PET_MODE_DEFAULT), m_retreating(false),
     m_stayPosSet(false), m_stayPosX(0), m_stayPosY(0), m_stayPosZ(0), m_stayPosO(0),
     m_opener(0), m_openerMinRange(0), m_openerMaxRange(0)
@@ -107,7 +107,7 @@ void Pet::RemoveFromWorld()
  * @param current true to load the current pet.
  * @return true if the pet was loaded successfully; otherwise, false.
  */
-bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool current)
+bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool current, int32 slot)
 {
     m_loading = true;
 
@@ -125,6 +125,12 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
         result = CharacterDatabase.PQuery("SELECT `id`, `entry`, `owner`, `modelid`, `level`, `exp`, `Reactstate`, `slot`, `name`, `renamed`, `curhealth`, `curmana`, `abdata`, `savetime`, `resettalents_cost`, `resettalents_time`, `CreatedBySpell`, `PetType` "
                                           "FROM `character_pet` WHERE `owner` = '%u' AND `slot` = '%u'",
                                           ownerid, PET_SAVE_AS_CURRENT);
+    else if (slot >= 0)
+        // Cata Call Pet 1..5: load the pet at this specific active slot (0..PET_SLOT_LAST_ACTIVE_SLOT).
+        //                                         0     1        2(?)     3          4        5      6             7       8       9          10           11         12        13          14                   15                   16                17
+        result = CharacterDatabase.PQuery("SELECT `id`, `entry`, `owner`, `modelid`, `level`, `exp`, `Reactstate`, `slot`, `name`, `renamed`, `curhealth`, `curmana`, `abdata`, `savetime`, `resettalents_cost`, `resettalents_time`, `CreatedBySpell`, `PetType` "
+                                          "FROM `character_pet` WHERE `owner` = '%u' AND `slot` = '%u'",
+                                          ownerid, uint32(slot));
     else if (petentry)
         // known petentry entry (unique for summoned pet, but non unique for hunter pet (only from current or not stabled pets)
         //                                         0     1        2(?)     3          4        5      6             7       8       9          10           11         12        13          14                   15                   16                17
@@ -257,7 +263,14 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
     // 0=current
     // 1..MAX_PET_STABLES in stable slot
     // PET_SAVE_NOT_IN_SLOT(100) = not stable slot (summoning))
-    if (fields[7].GetUInt32() != 0)
+    //
+    // Cata Call Pet 1..5 loads a specific active slot 0..PET_SLOT_LAST_ACTIVE_SLOT
+    // and must preserve every pet's assigned slot. When the caller passed an
+    // explicit slot we record it on the Pet and skip the legacy WotLK auto-promote
+    // (which would shift this pet to slot 0 and bump the current pet to slot 100,
+    // destroying the rest of the multi-pet roster on the next destructive save).
+    m_petSlot = int32(fields[7].GetUInt32());
+    if (slot < 0 && fields[7].GetUInt32() != 0)
     {
         CharacterDatabase.BeginTransaction();
 
@@ -271,6 +284,7 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
         stmt.PExecute(uint32(PET_SAVE_AS_CURRENT), ownerid, m_charmInfo->GetPetNumber());
 
         CharacterDatabase.CommitTransaction();
+        m_petSlot = int32(PET_SAVE_AS_CURRENT);
     }
 
     // load action bar, if data broken will fill later by default spells.
@@ -393,6 +407,59 @@ void Pet::SavePetToDB(PetSaveMode mode)
         return;
     }
 
+    // Cata multi-pet save modes -- must run BEFORE the "mode >= PET_SAVE_AS_CURRENT"
+    // gate below because PET_SAVE_NEW_PET (== 102) needs to be resolved into a real
+    // slot value (0..PET_SLOT_LAST_ACTIVE_SLOT) first.
+    uint32 ownerLowForSlot = GetOwnerGuid().GetCounter();
+    if (mode == PET_SAVE_NEW_PET)
+    {
+        // Tame path: find the next free active slot 0..PET_SLOT_LAST_ACTIVE_SLOT.
+        // If every active slot is taken the tame should be refused; we mark the
+        // pet's slot as not-in-slot so the caller can detect failure via GetSlot()
+        // and abort cleanly without leaking a half-saved row.
+        bool occupied[PET_SLOT_LAST_ACTIVE_SLOT + 1] = {};
+        if (QueryResult* used = CharacterDatabase.PQuery(
+                "SELECT `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` <= '%u'",
+                ownerLowForSlot, uint32(PET_SLOT_LAST_ACTIVE_SLOT)))
+        {
+            do
+            {
+                uint32 s = used->Fetch()[0].GetUInt32();
+                if (s <= uint32(PET_SLOT_LAST_ACTIVE_SLOT))
+                {
+                    occupied[s] = true;
+                }
+            }
+            while (used->NextRow());
+            delete used;
+        }
+        int32 freeSlot = -1;
+        for (int32 s = 0; s <= PET_SLOT_LAST_ACTIVE_SLOT; ++s)
+        {
+            if (!occupied[s])
+            {
+                freeSlot = s;
+                break;
+            }
+        }
+        if (freeSlot < 0)
+        {
+            // No room in the active roster -- bail out, do not persist anything.
+            m_petSlot = int32(PET_SAVE_NOT_IN_SLOT);
+            return;
+        }
+        m_petSlot = freeSlot;
+        mode = static_cast<PetSaveMode>(freeSlot);
+    }
+    else if (getPetType() == HUNTER_PET && mode == PET_SAVE_AS_CURRENT && m_petSlot >= 0
+             && m_petSlot <= int32(PET_SLOT_LAST_ACTIVE_SLOT))
+    {
+        // Cata re-save path: preserve the pet's existing active slot rather
+        // than nuking it to 0. Legacy WotLK callers that have never set
+        // m_petSlot (m_petSlot == -1) still hit the original slot-0 path.
+        mode = static_cast<PetSaveMode>(m_petSlot);
+    }
+
     // current/stable/not_in_slot
     if (mode >= PET_SAVE_AS_CURRENT)
     {
@@ -455,13 +522,19 @@ void Pet::SavePetToDB(PetSaveMode mode)
             stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), ownerLow, uint32(mode));
         }
 
-        // prevent existence another hunter pet in PET_SAVE_AS_CURRENT and PET_SAVE_NOT_IN_SLOT
+        // Cata multi-pet: reap orphan rows (slot > PET_SAVE_LAST_STABLE_SLOT)
+        // only -- the slot 0..PET_SAVE_LAST_STABLE_SLOT range is the Call Pet
+        // 1..N roster and must be preserved across every save. The previous
+        // WotLK code also nuked `slot = PET_SAVE_AS_CURRENT`, which destroyed
+        // every other tamed pet whenever the active pet was re-saved (dismiss,
+        // level-up, logout, taming a new one). The exclude-self clause keeps
+        // the INSERT below idempotent when it adds the new row for this pet.
         if (getPetType() == HUNTER_PET && (mode == PET_SAVE_AS_CURRENT || mode > PET_SAVE_LAST_STABLE_SLOT))
         {
             static SqlStatementID del ;
 
-            stmt = CharacterDatabase.CreateStatement(del, "DELETE FROM `character_pet` WHERE `owner` = ? AND (`slot` = ? OR `slot` > ?)");
-            stmt.PExecute(ownerLow, uint32(PET_SAVE_AS_CURRENT), uint32(PET_SAVE_LAST_STABLE_SLOT));
+            stmt = CharacterDatabase.CreateStatement(del, "DELETE FROM `character_pet` WHERE `owner` = ? AND `slot` > ? AND `id` <> ?");
+            stmt.PExecute(ownerLow, uint32(PET_SAVE_LAST_STABLE_SLOT), m_charmInfo->GetPetNumber());
         }
 
         // save pet

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -451,12 +451,23 @@ void Pet::SavePetToDB(PetSaveMode mode)
         m_petSlot = freeSlot;
         mode = static_cast<PetSaveMode>(freeSlot);
     }
-    else if (getPetType() == HUNTER_PET && mode == PET_SAVE_AS_CURRENT && m_petSlot >= 0
+    else if (getPetType() == HUNTER_PET
+             && (mode == PET_SAVE_AS_CURRENT || mode == PET_SAVE_NOT_IN_SLOT)
+             && m_petSlot >= 0
              && m_petSlot <= int32(PET_SLOT_LAST_ACTIVE_SLOT))
     {
-        // Cata re-save path: preserve the pet's existing active slot rather
-        // than nuking it to 0. Legacy WotLK callers that have never set
-        // m_petSlot (m_petSlot == -1) still hit the original slot-0 path.
+        // Cata re-save path: every hunter pet stays parked in its Call Pet
+        // 1..N slot for the entire character lifetime, including across
+        // dismiss. Pre-Cata code used PET_SAVE_NOT_IN_SLOT to mean "this
+        // pet isn't out anymore, leave it in the orphan pool until next
+        // stable visit" -- which evicted the row from the active range
+        // and made the next Call Pet N fail with NO_PET because the row
+        // had moved. EffectDismissPet is the typical caller. The
+        // PET_SAVE_AS_CURRENT branch also routes through here so legacy
+        // callers that re-save the active pet (logout, level-up, feed)
+        // preserve its slot rather than nuking it to 0.
+        // Legacy WotLK paths that have never set m_petSlot
+        // (m_petSlot == -1) still hit the original mode-as-passed path.
         mode = static_cast<PetSaveMode>(m_petSlot);
     }
 

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -83,7 +83,8 @@ enum PetSaveMode
     PET_SAVE_FIRST_STABLE_SLOT =  1,
     PET_SAVE_LAST_STABLE_SLOT  =  MAX_PET_STABLES,          // last in DB stable slot index (including), all higher have same meaning as PET_SAVE_NOT_IN_SLOT
     PET_SAVE_NOT_IN_SLOT       =  100,                      // for avoid conflict with stable size grow will use 100
-    PET_SAVE_REAGENTS          =  101                       // PET_SAVE_NOT_IN_SLOT with reagents return
+    PET_SAVE_REAGENTS          =  101,                      // PET_SAVE_NOT_IN_SLOT with reagents return
+    PET_SAVE_NEW_PET           =  102                       ///< Sentinel for Cata multi-pet tame: SavePetToDB allocates next free active slot 0..PET_SLOT_LAST_ACTIVE_SLOT and rewrites mode in place.
 };
 
 // There might be a lot more
@@ -191,7 +192,23 @@ class Pet : public Creature
 
         bool Create(uint32 guidlow, CreatureCreatePos& cPos, CreatureInfo const* cinfo, uint32 pet_number);
         bool CreateBaseAtCreature(Creature* creature);
-        bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false);
+        /// Load a pet from the character_pet table.
+        ///
+        /// Resolution priority on the selector arguments:
+        ///   1. petnumber > 0   -> exact row by id
+        ///   2. current == true -> the row at PET_SAVE_AS_CURRENT (legacy WotLK single-pet flow)
+        ///   3. slot >= 0       -> the row at character_pet.slot == slot (Cata Call Pet 1..5)
+        ///   4. petentry > 0    -> any row matching the creature entry (warlock summon)
+        ///   5. otherwise       -> the active or orphan pet (legacy fallback)
+        ///
+        /// When the explicit `slot` path is taken the legacy auto-promote-to-slot-0
+        /// behaviour is skipped so each Cata Call Pet 1..5 slot keeps its assignment.
+        bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false, int32 slot = -1);
+
+        /// Active-slot index this pet currently occupies in character_pet.slot,
+        /// or -1 when the pet has never been loaded or saved. Cata uses this for
+        /// the Call Pet 1..5 routing; WotLK callers can ignore it.
+        int32 GetSlot() const { return m_petSlot; }
         void SavePetToDB(PetSaveMode mode);
         void Unsummon(PetSaveMode mode, Unit* owner = NULL);
 
@@ -345,6 +362,7 @@ class Pet : public Creature
         PetType m_petType;
         int32   m_duration;                                 // time until unsummon (used mostly for summoned guardians and not used for controlled pets)
         int32   m_bonusdamage;
+        int32   m_petSlot;                                  ///< character_pet.slot value: 0..4 for Cata Call Pet 1..5; -1 when unassigned.
         uint64  m_auraUpdateMask;
         bool    m_loading;
 

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -7596,8 +7596,26 @@ SpellCastResult Spell::CheckCast(bool strict)
                     }
                     else
                     {
+                        // Cata Call Pet 1..5 spells (883, 83242, 83243, 83244,
+                        // 83245) encode the target slot in EffectBasePoints --
+                        // Call Pet 1 -> slot 0, Call Pet 5 -> slot 4. Other
+                        // hunter pet-summon spells (legacy WotLK content,
+                        // scripted summons) leave EffectMiscValue non-zero or
+                        // BasePoints outside 0..PET_SLOT_LAST_ACTIVE_SLOT and
+                        // fall back to slot 0 so existing behaviour is
+                        // preserved for non-Cata callers.
+                        int32 callSlot = 0;
+                        if (SpellEffectEntry const* eff = m_spellInfo->GetSpellEffect(EFFECT_INDEX_0))
+                        {
+                            if (eff->EffectMiscValue == 0
+                                && eff->EffectBasePoints >= 0
+                                && eff->EffectBasePoints <= PET_SLOT_LAST_ACTIVE_SLOT)
+                            {
+                                callSlot = eff->EffectBasePoints;
+                            }
+                        }
                         Pet* dbPet = new Pet;
-                        if (dbPet->LoadPetFromDB((Player*)m_caster, 0))
+                        if (dbPet->LoadPetFromDB((Player*)m_caster, 0, 0, false, callSlot))
                         {
                             return SPELL_CAST_OK;           // still returns an error to the player, so this error must come from somewhere else...
                         }

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -8032,7 +8032,18 @@ void Spell::EffectTameCreature(SpellEffectEntry const* /*effect*/)
 
     plr->PetSpellInitialize();
 
-    pet->SavePetToDB(PET_SAVE_AS_CURRENT);
+    // Cata Call Pet 1..5 storage: allocate the next free active slot instead
+    // of always overwriting slot 0. SavePetToDB(PET_SAVE_NEW_PET) leaves
+    // pet->GetSlot() at a value above PET_SLOT_LAST_ACTIVE_SLOT when the
+    // roster is full; in that case the tame is rolled back rather than
+    // letting an unowned pet linger in world.
+    pet->SavePetToDB(PET_SAVE_NEW_PET);
+    if (pet->GetSlot() > PET_SLOT_LAST_ACTIVE_SLOT)
+    {
+        plr->SendPetTameFailure(PETTAME_TOOMANY);
+        pet->Unsummon(PET_SAVE_AS_DELETED, plr);
+        return;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Hunter tames overwrote `character_pet.slot = 0` on every save, and the Call Pet 1..5 spell family (`883`, `83242`, `83243`, `83244`, `83245`) all ran the same slot-agnostic load query — so a hunter could only ever own one pet, and every Call Pet hotkey summoned the same one. Visible in-game as "tame second pet → first pet vanishes; Call Pet 2 summons the most recent tame, not a different stored pet."

Wires the storage layer to Cata 4.3.4's active-roster model (5 callable slots indexed 0..4):

**`Pet.h`**
- `PET_SAVE_NEW_PET = 102` sentinel — `SavePetToDB` resolves it into a real slot 0..4 in place.
- `Pet::GetSlot()` accessor over a new `m_petSlot` member (`-1` = unassigned).
- `LoadPetFromDB` gains an `int32 slot` parameter for explicit Call Pet routing.

**`Pet.cpp`**
- `LoadPetFromDB`: new explicit-slot SELECT branch; captures `m_petSlot` from the row; **skips the WotLK auto-promote-to-slot-0** when called via explicit slot so the rest of the roster keeps its assignment.
- `SavePetToDB(PET_SAVE_NEW_PET)`: scans `character_pet` for taken active slots and writes the first free one (returns early with `m_petSlot = PET_SAVE_NOT_IN_SLOT` if the roster is full).
- `SavePetToDB(PET_SAVE_AS_CURRENT)` for hunter pets respects an already-known `m_petSlot` rather than nuking back to slot 0.
- Destructive hunter-pet cleanup now only reaps **orphan rows** (`slot > PET_SAVE_LAST_STABLE_SLOT`) and excludes self. The previous code also deleted every other slot-0 row on every save, which destroyed the multi-pet roster.

**`Spell.cpp`**
- `CheckCast` for `SPELL_EFFECT_SUMMON_PET` decodes `EffectBasePoints` as the slot for Cata Call Pet (Call Pet 1 → BasePoints=0, Call Pet 5 → BasePoints=4). Non-Cata callers (`EffectMiscValue != 0` or out-of-range) fall back to slot 0 unchanged.

**`SpellEffects.cpp`**
- `EffectTameCreature` saves via `PET_SAVE_NEW_PET`; if no free active slot, the tame is rolled back via `Unsummon(PET_SAVE_AS_DELETED)` and the player gets `PETTAME_TOOMANY`.

## Migration

Existing characters with a single pet at slot 0 keep working unchanged — legacy `LoadPetFromDB` paths still return that row and re-saves preserve slot 0. **No DB schema change, no data migration required.**

## Out of scope

- TC's `PlayerPetDataStore` in-memory cache (perf only)
- `CMSG_STABLE_PET` / `CMSG_SET_PET_SLOT` Cata bit-packed payload parser
- `HandleAuraOpenStable` (Cata in-world stable UI trigger)
- Pet talent recalibration on slot swap

Builds on PR #134 (5 free slots), #135 (rare tame name fallback), #136 (MSG_LIST_STABLED_PETS Cata packet shape).

## Test plan

- [x] Build clean (warnings-as-errors)
- [ ] Fresh hunter, no pets — tame pet A → saved at slot 0; `/cast Call Pet 1` resummons pet A after dismiss
- [ ] Same hunter — dismiss A, tame pet B → pet B saved at slot 1 (not overwriting A)
- [ ] `/cast Call Pet 1` after dismissing B → pet A summons (loads from slot 0)
- [ ] `/cast Call Pet 2` after dismissing A → pet B summons (loads from slot 1)
- [ ] Fill slots 2/3/4 with pets C/D/E
- [ ] Attempt 6th tame at full roster → fails cleanly with `PETTAME_TOOMANY`, no DB corruption
- [ ] Logout / login — all 5 pets persist; Call Pet 1..5 still routes correctly
- [ ] Stable master UI (PR #136 regression check) — 5 pets render with correct names
- [ ] Pre-existing character with one pet at slot 0 still works (legacy compat)

Mangostwo not synced — Call Pet 1..5 is a Cata-only mechanic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/137)
<!-- Reviewable:end -->
