### PR TITLE
[Loot] Deny NPC-killed mobs to player looters (server + visual)

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -1364,7 +1364,13 @@ void Creature::PrepareBodyLootState()
                 // ... or can have skinning after
                 (GetCreatureInfo()->SkinningLootId && sWorld.getConfig(CONFIG_BOOL_CORPSE_EMPTY_LOOT_SHOW)))
         {
-            SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+            // Only show the lootable glitter if a player participated in the kill.
+            // Without a recipient, no player is allowed to loot (see Player::SendLoot
+            // and Player::isAllowedToLoot), so hide the visual cue too.
+            if (HasLootRecipient())
+            {
+                SetFlag(UNIT_DYNAMIC_FLAGS, UNIT_DYNFLAG_LOOTABLE);
+            }
             return;
         }
     }

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -10486,10 +10486,13 @@ void Player::SendLoot(ObjectGuid guid, LootType loot_type)
             {
                 // the player whose group may loot the corpse
                 Player* recipient = creature->GetLootRecipient();
-                if (!recipient)
+                Group* recipientGroup = creature->GetGroupLootRecipient();
+                // no recipient means the kill had no player participation (e.g. NPC-only kill).
+                // Deny loot rather than silently transferring ownership to the first clicker.
+                if (!recipient && !recipientGroup)
                 {
-                    creature->SetLootRecipient(this);
-                    recipient = this;
+                    SendLootRelease(guid);
+                    return;
                 }
 
                 if (creature->lootForPickPocketed)


### PR DESCRIPTION
Fixes two paired bugs surfaced when a friendly NPC solo-killed a hostile mob (no player damage).

**1. Server-side**: `Player::SendLoot` (HIGHGUID_UNIT case) silently set the first clicker as recipient when `GetLootRecipient()` was NULL, so any passerby could loot.
`SetLootRecipient` (`Creature.cpp:1481`) already gates assignment to players and player-controlled pets, so a NULL recipient on a dead creature unambiguously means no player damage landed - deny via `SendLootRelease`.
Matches the TC pattern (`LOOT_ERROR_DIDNT_KILL` when both recipient and group are NULL); mangosthree has no `SendLootError` yet, so `SendLootRelease` is used for consistency with surrounding code.

**2. Visual**: `Creature::PrepareBodyLootState` set `UNIT_DYNFLAG_LOOTABLE` on every loot-bearing corpse regardless of player participation, so NPC-only kills still showed the sparkle and loot cursor even though clicking produced nothing. Gate the flag on `HasLootRecipient()`.

## Test plan
- [x] NPC (guard) solo-kills a mob → no sparkle, no loot cursor, click does nothing.
- [x] Player tags mob with one auto-attack, NPC finishes it → sparkle visible, loot opens normally.
- [x] Solo player kill → loot works as before (regression check).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/142)
<!-- Reviewable:end -->
