### PR TITLE
[Pet] Cata 4.3.4 hunter pet overhaul (multi-pet + stable UX)

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -585,13 +585,36 @@ void Pet::SavePetToDB(PetSaveMode mode)
             stmt.PExecute(uint32(PET_SAVE_NOT_IN_SLOT), ownerLow, uint32(mode));
         }
 
-        // prevent existence another hunter pet in PET_SAVE_AS_CURRENT and PET_SAVE_NOT_IN_SLOT
+        // Cata multi-pet hunter cleanup: reap orphan rows
+        // (slot > PET_SAVE_LAST_STABLE_SLOT) only -- the
+        // slot 0..PET_SAVE_LAST_STABLE_SLOT range is the Call Pet 1..N
+        // roster and must be preserved across every save.
+        //
+        // The legacy WHERE clause was `slot = PET_SAVE_AS_CURRENT OR
+        // slot > PET_SAVE_LAST_STABLE_SLOT`, which destroyed every
+        // other tamed pet at slot 0 whenever the active pet was
+        // re-saved (dismiss, level-up, logout, taming a new one).
+        // That was the data-loss root surfaced when PR #137 was
+        // tested in-game and reverted -- the fix is here, in the
+        // WHERE clause, not in the per-mode intercepts.
+        //
+        // `id <> ?` excludes the pet we are about to INSERT below so
+        // that even if its previous row was bumped to NOT_IN_SLOT by
+        // the UPDATE above, we do not immediately delete the new row.
+        //
+        // No behaviour change for SUMMON_PET / GUARDIAN_PET (the
+        // outer `getPetType() == HUNTER_PET` guard already excluded
+        // them). No behaviour change for any current hunter that has
+        // a single pet at slot 0 -- there are no orphan rows to reap,
+        // so the DELETE is a no-op on a healthy single-pet DB. The
+        // cleanup re-engages only once multi-pet hunters exist
+        // (after step 10 of the audit ships).
         if (getPetType() == HUNTER_PET && (mode == PET_SAVE_AS_CURRENT || mode > PET_SAVE_LAST_STABLE_SLOT))
         {
             static SqlStatementID del ;
 
-            stmt = CharacterDatabase.CreateStatement(del, "DELETE FROM `character_pet` WHERE `owner` = ? AND (`slot` = ? OR `slot` > ?)");
-            stmt.PExecute(ownerLow, uint32(PET_SAVE_AS_CURRENT), uint32(PET_SAVE_LAST_STABLE_SLOT));
+            stmt = CharacterDatabase.CreateStatement(del, "DELETE FROM `character_pet` WHERE `owner` = ? AND `slot` > ? AND `id` <> ?");
+            stmt.PExecute(ownerLow, uint32(PET_SAVE_LAST_STABLE_SLOT), m_charmInfo->GetPetNumber());
         }
 
         // save pet

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -43,7 +43,7 @@ Pet::Pet(PetType type) :
     Creature(CREATURE_SUBTYPE_PET),
     m_resetTalentsCost(0), m_resetTalentsTime(0), m_usedTalentCount(0),
     m_removed(false),  m_petType(type), m_duration(0),
-    m_bonusdamage(0), m_auraUpdateMask(0), m_loading(false),
+    m_bonusdamage(0), m_petSlot(-1), m_auraUpdateMask(0), m_loading(false),
     m_declinedname(NULL), m_petModeFlags(PET_MODE_DEFAULT), m_retreating(false),
     m_stayPosSet(false), m_stayPosX(0), m_stayPosY(0), m_stayPosZ(0), m_stayPosO(0),
     m_opener(0), m_openerMinRange(0), m_openerMaxRange(0)

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -107,7 +107,7 @@ void Pet::RemoveFromWorld()
  * @param current true to load the current pet.
  * @return true if the pet was loaded successfully; otherwise, false.
  */
-bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool current)
+bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool current, int32 slot)
 {
     m_loading = true;
 
@@ -125,6 +125,16 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
         result = CharacterDatabase.PQuery("SELECT `id`, `entry`, `owner`, `modelid`, `level`, `exp`, `Reactstate`, `slot`, `name`, `renamed`, `curhealth`, `curmana`, `abdata`, `savetime`, `resettalents_cost`, `resettalents_time`, `CreatedBySpell`, `PetType` "
                                           "FROM `character_pet` WHERE `owner` = '%u' AND `slot` = '%u'",
                                           ownerid, PET_SAVE_AS_CURRENT);
+    else if (slot >= 0)
+        // Cata Call Pet 1..N: load the pet at this specific active slot
+        // (0..PET_SLOT_LAST_ACTIVE_SLOT). Caller is Spell::CheckCast for
+        // the hunter Call Pet spell family in a future commit on this
+        // branch; until then this branch is unreachable and the existing
+        // dispatch falls through as before.
+        //                                         0     1        2(?)     3          4        5      6             7       8       9          10           11         12        13          14                   15                   16                17
+        result = CharacterDatabase.PQuery("SELECT `id`, `entry`, `owner`, `modelid`, `level`, `exp`, `Reactstate`, `slot`, `name`, `renamed`, `curhealth`, `curmana`, `abdata`, `savetime`, `resettalents_cost`, `resettalents_time`, `CreatedBySpell`, `PetType` "
+                                          "FROM `character_pet` WHERE `owner` = '%u' AND `slot` = '%u'",
+                                          ownerid, uint32(slot));
     else if (petentry)
         // known petentry entry (unique for summoned pet, but non unique for hunter pet (only from current or not stabled pets)
         //                                         0     1        2(?)     3          4        5      6             7       8       9          10           11         12        13          14                   15                   16                17
@@ -144,6 +154,17 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
     }
 
     Field* fields = result->Fetch();
+
+    // Record the slot column on the Pet instance. Future commits on this
+    // branch (audit IDs C2 / D-row hunter re-saves) read m_petSlot to keep
+    // each tamed pet parked at its Call Pet 1..N slot across re-saves and
+    // dismisses. Capturing it here (after `result` is known non-null and
+    // the row exists, but before any early-out) means every successful
+    // load -- by petnumber, current-flag, explicit slot, petentry, or
+    // legacy fallback -- gets the same accurate value. Harmless for the
+    // early-out failure paths below: a Pet object that returns false
+    // gets discarded by the caller, m_petSlot included.
+    m_petSlot = int32(fields[7].GetUInt32());
 
     // update for case of current pet "slot = 0"
     petentry = fields[1].GetUInt32();

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -471,6 +471,58 @@ void Pet::SavePetToDB(PetSaveMode mode)
         return;
     }
 
