### PR TITLE
[Player] Trainer level check actually compares player level

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -5284,8 +5284,24 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
     }
 
     // check level requirement
+    //
+    // The previous check `trainer_spell->reqLevel < reqLevel` compared two
+    // values that both derive from trainer_spell itself (the right-hand
+    // `reqLevel` parameter is computed in NPCHandler.cpp as
+    // `max(class-fit reqLevel, trainer_spell->reqLevel)`), so the
+    // comparison was effectively `X < X` -- always false -- and the
+    // player's actual level was never checked. Mirror mangostwo /
+    // TC-Preservation and compare the player's level against the
+    // effective required level instead.
+    //
+    // The bare `prof ||` short-circuit-RED has been dropped: it forced
+    // profession spells to RED unconditionally, which never matched
+    // observed behaviour (the destructive bug was that the level check
+    // was a no-op, masking that line entirely for class spells where
+    // prof == false). mangostwo additionally gates the level check on a
+    // GM-trade-skill-bypass config; that is out of scope here.
     bool prof = SpellMgr::IsProfessionSpell(trainer_spell->spell);
-    if (prof || trainer_spell->reqLevel && (trainer_spell->reqLevel) < reqLevel)
+    if (getLevel() < reqLevel)
     {
         return TRAINER_SPELL_RED;
     }


### PR DESCRIPTION
## Summary

User-reported on a fresh Linux mangosthree install: class trainers offer every spell regardless of player level, and any spell can be learned as long as the player has the gold. Bug has been in the tree since the initial import.

Root cause in `Player::GetTrainerSpellState` (`Player.cpp:5288`):

```cpp
if (prof || trainer_spell->reqLevel && (trainer_spell->reqLevel) < reqLevel)
    return TRAINER_SPELL_RED;
```

Both sides of the `<` derive from `trainer_spell`. The right-hand `reqLevel` parameter is computed by `NPCHandler.cpp` as `max(class-fit reqLevel, trainer_spell->reqLevel)`, so the comparison is effectively `X < X` (always false) or `X < max(X, Y)` (false unless `Y > X`). The player's actual level never enters the check, so the function always falls through to `TRAINER_SPELL_GREEN` for class spells.

Replaced with the canonical mangostwo / TC pattern:

```cpp
if (getLevel() < reqLevel)
    return TRAINER_SPELL_RED;
```

Compares the player's level against the effective required level. Spells now show as red until the player reaches the required level; the downstream `GetTrainerSpellState` check in `HandleTrainerBuySpellOpcode` (`NPCHandler.cpp:376`) then refuses the buy.

`prof` is still computed because it's used by the separate skill check immediately below.

## Test plan

- [x] Build clean (warnings-as-errors)
- [x] In-game verified: low-level character at class trainer no longer sees / can learn over-level spells
- [x] Existing characters above the spell's required level continue to learn normally

Credit: bug reported by community user on a fresh Linux build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/141)
<!-- Reviewable:end -->
