### PR TITLE
[Pet] Fall back to family / creature name when LoadPetFromDB row is empty

### DIFF
--- a/src/game/Object/Pet.cpp
+++ b/src/game/Object/Pet.cpp
@@ -219,6 +219,43 @@ bool Pet::LoadPetFromDB(Player* owner, uint32 petentry, uint32 petnumber, bool c
     SetUInt32Value(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_NONE);
     SetName(fields[8].GetString());
 
+    // Defensive name fallback. The starter pet rows created by
+    // WorldSession::HandleCharCreateOpcode (CharacterHandler.cpp) write
+    // `name = ' '` (single space) into character_pet for every race's
+    // hunter starter and the warlock imp. An empty / whitespace-only
+    // name renders client-side as "Unknown's Pet" in unit frames and
+    // produces blank-name rows in the stable list. Any future code path
+    // that persists a Pet row without setting a name lands here too --
+    // this fallback mirrors the family-name logic in CreateBaseAtCreature
+    // (PR #135) so the load path is consistent with the tame path.
+    {
+        bool nameIsBlank = true;
+        for (char const* p = m_name.c_str(); *p; ++p)
+        {
+            if (*p != ' ' && *p != '\t' && *p != '\r' && *p != '\n')
+            {
+                nameIsBlank = false;
+                break;
+            }
+        }
+        if (nameIsBlank)
+        {
+            std::string fallback;
+            if (CreatureFamilyEntry const* cFamily = sCreatureFamilyStore.LookupEntry(creatureInfo->Family))
+            {
+                fallback = cFamily->Name[sWorld.GetDefaultDbcLocale()];
+            }
+            if (fallback.empty() && creatureInfo->Name)
+            {
+                fallback = creatureInfo->Name;
+            }
+            if (!fallback.empty())
+            {
+                SetName(fallback);
+            }
+        }
+    }
+
     SetByteValue(UNIT_FIELD_BYTES_2, 1, UNIT_BYTE2_FLAG_SUPPORTABLE | UNIT_BYTE2_FLAG_AURAS);
     SetUInt32Value(UNIT_FIELD_FLAGS, UNIT_FLAG_PVP_ATTACKABLE);
 


### PR DESCRIPTION
## Summary

Starter pets created by `WorldSession::HandleCharCreateOpcode` write `name = ' '` (single space) into `character_pet` for every race's hunter starter and the warlock imp. The WoW client renders an empty/whitespace name as "Unknown's Pet" in unit frames and as a blank row in the stable list.

Adds a defensive empty-name fallback in `Pet::LoadPetFromDB` after the existing `SetName(fields[8].GetString())`. If the loaded name is blank, derives a fallback from `CreatureFamilyEntry::Name[locale]` (matches the family-name path PR #135 uses for fresh tames), with a secondary fallback to `creature_template.Name`. Only fires when the stored value is blank, so player renames are preserved.

Catches starter pets on first login (named "Wolf", "Bear", "Cat", "Raptor", "Imp", etc.) and any future code path that persists a Pet row without a name.

## Testing

Fresh hunter character of each race → login → starter pet displays family name in unit frame and stable list. Logout/login round-trip preserves the name.

Companion to PR #135 (rare-tame name fallback).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/139)
<!-- Reviewable:end -->