+    // Cata multi-pet allocator. Resolves PET_SAVE_NEW_PET (== 102) into
+    // a concrete active-roster slot 0..PET_SLOT_LAST_ACTIVE_SLOT by
+    // scanning character_pet for the first vacant slot in that range.
+    // Updates `mode` and `m_petSlot` in place so the rest of the
+    // function continues unchanged. If the roster is full, leaves
+    // m_petSlot at PET_SAVE_NOT_IN_SLOT and bails out without writing
+    // any row -- the caller (EffectTameCreature, future commit) checks
+    // GetSlot() after the call to detect failure and roll the tame back.
+    //
+    // No caller passes PET_SAVE_NEW_PET in this commit; the block
+    // becomes reachable in step 10 of the audit. Adding the allocator
+    // ahead of its caller keeps each diff small enough to review on
+    // its own.
+    if (mode == PET_SAVE_NEW_PET)
+    {
+        uint32 ownerLowForNewPet = GetOwnerGuid().GetCounter();
+        bool occupied[PET_SLOT_LAST_ACTIVE_SLOT + 1] = {};
+        if (QueryResult* used = CharacterDatabase.PQuery(
+                "SELECT `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` <= '%u'",
+                ownerLowForNewPet, uint32(PET_SLOT_LAST_ACTIVE_SLOT)))
+        {
+            do
+            {
+                uint32 s = used->Fetch()[0].GetUInt32();
+                if (s <= uint32(PET_SLOT_LAST_ACTIVE_SLOT))
+                {
+                    occupied[s] = true;
+                }
+            }
+            while (used->NextRow());
+            delete used;
+        }
+        int32 freeSlot = -1;
+        for (int32 s = 0; s <= PET_SLOT_LAST_ACTIVE_SLOT; ++s)
+        {
+            if (!occupied[s])
+            {
+                freeSlot = s;
+                break;
+            }
+        }
+        if (freeSlot < 0)
+        {
+            // Roster full -- do not persist anything. m_petSlot value
+            // signals "no slot allocated" to the caller.
+            m_petSlot = int32(PET_SAVE_NOT_IN_SLOT);
+            return;
+        }
+        m_petSlot = freeSlot;
+        mode = static_cast<PetSaveMode>(freeSlot);
+    }
+
     // current/stable/not_in_slot
     if (mode >= PET_SAVE_AS_CURRENT)
     {

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -315,7 +315,27 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
     // 0=current
     // 1..MAX_PET_STABLES in stable slot
     // PET_SAVE_NOT_IN_SLOT(100) = not stable slot (summoning))
-    if (fields[7].GetUInt32() != 0)
+    //
+    // The legacy auto-promote block below moves whichever pet we just
+    // loaded into PET_SAVE_AS_CURRENT (slot 0) and bumps any previous
+    // slot-0 pet to PET_SAVE_NOT_IN_SLOT (=100). That was correct under
+    // the WotLK 1-active-pet model where loading a stabled pet implied
+    // making it the active one and demoting the old current.
+    //
+    // For Cata HUNTER_PET the same code path is destructive: every pet
+    // permanently lives in its assigned Call Pet 1..N slot 0..4 and
+    // loading one must NOT shift it. Without this gate,
+    // ResummonTemporaryUnsummonedIfAny (mount, transport, vehicle exit)
+    // would force the resumed pet back to slot 0 and silently bump the
+    // pet that owns slot 0 out into orphan land, breaking the next
+    // Call Pet 1 cast. This was the bug audit row C2 in
+    // MANGOS/PET_SAVE_CALLSITE_AUDIT.md and the gap closed PR #137 left
+    // open when it was reverted.
+    //
+    // SUMMON_PET / GUARDIAN_PET / MINI_PET keep the legacy auto-promote
+    // -- they have no Call Pet 1..N concept and the warlock pet pool
+    // still expects loading from slot 100 to mean "becomes active."
+    if (getPetType() != HUNTER_PET && fields[7].GetUInt32() != 0)
     {
         CharacterDatabase.BeginTransaction();
 

--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -522,6 +522,41 @@ void Pet::SavePetToDB(PetSaveMode mode)
         m_petSlot = freeSlot;
         mode = static_cast<PetSaveMode>(freeSlot);
     }
+    else if (getPetType() == HUNTER_PET
+             && (mode == PET_SAVE_AS_CURRENT || mode == PET_SAVE_NOT_IN_SLOT)
+             && m_petSlot >= 0
+             && m_petSlot <= int32(PET_SLOT_LAST_ACTIVE_SLOT))
+    {
+        // Cata multi-pet re-save path. Every hunter pet stays parked in
+        // its Call Pet 1..N slot for the entire character lifetime,
+        // including across dismiss, logout, level-up, feed, range
+        // unsummon and visibility teardown. The pre-Cata code routed
+        // PET_SAVE_AS_CURRENT (=0) and PET_SAVE_NOT_IN_SLOT (=100)
+        // directly through to the INSERT, evicting the pet from its
+        // assigned slot and breaking the next Call Pet N cast with
+        // NO_PET.
+        //
+        // Rewrite mode in place so the rest of SavePetToDB writes
+        // back to the pet's known slot. Legacy WotLK paths that have
+        // never set m_petSlot (m_petSlot == -1, e.g. a fresh Pet*
+        // about to be saved for the first time -- though tame goes
+        // through PET_SAVE_NEW_PET in step 10) still fall through to
+        // the original mode-as-passed behaviour. SUMMON_PET /
+        // GUARDIAN_PET also fall through (gated on HUNTER_PET).
+        //
+        // Audit row IDs: D1 (EffectDismissPet), D2 (mount/transport
+        // temp-unsummon), D4 (out-of-range), D5 (talent reset),
+        // D6 (visibility teardown), D7 (GM .pet unsummon),
+        // S4 (Player::SaveToDB periodic).
+        //
+        // Until step 10 ships, no hunter has a pet with m_petSlot
+        // in 0..PET_SLOT_LAST_ACTIVE_SLOT (taming still goes through
+        // PET_SAVE_AS_CURRENT and m_petSlot stays at -1 because there
+        // is no load path to populate it). So this branch is dormant
+        // in practice today and engages once step 10's tame change
+        // starts populating m_petSlot.
+        mode = static_cast<PetSaveMode>(m_petSlot);
+    }
 
     // current/stable/not_in_slot
     if (mode >= PET_SAVE_AS_CURRENT)

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -111,6 +111,34 @@ enum PetStableSlot
     PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
 };
 
+/// @brief Cata Call Pet slot model used in MSG_LIST_STABLED_PETS.
+///
+/// Cata 4.3.4 lets a hunter address up to five pets via the Call Pet 1-5
+/// spell family. The client identifies each pet in the stable payload by
+/// a slot index in this range. Distinct from PetSaveMode, which is the
+/// on-disk character_pet.slot value (PET_SAVE_AS_CURRENT for the live
+/// pet, 1..MAX_PET_STABLES for stabled pets). The mapping is direct:
+/// storage slot 0 = Call Pet 1, storage slot 1 = Call Pet 2, etc.
+enum PetStableSlot
+{
+    PET_SLOT_FIRST             = 0,
+    PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
+};
+
+/// @brief Flag bits for the per-pet status field in MSG_LIST_STABLED_PETS.
+///
+/// Sent for every pet in the stable list. PET_STABLE_ACTIVE marks the
+/// pet as part of the Call Pet roster (always set in 4.3.4 since every
+/// stored slot is callable). PET_STABLE_INACTIVE is reserved for
+/// stable-only slots beyond the active range and is not produced by
+/// the current data model; the bit is kept for forward parity with TC's
+/// Cata layout, which expects the field to be present and bit-coded.
+enum PetStableFlags
+{
+    PET_STABLE_ACTIVE   = 1,
+    PET_STABLE_INACTIVE = 2
+};
+
 // There might be a lot more
 /// @brief Pet mode flags enumeration.
 ///

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -103,7 +103,9 @@ enum PetSaveMode
 enum PetStableSlot
 {
     PET_SLOT_FIRST             = 0,
-    PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
+    PET_SLOT_LAST_ACTIVE_SLOT  = 4,   ///< Inclusive. Slots 0..4 = Call Pet 1..5 (callable anywhere).
+    PET_SLOT_FIRST_STABLE_SLOT = 5,
+    PET_SLOT_LAST_STABLE_SLOT  = 20   ///< Inclusive. Slots 5..20 = stable-only (no Call Pet; require stable master interaction to move out). Mirrors TC-Preservation 4.3.4 PetDefines.h.
 };
 
 /// @brief Flag bits for the per-pet status field in MSG_LIST_STABLED_PETS.

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -219,6 +219,16 @@ class Pet : public Creature
         void SavePetToDB(PetSaveMode mode);
         void Unsummon(PetSaveMode mode, Unit* owner = NULL);
 
+        /// Active-roster slot this pet currently occupies in
+        /// `character_pet.slot` (0..PET_SLOT_LAST_ACTIVE_SLOT for Cata
+        /// Call Pet 1..N), or -1 when the pet has never been loaded
+        /// from or saved to the database. Populated by future commits
+        /// in this branch -- see MANGOS/PET_SAVE_CALLSITE_AUDIT.md.
+        /// Reading it from existing code is harmless: the default
+        /// value -1 means "no known slot," which is the right answer
+        /// before any caller has supplied one.
+        int32 GetSlot() const { return m_petSlot; }
+
         static void DeleteFromDB(uint32 guidlow, bool separate_transaction = true);
 
         void SetDeathState(DeathState s) override;          // overwrite virtual Creature::SetDeathState and Unit::SetDeathState
@@ -369,6 +379,7 @@ class Pet : public Creature
         PetType m_petType;
         int32   m_duration;                                 // time until unsummon (used mostly for summoned guardians and not used for controlled pets)
         int32   m_bonusdamage;
+        int32   m_petSlot;                                  ///< character_pet.slot value: 0..PET_SLOT_LAST_ACTIVE_SLOT for Cata Call Pet 1..N; -1 when unassigned. Read via GetSlot().
         uint64  m_auraUpdateMask;
         bool    m_loading;
 

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -86,6 +86,30 @@ enum PetSaveMode
     PET_SAVE_REAGENTS          =  101                       // PET_SAVE_NOT_IN_SLOT with reagents return
 };
 
+/// @brief Cata Call Pet 1..5 slot model.
+///
+/// Cata 4.3.4 lets a hunter address up to five pets via the Call Pet 1-5
+/// spell family (883, 83242, 83243, 83244, 83245). Each spell encodes its
+/// target slot index in `SpellEffectEntry::EffectBasePoints` -- Call Pet 1
+/// -> 0, Call Pet 5 -> 4. These constants name the active-roster range
+/// independently of `PetSaveMode` (which is the on-disk
+/// `character_pet.slot` value: 0 = current pet, 1..MAX_PET_STABLES = stable
+/// slots). In Cata the two ranges map 1:1 onto each other -- storage slot
+/// 0 = Call Pet 1, storage slot 1 = Call Pet 2, ... -- but the slot model
+/// is named separately so the multi-pet code can grep for it without
+/// touching the legacy save-mode call sites.
+///
+/// Declared in this commit but not yet referenced by any caller. Subsequent
+/// commits (see MANGOS/PET_SAVE_CALLSITE_AUDIT.md) add the m_petSlot
+/// member, the LoadPetFromDB slot parameter, the PET_SAVE_NEW_PET save
+/// mode, and the EffectSummonPet routing that decode EffectBasePoints
+/// against this range.
+enum PetStableSlot
+{
+    PET_SLOT_FIRST             = 0,
+    PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
+};
+
 // There might be a lot more
 /// @brief Pet mode flags enumeration.
 ///

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -83,7 +83,8 @@ enum PetSaveMode
     PET_SAVE_FIRST_STABLE_SLOT =  1,
     PET_SAVE_LAST_STABLE_SLOT  =  MAX_PET_STABLES,          // last in DB stable slot index (including), all higher have same meaning as PET_SAVE_NOT_IN_SLOT
     PET_SAVE_NOT_IN_SLOT       =  100,                      // for avoid conflict with stable size grow will use 100
-    PET_SAVE_REAGENTS          =  101                       // PET_SAVE_NOT_IN_SLOT with reagents return
+    PET_SAVE_REAGENTS          =  101,                      // PET_SAVE_NOT_IN_SLOT with reagents return
+    PET_SAVE_NEW_PET           =  102                       ///< Cata tame: ask SavePetToDB to allocate the next free active slot 0..PET_SLOT_LAST_ACTIVE_SLOT and rewrite this mode in place. Returns with m_petSlot == PET_SAVE_NOT_IN_SLOT and no row written when the active roster is full -- caller checks via GetSlot().
 };
 
 /// @brief Cata Call Pet 1..5 slot model.

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -215,7 +215,19 @@ class Pet : public Creature
 
         bool Create(uint32 guidlow, CreatureCreatePos& cPos, CreatureInfo const* cinfo, uint32 pet_number);
         bool CreateBaseAtCreature(Creature* creature);
-        bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false);
+        /// Load a pet row from `character_pet` into this Pet instance.
+        ///
+        /// Resolution priority (first non-default selector wins):
+        ///   1. `petnumber > 0`    -> exact row by id
+        ///   2. `current == true`  -> the row at PET_SAVE_AS_CURRENT (legacy WotLK single-pet flow)
+        ///   3. `slot >= 0`        -> the row at character_pet.slot == slot (Cata Call Pet 1..N routing)
+        ///   4. `petentry > 0`     -> any row matching the creature entry (warlock summon)
+        ///   5. otherwise          -> the active or orphan pet (legacy fallback)
+        ///
+        /// `m_petSlot` is captured from the loaded row regardless of which
+        /// branch fired, so subsequent re-saves know which slot to write
+        /// back to.
+        bool LoadPetFromDB(Player* owner, uint32 petentry = 0, uint32 petnumber = 0, bool current = false, int32 slot = -1);
         void SavePetToDB(PetSaveMode mode);
         void Unsummon(PetSaveMode mode, Unit* owner = NULL);
 

--- a/src/game/Object/Pet.h
+++ b/src/game/Object/Pet.h
@@ -98,27 +98,8 @@ enum PetSaveMode
 /// slots). In Cata the two ranges map 1:1 onto each other -- storage slot
 /// 0 = Call Pet 1, storage slot 1 = Call Pet 2, ... -- but the slot model
 /// is named separately so the multi-pet code can grep for it without
-/// touching the legacy save-mode call sites.
-///
-/// Declared in this commit but not yet referenced by any caller. Subsequent
-/// commits (see MANGOS/PET_SAVE_CALLSITE_AUDIT.md) add the m_petSlot
-/// member, the LoadPetFromDB slot parameter, the PET_SAVE_NEW_PET save
-/// mode, and the EffectSummonPet routing that decode EffectBasePoints
-/// against this range.
-enum PetStableSlot
-{
-    PET_SLOT_FIRST             = 0,
-    PET_SLOT_LAST_ACTIVE_SLOT  = 4    ///< Inclusive. Slots 0..4 = Call Pet 1..5.
-};
-
-/// @brief Cata Call Pet slot model used in MSG_LIST_STABLED_PETS.
-///
-/// Cata 4.3.4 lets a hunter address up to five pets via the Call Pet 1-5
-/// spell family. The client identifies each pet in the stable payload by
-/// a slot index in this range. Distinct from PetSaveMode, which is the
-/// on-disk character_pet.slot value (PET_SAVE_AS_CURRENT for the live
-/// pet, 1..MAX_PET_STABLES for stabled pets). The mapping is direct:
-/// storage slot 0 = Call Pet 1, storage slot 1 = Call Pet 2, etc.
+/// touching the legacy save-mode call sites. Also consumed by the Cata
+/// CMSG_STABLE_PET handler and the MSG_LIST_STABLED_PETS packet shape.
 enum PetStableSlot
 {
     PET_SLOT_FIRST             = 0,
@@ -269,6 +250,14 @@ class Pet : public Creature
         /// value -1 means "no known slot," which is the right answer
         /// before any caller has supplied one.
         int32 GetSlot() const { return m_petSlot; }
+
+        /// Move this in-world Pet to a different character_pet.slot value.
+        /// Used by the CMSG_STABLE_PET Cata handler when the player drags
+        /// the currently summoned pet to a different Call Pet 1..N pane.
+        /// Does NOT persist the change on its own -- the caller is expected
+        /// to follow up with SavePetToDB(PET_SAVE_AS_CURRENT), which will
+        /// route through the m_petSlot intercept and write the new slot.
+        void SetSlot(int32 slot) { m_petSlot = slot; }
 
         static void DeleteFromDB(uint32 guidlow, bool separate_transaction = true);
 

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -744,8 +744,9 @@ void InitializeOpcodes()
     // HandleBuyStableSlot in NPCHandler.cpp is a CheckStableMaster stub.
     //OPCODE(CMSG_BUY_STABLE_SLOT,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleBuyStableSlot             );
     OPCODE(SMSG_STABLE_RESULT,                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    OPCODE(CMSG_STABLE_REVIVE_PET,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableRevivePet           );
-    OPCODE(CMSG_STABLE_SWAP_PET,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableSwapPet             );
+    //OPCODE(CMSG_STABLE_REVIVE_PET,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableRevivePet           );
+    //OPCODE(CMSG_STABLE_SWAP_PET,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStableSwapPet             );
+    OPCODE(CMSG_SET_PET_SLOT,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleStablePet                 );
     OPCODE(MSG_QUEST_PUSH_RESULT,                        STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleQuestPushResult           );
     OPCODE(SMSG_PLAY_MUSIC,                              STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_PLAY_OBJECT_SOUND,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -701,6 +701,7 @@ enum OpcodesList
     SMSG_STABLE_RESULT                                    = 0x2204, // 4.3.4 15595
     CMSG_STABLE_REVIVE_PET                                = 0x1275,
     CMSG_STABLE_SWAP_PET                                  = 0x1276,
+    CMSG_SET_PET_SLOT                                     = 0x3A04, // 4.3.4 15595 -- Cata stable drag-and-drop; supersedes CMSG_STABLE_PET/UNSTABLE_PET/SWAP_PET
     MSG_QUEST_PUSH_RESULT                                 = 0x4515, // 4.3.4 15595
     SMSG_PLAY_MUSIC                                       = 0x4B06, // 4.3.4 15595
     SMSG_PLAY_OBJECT_SOUND                                = 0x2635, // 4.3.4 15595

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -680,31 +680,46 @@ void WorldSession::SendStablePet(ObjectGuid guid)
 {
     DEBUG_LOG("WORLD: Recv MSG_LIST_STABLED_PETS Send.");
 
+    // Cata 4.3.4 MSG_LIST_STABLED_PETS payload layout (mirrors TC):
+    //   uint64  stablemaster guid
+    //   uint8   pet count (N)
+    //   uint8   slot count exposed to client (PET_SLOT_LAST_ACTIVE_SLOT + 1)
+    //   N times:
+    //     int32  petSlot              -- Call Pet 1..5 == slots 0..4
+    //     uint32 petNumber            -- character_pet.id
+    //     uint32 creatureEntry        -- character_pet.entry
+    //     uint32 petLevel             -- character_pet.level
+    //     string name                 -- character_pet.name
+    //     uint8  flags                -- PET_STABLE_ACTIVE [| PET_STABLE_INACTIVE]
+    //
+    // The pre-Cata layout (no slot field, magic status byte 1/2/3) is
+    // what the WotLK client expects; the Cata client misreads it field-
+    // for-field and renders the wrong pet name/level/entry in each pane.
     WorldPacket data(MSG_LIST_STABLED_PETS, 200);           // guess size
     data << guid;
 
     Pet* pet = _player->GetPet();
 
     size_t wpos = data.wpos();
-    data << uint8(0);                                       // place holder for slot show number
-
-    data << uint8(GetPlayer()->GetStableSlots());
+    data << uint8(0);                                       // place holder for pet count
+    data << uint8(PET_SLOT_LAST_ACTIVE_SLOT + 1);           // slots exposed to client = 5
 
     uint8 num = 0;                                          // counter for place holder
 
     // not let move dead pet in slot
     if (pet && pet->IsAlive() && pet->getPetType() == HUNTER_PET)
     {
+        data << int32(PET_SLOT_FIRST);                      // active pet always lives in slot 0 (Call Pet 1)
         data << uint32(pet->GetCharmInfo()->GetPetNumber());
         data << uint32(pet->GetEntry());
         data << uint32(pet->getLevel());
-        data << pet->GetName();                             // petname
-        data << uint8(1);                                   // 1 = current, 2/3 = in stable (any from 4,5,... create problems with proper show)
+        data << pet->GetName();
+        data << uint8(PET_STABLE_ACTIVE);
         ++num;
     }
 
-    //                                                      0        1     2        3        4
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
+    //                                                      0        1     2        3        4       5
+    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
                           _player->GetGUIDLow(), PET_SAVE_FIRST_STABLE_SLOT, PET_SAVE_LAST_STABLE_SLOT);
 
     if (result)
@@ -713,11 +728,23 @@ void WorldSession::SendStablePet(ObjectGuid guid)
         {
             Field* fields = result->Fetch();
 
+            // character_pet.slot 1..MAX_PET_STABLES maps directly onto
+            // Call Pet 2..N+1 in the Cata client. Pets stored beyond the
+            // Call Pet range get PET_STABLE_INACTIVE for forward parity,
+            // even though 4.3.4 has no such slots today.
+            uint32 petSlot = fields[5].GetUInt32();
+            uint8 flags = PET_STABLE_ACTIVE;
+            if (petSlot > uint32(PET_SLOT_LAST_ACTIVE_SLOT))
+            {
+                flags |= PET_STABLE_INACTIVE;
+            }
+
+            data << int32(petSlot);
             data << uint32(fields[1].GetUInt32());          // petnumber
             data << uint32(fields[2].GetUInt32());          // creature entry
             data << uint32(fields[3].GetUInt32());          // level
             data << fields[4].GetString();                  // name
-            data << uint8(2);                               // 1 = current, 2/3 = in stable (any from 4,5,... create problems with proper show)
+            data << uint8(flags);
 
             ++num;
         }

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -827,16 +827,37 @@ bool WorldSession::CheckStableMaster(ObjectGuid guid)
 }
 
 /**
- * @brief Moves the current hunter pet into the stable.
+ * @brief Moves a hunter pet between Call Pet 1..N slots (Cata payload).
  *
  * @param recv_data The received opcode packet.
+ *
+ * Cata 4.3.4 reuses the CMSG_STABLE_PET opcode value but ships a
+ * completely different payload: a pet number, a destination slot
+ * index, and a bit-packed stable-master guid. The drag-and-drop
+ * stable UI sends one of these per move. The legacy WotLK semantics
+ * (`stable my current pet into the first free stable slot`) are
+ * gone -- there is no "stable" vs "active" distinction in 4.3.4
+ * since every slot is callable from anywhere.
+ *
+ * Payload layout (matches TC-Preservation 4.3.4
+ * `Handlers/NPCHandler.cpp::HandleSetPetSlot`):
+ *   uint32  petId
+ *   uint8   new_slot
+ *   bits    stable-master guid mask  (3,2,0,7,5,6,1,4)
+ *   bytes   stable-master guid bytes (5,3,1,7,4,0,6,2)
  */
 void WorldSession::HandleStablePet(WorldPacket& recv_data)
 {
-    DEBUG_LOG("WORLD: Recv CMSG_STABLE_PET");
-    ObjectGuid npcGUID;
+    DEBUG_LOG("WORLD: Recv CMSG_STABLE_PET (Cata payload)");
 
-    recv_data >> npcGUID;
+    uint32 petId;
+    uint8 new_slot;
+    ObjectGuid guid;
+
+    recv_data >> petId >> new_slot;
+
+    recv_data.ReadGuidMask<3, 2, 0, 7, 5, 6, 1, 4>(guid);
+    recv_data.ReadGuidBytes<5, 3, 1, 7, 4, 0, 6, 2>(guid);
 
     if (!GetPlayer()->IsAlive())
     {
@@ -844,56 +865,114 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         return;
     }
 
-    if (!CheckStableMaster(npcGUID))
+    if (!CheckStableMaster(guid))
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
     }
 
+    if (new_slot > uint8(PET_SLOT_LAST_ACTIVE_SLOT))
+    {
+        SendStableResult(STABLE_ERR_STABLE);
+        return;
+    }
+
+    // Look up the source pet by petId. Verify it belongs to this
+    // player so a forged packet can't reassign another character's
+    // pet. Capture the creature entry and the current slot for the
+    // tameable-exotic check and the swap logic below.
+    QueryResult* result = CharacterDatabase.PQuery(
+        "SELECT `entry`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `id` = '%u'",
+        _player->GetGUIDLow(), petId);
+    if (!result)
+    {
+        SendStableResult(STABLE_ERR_STABLE);
+        return;
+    }
+
+    Field* fields = result->Fetch();
+    uint32 creatureEntry = fields[0].GetUInt32();
+    int32 old_slot = int32(fields[1].GetUInt32());
+    delete result;
+
+    CreatureInfo const* creatureInfo = ObjectMgr::GetCreatureTemplate(creatureEntry);
+    if (!creatureInfo || !creatureInfo->isTameable(true))
+    {
+        SendStableResult(STABLE_ERR_STABLE);
+        return;
+    }
+    if (!creatureInfo->isTameable(_player->CanTameExoticPets()))
+    {
+        SendStableResult(STABLE_ERR_EXOTIC);
+        return;
+    }
+
+    // Currently summoned pet must be alive AND must be a hunter pet
+    // before any move is attempted: dragging a dead pet around the
+    // panel is a client-side mistake the server has to reject.
     Pet* pet = _player->GetPet();
-
-    // can't place in stable dead pet
-    if (!pet || !pet->IsAlive() || pet->getPetType() != HUNTER_PET)
+    if (pet && pet->GetCharmInfo()->GetPetNumber() == petId
+        && (!pet->IsAlive() || pet->getPetType() != HUNTER_PET))
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
     }
 
-    uint32 free_slot = 1;
-
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`,`slot`,`id` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
-                          _player->GetGUIDLow(), PET_SAVE_FIRST_STABLE_SLOT, PET_SAVE_LAST_STABLE_SLOT);
-    if (result)
+    // No-op when the source pet is already at new_slot. Acknowledge
+    // success so the client UI settles.
+    if (old_slot == int32(new_slot))
     {
-        do
-        {
-            Field* fields = result->Fetch();
-
-            uint32 slot = fields[1].GetUInt32();
-
-            // slots ordered in query, and if not equal then free
-            if (slot != free_slot)
-            {
-                break;
-            }
-
-            // this slot not free, skip
-            ++free_slot;
-        }
-        while (result->NextRow());
-
-        delete result;
-    }
-
-    if (free_slot > 0 && free_slot <= GetPlayer()->GetStableSlots())
-    {
-        pet->Unsummon(PetSaveMode(free_slot), _player);
         SendStableResult(STABLE_SUCCESS_STABLE);
+        SendStablePet(guid);
+        return;
     }
-    else
+
+    // Find the pet (if any) currently occupying new_slot, so we can
+    // swap their slots atomically. character_pet has no unique key
+    // on (owner, slot) so we have to walk it explicitly.
+    QueryResult* swapResult = CharacterDatabase.PQuery(
+        "SELECT `id` FROM `character_pet` WHERE `owner` = '%u' AND `slot` = '%u' AND `id` <> '%u'",
+        _player->GetGUIDLow(), uint32(new_slot), petId);
+    uint32 displacedPetId = 0;
+    if (swapResult)
     {
-        SendStableResult(STABLE_ERR_STABLE);
+        displacedPetId = swapResult->Fetch()[0].GetUInt32();
+        delete swapResult;
     }
+
+    CharacterDatabase.BeginTransaction();
+    if (displacedPetId)
+    {
+        CharacterDatabase.PExecute(
+            "UPDATE `character_pet` SET `slot` = '%u' WHERE `owner` = '%u' AND `id` = '%u'",
+            uint32(old_slot), _player->GetGUIDLow(), displacedPetId);
+    }
+    CharacterDatabase.PExecute(
+        "UPDATE `character_pet` SET `slot` = '%u' WHERE `owner` = '%u' AND `id` = '%u'",
+        uint32(new_slot), _player->GetGUIDLow(), petId);
+    CharacterDatabase.CommitTransaction();
+
+    // Keep the in-world Pet's m_petSlot in sync so any subsequent
+    // SavePetToDB(PET_SAVE_AS_CURRENT) writes the new slot back via
+    // the multi-pet intercept. Cover both the case where the moved
+    // pet is the active pet AND the case where the displaced pet
+    // was the active pet.
+    if (pet)
+    {
+        if (pet->GetCharmInfo()->GetPetNumber() == petId)
+        {
+            pet->SetSlot(int32(new_slot));
+        }
+        else if (displacedPetId && pet->GetCharmInfo()->GetPetNumber() == displacedPetId)
+        {
+            pet->SetSlot(old_slot);
+        }
+    }
+
+    SendStableResult(STABLE_SUCCESS_STABLE);
+    // Refresh the stable panel so the client sees the new layout
+    // without waiting for the next interaction.
+    SendStablePet(guid);
 }
 
 /**

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -907,14 +907,17 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         return;
     }
 
-    // Currently summoned pet must be alive AND must be a hunter pet
-    // before any move is attempted: dragging a dead pet around the
-    // panel is a client-side mistake the server has to reject.
+    // Retail Cata workflow: the currently summoned pet cannot have
+    // its slot changed -- the player must dismiss it first. Reject
+    // any drag operation whose source pet is the active in-world
+    // pet so the client surfaces the "That slot is locked" message
+    // via STABLE_INVALID_SLOT and the user knows to dismiss.
+    // The displaced-pet equivalent of this check fires below, after
+    // we know which pet (if any) sits at new_slot.
     Pet* pet = _player->GetPet();
-    if (pet && pet->GetCharmInfo()->GetPetNumber() == petId
-        && (!pet->IsAlive() || pet->getPetType() != HUNTER_PET))
+    if (pet && pet->GetCharmInfo()->GetPetNumber() == petId)
     {
-        SendStableResult(STABLE_ERR_STABLE);
+        SendStableResult(STABLE_INVALID_SLOT);
         return;
     }
 
@@ -938,6 +941,16 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
     {
         displacedPetId = swapResult->Fetch()[0].GetUInt32();
         delete swapResult;
+    }
+
+    // Symmetric to the active-pet check above: if the swap would
+    // shove the currently summoned pet into a different slot, refuse
+    // until the player dismisses it. The active pet's slot may not
+    // change while it is in world.
+    if (pet && displacedPetId && pet->GetCharmInfo()->GetPetNumber() == displacedPetId)
+    {
+        SendStableResult(STABLE_INVALID_SLOT);
+        return;
     }
 
     CharacterDatabase.BeginTransaction();

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -709,7 +709,20 @@ void WorldSession::SendStablePet(ObjectGuid guid)
     // not let move dead pet in slot
     if (pet && pet->IsAlive() && pet->getPetType() == HUNTER_PET)
     {
-        data << int32(PET_SLOT_FIRST);                      // active pet always lives in slot 0 (Call Pet 1)
+        // Use the pet's actual stored slot, not a hardcoded slot 0.
+        // Under the Cata multi-pet model the currently summoned pet
+        // can live in any active slot 0..PET_SLOT_LAST_ACTIVE_SLOT --
+        // emitting the wrong slot here would render the active pet in
+        // the wrong stable pane. Falls back to PET_SLOT_FIRST when
+        // m_petSlot is -1 (pet object that has never round-tripped
+        // through LoadPetFromDB or SavePetToDB -- pre-Cata single-pet
+        // legacy path).
+        int32 activeSlot = pet->GetSlot();
+        if (activeSlot < int32(PET_SLOT_FIRST) || activeSlot > int32(PET_SLOT_LAST_ACTIVE_SLOT))
+        {
+            activeSlot = int32(PET_SLOT_FIRST);
+        }
+        data << int32(activeSlot);
         data << uint32(pet->GetCharmInfo()->GetPetNumber());
         data << uint32(pet->GetEntry());
         data << uint32(pet->getLevel());
@@ -718,9 +731,22 @@ void WorldSession::SendStablePet(ObjectGuid guid)
         ++num;
     }
 
+    // Query covers the entire active-roster range (slot 0..MAX) instead
+    // of starting at PET_SAVE_FIRST_STABLE_SLOT. Pre-Cata the slot-0
+    // branch was exclusively the currently summoned pet (one active pet
+    // per character) so the legacy query intentionally skipped it.
+    // Under Cata multi-pet a hunter can have multiple pets in
+    // 0..PET_SLOT_LAST_ACTIVE_SLOT and any of them can be dismissed --
+    // the dismissed ones still belong in the stable panel, just not as
+    // the active pet. Excluding the currently summoned pet's id
+    // prevents emitting it twice (once from the active branch above,
+    // once from this query). When no pet is summoned the WHERE id <> 0
+    // matches every row because character_pet.id is never zero.
+    uint32 activePetId = pet ? pet->GetCharmInfo()->GetPetNumber() : 0;
+
     //                                                      0        1     2        3        4       5
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' ORDER BY `slot`",
-                          _player->GetGUIDLow(), PET_SAVE_FIRST_STABLE_SLOT, PET_SAVE_LAST_STABLE_SLOT);
+    QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' AND `id` <> '%u' ORDER BY `slot`",
+                          _player->GetGUIDLow(), PET_SAVE_AS_CURRENT, PET_SAVE_LAST_STABLE_SLOT, activePetId);
 
     if (result)
     {

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -702,7 +702,11 @@ void WorldSession::SendStablePet(ObjectGuid guid)
 
     size_t wpos = data.wpos();
     data << uint8(0);                                       // place holder for pet count
-    data << uint8(PET_SLOT_LAST_ACTIVE_SLOT + 1);           // slots exposed to client = 5
+    // Tell the client how many stable-slot panes to draw. TC sends
+    // PET_SLOT_LAST_STABLE_SLOT (=20) literally; mirror that so the
+    // 4.3.4 client renders the full stable grid and the drag-and-drop
+    // targets in slots 5..20 are valid drop zones.
+    data << uint8(PET_SLOT_LAST_STABLE_SLOT);
 
     uint8 num = 0;                                          // counter for place holder
 
@@ -744,9 +748,16 @@ void WorldSession::SendStablePet(ObjectGuid guid)
     // matches every row because character_pet.id is never zero.
     uint32 activePetId = pet ? pet->GetCharmInfo()->GetPetNumber() : 0;
 
+    // Query the full Cata slot range 0..PET_SLOT_LAST_STABLE_SLOT
+    // (=20), not just the legacy PET_SAVE_LAST_STABLE_SLOT
+    // (=MAX_PET_STABLES). Slots 5..20 are stable-only positions the
+    // Cata stable UI displays and the player drags pets into via
+    // CMSG_SET_PET_SLOT. Restricting the query to 0..4 like the
+    // pre-Cata code would make any stable-only pet vanish from the
+    // panel the moment the player dragged it past slot 4.
     //                                                      0        1     2        3        4       5
     QueryResult* result = CharacterDatabase.PQuery("SELECT `owner`, `id`, `entry`, `level`, `name`, `slot` FROM `character_pet` WHERE `owner` = '%u' AND `slot` >= '%u' AND `slot` <= '%u' AND `id` <> '%u' ORDER BY `slot`",
-                          _player->GetGUIDLow(), PET_SAVE_AS_CURRENT, PET_SAVE_LAST_STABLE_SLOT, activePetId);
+                          _player->GetGUIDLow(), uint32(PET_SLOT_FIRST), uint32(PET_SLOT_LAST_STABLE_SLOT), activePetId);
 
     if (result)
     {
@@ -871,7 +882,16 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         return;
     }
 
-    if (new_slot > uint8(PET_SLOT_LAST_ACTIVE_SLOT))
+    // Slot range goes up to PET_SLOT_LAST_STABLE_SLOT (=20), not just
+    // PET_SLOT_LAST_ACTIVE_SLOT (=4). The Cata client uses slots 0..4
+    // for the Call Pet 1..5 active roster and 5..20 for stable-only
+    // pets that need a stable master interaction to move out. Drag-
+    // and-drop in the stable UI sends new_slot values across the full
+    // 0..20 range -- a wire-capture of drag operations against
+    // mangosthree confirmed values up to 0x0F. Reject only the
+    // genuinely out-of-range case so the storage layer doesn't end
+    // up with nonsensical slot indices.
+    if (new_slot > uint8(PET_SLOT_LAST_STABLE_SLOT))
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -7596,8 +7596,27 @@ SpellCastResult Spell::CheckCast(bool strict)
                     }
                     else
                     {
+                        // Cata Call Pet 1..5 spells (883, 83242, 83243,
+                        // 83244, 83245) encode the target slot in the
+                        // EffectBasePoints of effect index 0 -- Call Pet 1
+                        // resolves to slot 0, ... Call Pet 5 to slot 4.
+                        // Pre-Cata hunter pet-summon spells (legacy WotLK
+                        // content, scripted summons) leave EffectMiscValue
+                        // non-zero or BasePoints outside the active range,
+                        // and fall back to slot 0 so existing single-pet
+                        // hunters keep working.
+                        int32 callSlot = 0;
+                        if (SpellEffectEntry const* eff = m_spellInfo->GetSpellEffect(EFFECT_INDEX_0))
+                        {
+                            if (eff->EffectMiscValue == 0
+                                && eff->EffectBasePoints >= 0
+                                && eff->EffectBasePoints <= PET_SLOT_LAST_ACTIVE_SLOT)
+                            {
+                                callSlot = eff->EffectBasePoints;
+                            }
+                        }
                         Pet* dbPet = new Pet;
-                        if (dbPet->LoadPetFromDB((Player*)m_caster, 0))
+                        if (dbPet->LoadPetFromDB((Player*)m_caster, 0, 0, false, callSlot))
                         {
                             return SPELL_CAST_OK;           // still returns an error to the player, so this error must come from somewhere else...
                         }

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -7302,6 +7302,30 @@ SpellCastResult Spell::CheckCast(bool strict)
                     return SPELL_FAILED_DONT_REPORT;
                 }
 
+                // Cata multi-pet roster guard: reject the cast up front
+                // if every Call Pet 1..N slot is already occupied. Without
+                // this check the 6-second Tame Beast channel completes
+                // before EffectTameCreature's SavePetToDB(PET_SAVE_NEW_PET)
+                // discovers the roster is full -- by which time the source
+                // creature has been ForcedDespawned and another hunter may
+                // already have it. The post-channel rollback in
+                // EffectTameCreature stays as a defensive safety net for
+                // any race between cast-start and effect-time (player
+                // gains a pet mid-cast somehow), but the user-visible
+                // failure now fires immediately.
+                if (QueryResult* roster = CharacterDatabase.PQuery(
+                        "SELECT COUNT(*) FROM `character_pet` WHERE `owner` = '%u' AND `slot` <= '%u'",
+                        plrCaster->GetGUIDLow(), uint32(PET_SLOT_LAST_ACTIVE_SLOT)))
+                {
+                    uint32 owned = roster->Fetch()[0].GetUInt32();
+                    delete roster;
+                    if (owned > uint32(PET_SLOT_LAST_ACTIVE_SLOT))
+                    {
+                        plrCaster->SendPetTameFailure(PETTAME_TOOMANY);
+                        return SPELL_FAILED_DONT_REPORT;
+                    }
+                }
+
                 break;
             }
             case SPELL_EFFECT_LEARN_SPELL:

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -7607,48 +7607,62 @@ SpellCastResult Spell::CheckCast(bool strict)
                 uint32 plClass = m_caster->getClass();
                 if (plClass == CLASS_HUNTER)
                 {
-                    if (Creature* pet = m_caster->GetPet())
+                    // Cata Call Pet 1..5 spells (883, 83242, 83243,
+                    // 83244, 83245) encode the target slot in
+                    // EffectBasePoints of effect index 0 -- Call Pet 1
+                    // resolves to slot 0, ... Call Pet 5 to slot 4.
+                    // Pre-Cata hunter pet-summon spells (legacy WotLK
+                    // content, scripted summons) leave EffectMiscValue
+                    // non-zero or BasePoints outside the active range
+                    // and fall back to slot 0 so existing single-pet
+                    // hunters keep working.
+                    int32 callSlot = 0;
+                    if (SpellEffectEntry const* eff = m_spellInfo->GetSpellEffect(EFFECT_INDEX_0))
                     {
-                        if (!pet->IsAlive() || pet->IsDead()) // this one will not play along; tried and retried countless times....
+                        if (eff->EffectMiscValue == 0
+                            && eff->EffectBasePoints >= 0
+                            && eff->EffectBasePoints <= PET_SLOT_LAST_ACTIVE_SLOT)
+                        {
+                            callSlot = eff->EffectBasePoints;
+                        }
+                    }
+
+                    // Cata multi-pet: Call Pet on the same slot as the
+                    // already-summoned pet is a no-op (the pet is
+                    // already out). Call Pet on a different slot
+                    // auto-dismisses the active pet so the new one can
+                    // load. Either way no SPELL_FAILED_ALREADY_HAVE_SUMMON
+                    // error -- that was the WotLK single-pet rule and
+                    // the wrong behaviour for the Cata Call Pet family,
+                    // which is expected to swap pets seamlessly.
+                    if (Pet* activePet = m_caster->GetPet())
+                    {
+                        if (!activePet->IsAlive() || activePet->IsDead())
                         {
                             return SPELL_FAILED_TARGETS_DEAD;
                         }
-                        else
+                        if (activePet->getPetType() == HUNTER_PET
+                            && activePet->GetSlot() == callSlot)
                         {
-                            return SPELL_FAILED_ALREADY_HAVE_SUMMON;
+                            return SPELL_CAST_OK;
                         }
+                        // Different slot requested -- dismiss the active
+                        // pet so the LoadPetFromDB below can place the
+                        // new one. PET_SAVE_AS_CURRENT routes through the
+                        // multi-pet intercept and preserves the dismissed
+                        // pet at its own slot.
+                        activePet->Unsummon(PET_SAVE_AS_CURRENT, m_caster);
+                    }
+
+                    Pet* dbPet = new Pet;
+                    if (dbPet->LoadPetFromDB((Player*)m_caster, 0, 0, false, callSlot))
+                    {
+                        return SPELL_CAST_OK;
                     }
                     else
                     {
-                        // Cata Call Pet 1..5 spells (883, 83242, 83243,
-                        // 83244, 83245) encode the target slot in the
-                        // EffectBasePoints of effect index 0 -- Call Pet 1
-                        // resolves to slot 0, ... Call Pet 5 to slot 4.
-                        // Pre-Cata hunter pet-summon spells (legacy WotLK
-                        // content, scripted summons) leave EffectMiscValue
-                        // non-zero or BasePoints outside the active range,
-                        // and fall back to slot 0 so existing single-pet
-                        // hunters keep working.
-                        int32 callSlot = 0;
-                        if (SpellEffectEntry const* eff = m_spellInfo->GetSpellEffect(EFFECT_INDEX_0))
-                        {
-                            if (eff->EffectMiscValue == 0
-                                && eff->EffectBasePoints >= 0
-                                && eff->EffectBasePoints <= PET_SLOT_LAST_ACTIVE_SLOT)
-                            {
-                                callSlot = eff->EffectBasePoints;
-                            }
-                        }
-                        Pet* dbPet = new Pet;
-                        if (dbPet->LoadPetFromDB((Player*)m_caster, 0, 0, false, callSlot))
-                        {
-                            return SPELL_CAST_OK;           // still returns an error to the player, so this error must come from somewhere else...
-                        }
-                        else
-                        {
-                            delete dbPet;
-                            return SPELL_FAILED_NO_PET;
-                        }
+                        delete dbPet;
+                        return SPELL_FAILED_NO_PET;
                     }
                 }
                 else if (m_caster->GetPetGuid())

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -8032,7 +8032,28 @@ void Spell::EffectTameCreature(SpellEffectEntry const* /*effect*/)
 
     plr->PetSpellInitialize();
 
-    pet->SavePetToDB(PET_SAVE_AS_CURRENT);
+    // Cata Call Pet 1..5 storage: allocate the next free active slot
+    // instead of always overwriting slot 0. SavePetToDB(PET_SAVE_NEW_PET)
+    // resolves into 0..PET_SLOT_LAST_ACTIVE_SLOT via the free-slot scan
+    // added in step 6 of MANGOS/PET_SAVE_CALLSITE_AUDIT.md, and leaves
+    // GetSlot() above PET_SLOT_LAST_ACTIVE_SLOT when the roster is full.
+    // Roll the tame back when that happens: keep the player from owning
+    // a phantom pet that has no character_pet row, and notify the client
+    // with PETTAME_TOOMANY so the UI clears the cast.
+    //
+    // Audit row T1. This is the keystone commit that makes Call Pet 1..5
+    // routing meaningful end-to-end: with this in place each tame writes
+    // to its own slot, step 9's CheckCast slot-decoding retrieves the
+    // right pet, step 5's auto-promote gate keeps it parked during temp
+    // unsummon, and step 8's intercept preserves the slot across
+    // dismiss / re-save / logout.
+    pet->SavePetToDB(PET_SAVE_NEW_PET);
+    if (pet->GetSlot() > PET_SLOT_LAST_ACTIVE_SLOT)
+    {
+        plr->SendPetTameFailure(PETTAME_TOOMANY);
+        pet->Unsummon(PET_SAVE_AS_DELETED, plr);
+        return;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes hunter pet system end-to-end for Cata 4.3.4. Before: only slot 0 worked; tame overwrote previous pet; Call Pet 1-5 all summoned the same pet; stable panel was garbled; drag-and-drop listened on wrong opcode (0x1271 vs Cata's 0x3A04).

After: 5 active slots (0-4) + 16 stable slots (5-20); tame allocates next free slot; Call Pet N summons slot N (auto-dismisses active pet); stable panel renders correctly; drag-and-drop works; slots persist across logout.

## Changes

- Add `PetStableSlot` enum + slot tracking on `Pet` (m_petSlot member, accessors).
- Rewrite `LoadPetFromDB` to respect slot parameter; gate auto-promote-to-slot-0 to non-hunter pets only.
- Add `PET_SAVE_NEW_PET` mode; allocate next free active slot on tame via `EffectTameCreature`.
- Gate Tame Beast cast-start: reject if all 5 active slots full.
- Port `MSG_LIST_STABLED_PETS` to Cata payload shape (slot + flags).
- Rewrite `CMSG_STABLE_PET` (0x1271) handler: decode bit-packed Cata format, guard against swapping summoned pets.
- Register `CMSG_SET_PET_SLOT` (0x3A04) — actual Cata stable opcode.
- Extend stable queries to full 0-20 slot range; show slot-0 pets when dismissed.
- Rewrite `CheckCast` for Call Pet to decode `EffectBasePoints` as slot parameter.

## Testing

Tame 5 pets → dismiss → Call Pet 1-5 each → swap pets in stable → logout/login verify persistence.

Supersedes PR #136 (packet shape included). Cata-only; mangostwo not synced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/138)
<!-- Reviewable:end -->
