### PR TITLE
[Decomp][Player] Cohesion split bundle: corpse-reclaim -> PlayerDeath, quest-status -> PlayerQuest

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -6802,66 +6802,6 @@ void Player::SendAurasForTarget(Unit* target)
     GetSession()->SendPacket(&data);
 }
 
-void Player::SetDailyQuestStatus(uint32 quest_id)
-{
-    for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
-    {
-        if (!GetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx))
-        {
-            SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx, quest_id);
-            m_DailyQuestChanged = true;
-            break;
-        }
-    }
-}
-
-void Player::SetWeeklyQuestStatus(uint32 quest_id)
-{
-    m_weeklyquests.insert(quest_id);
-    m_WeeklyQuestChanged = true;
-}
-
-void Player::SetMonthlyQuestStatus(uint32 quest_id)
-{
-    m_monthlyquests.insert(quest_id);
-    m_MonthlyQuestChanged = true;
-}
-
-void Player::ResetDailyQuestStatus()
-{
-    for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
-    {
-        SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx, 0);
-    }
-
-    // DB data deleted in caller
-    m_DailyQuestChanged = false;
-}
-
-void Player::ResetWeeklyQuestStatus()
-{
-    if (m_weeklyquests.empty())
-    {
-        return;
-    }
-
-    m_weeklyquests.clear();
-    // DB data deleted in caller
-    m_WeeklyQuestChanged = false;
-}
-
-void Player::ResetMonthlyQuestStatus()
-{
-    if (m_monthlyquests.empty())
-    {
-        return;
-    }
-
-    m_monthlyquests.clear();
-    // DB data deleted in caller
-    m_MonthlyQuestChanged = false;
-}
-
 /**
  * @brief Gets the battleground instance the player is currently associated with.
  *

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -128,12 +128,6 @@ enum CharacterCustomizeFlags
     CHAR_CUSTOMIZE_FLAG_RACE            = 0x00100000        // name, gender, race, etc...
 };
 
-// corpse reclaim times
-#define DEATH_EXPIRE_STEP (5*MINUTE)
-#define MAX_DEATH_COUNT 3
-
-static const uint32 corpseReclaimDelay[MAX_DEATH_COUNT] = {30, 60, 120};
-
 //== TradeData =================================================
 
 TradeData* TradeData::GetTraderData() const
@@ -7613,118 +7607,6 @@ void Player::UpdateZoneDependentPets()
 {
     // check pet (permanent pets ignored), minipet, guardians (including protector)
     CallForAllControlledUnits(UpdateZoneDependentPetsHelper(this, m_zoneUpdateId, m_areaUpdateId), CONTROLLED_PET | CONTROLLED_GUARDIANS | CONTROLLED_MINIPET);
-}
-
-/**
- * @brief Gets the current corpse reclaim delay for PvE or PvP death.
- *
- * @param pvp True for PvP death rules; false for PvE death rules.
- * @return The reclaim delay in seconds.
- */
-uint32 Player::GetCorpseReclaimDelay(bool pvp) const
-{
-    if ((pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
-            (!pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
-    {
-        return corpseReclaimDelay[0];
-    }
-
-    time_t now = time(NULL);
-    // 0..2 full period
-    uint32 count = (now < m_deathExpireTime) ? uint32((m_deathExpireTime - now) / DEATH_EXPIRE_STEP) : 0;
-    return corpseReclaimDelay[count];
-}
-
-/**
- * @brief Advances the corpse reclaim delay escalation after death.
- */
-void Player::UpdateCorpseReclaimDelay()
-{
-    bool pvp = m_ExtraFlags & PLAYER_EXTRA_PVP_DEATH;
-
-    if ((pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
-            (!pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
-    {
-        return;
-    }
-
-    time_t now = time(NULL);
-    if (now < m_deathExpireTime)
-    {
-        // full and partly periods 1..3
-        uint32 count = uint32((m_deathExpireTime - now) / DEATH_EXPIRE_STEP + 1);
-        if (count < MAX_DEATH_COUNT)
-        {
-            m_deathExpireTime = now + (count + 1) * DEATH_EXPIRE_STEP;
-        }
-        else
-        {
-            m_deathExpireTime = now + MAX_DEATH_COUNT * DEATH_EXPIRE_STEP;
-        }
-    }
-    else
-    {
-        m_deathExpireTime = now + DEATH_EXPIRE_STEP;
-    }
-}
-
-/**
- * @brief Sends the current corpse reclaim delay to the client.
- *
- * @param load True when restoring the delay from saved corpse state.
- */
-void Player::SendCorpseReclaimDelay(bool load)
-{
-    Corpse* corpse = GetCorpse();
-    if (!corpse)
-    {
-        return;
-    }
-
-    uint32 delay;
-    if (load)
-    {
-        if (corpse->GetGhostTime() > m_deathExpireTime)
-        {
-            return;
-        }
-
-        bool pvp = corpse->GetType() == CORPSE_RESURRECTABLE_PVP;
-
-        uint32 count;
-        if ((pvp && sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
-                (!pvp && sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
-        {
-            count = uint32(m_deathExpireTime - corpse->GetGhostTime()) / DEATH_EXPIRE_STEP;
-            if (count >= MAX_DEATH_COUNT)
-            {
-                count = MAX_DEATH_COUNT - 1;
-            }
-        }
-        else
-        {
-            count = 0;
-        }
-
-        time_t expected_time = corpse->GetGhostTime() + corpseReclaimDelay[count];
-
-        time_t now = time(NULL);
-        if (now >= expected_time)
-        {
-            return;
-        }
-
-        delay = uint32(expected_time - now);
-    }
-    else
-    {
-        delay = GetCorpseReclaimDelay(corpse->GetType() == CORPSE_RESURRECTABLE_PVP);
-    }
-
-    //! corpse reclaim delay 30 * 1000ms or longer at often deaths
-    WorldPacket data(SMSG_CORPSE_RECLAIM_DELAY, 4);
-    data << uint32(delay * IN_MILLISECONDS);
-    GetSession()->SendPacket(&data);
 }
 
 uint32 Player::GetNextResetTalentsCost()    const

--- a/src/game/Object/PlayerDeath.cpp
+++ b/src/game/Object/PlayerDeath.cpp
@@ -81,6 +81,12 @@
 
 #include <cmath>
 
+// corpse reclaim times
+#define DEATH_EXPIRE_STEP (5*MINUTE)
+#define MAX_DEATH_COUNT 3
+
+static const uint32 corpseReclaimDelay[MAX_DEATH_COUNT] = {30, 60, 120};
+
 /* Preconditions:
   - a resurrectable corpse must not be loaded for the player (only bones)
   - the player must be in world
@@ -407,4 +413,116 @@ void Player::RepopAtGraveyard()
             UpdateVisibilityAndView();
         }
     }
+}
+
+/**
+ * @brief Gets the current corpse reclaim delay for PvE or PvP death.
+ *
+ * @param pvp True for PvP death rules; false for PvE death rules.
+ * @return The reclaim delay in seconds.
+ */
+uint32 Player::GetCorpseReclaimDelay(bool pvp) const
+{
+    if ((pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
+            (!pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
+    {
+        return corpseReclaimDelay[0];
+    }
+
+    time_t now = time(NULL);
+    // 0..2 full period
+    uint32 count = (now < m_deathExpireTime) ? uint32((m_deathExpireTime - now) / DEATH_EXPIRE_STEP) : 0;
+    return corpseReclaimDelay[count];
+}
+
+/**
+ * @brief Advances the corpse reclaim delay escalation after death.
+ */
+void Player::UpdateCorpseReclaimDelay()
+{
+    bool pvp = m_ExtraFlags & PLAYER_EXTRA_PVP_DEATH;
+
+    if ((pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
+            (!pvp && !sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
+    {
+        return;
+    }
+
+    time_t now = time(NULL);
+    if (now < m_deathExpireTime)
+    {
+        // full and partly periods 1..3
+        uint32 count = uint32((m_deathExpireTime - now) / DEATH_EXPIRE_STEP + 1);
+        if (count < MAX_DEATH_COUNT)
+        {
+            m_deathExpireTime = now + (count + 1) * DEATH_EXPIRE_STEP;
+        }
+        else
+        {
+            m_deathExpireTime = now + MAX_DEATH_COUNT * DEATH_EXPIRE_STEP;
+        }
+    }
+    else
+    {
+        m_deathExpireTime = now + DEATH_EXPIRE_STEP;
+    }
+}
+
+/**
+ * @brief Sends the current corpse reclaim delay to the client.
+ *
+ * @param load True when restoring the delay from saved corpse state.
+ */
+void Player::SendCorpseReclaimDelay(bool load)
+{
+    Corpse* corpse = GetCorpse();
+    if (!corpse)
+    {
+        return;
+    }
+
+    uint32 delay;
+    if (load)
+    {
+        if (corpse->GetGhostTime() > m_deathExpireTime)
+        {
+            return;
+        }
+
+        bool pvp = corpse->GetType() == CORPSE_RESURRECTABLE_PVP;
+
+        uint32 count;
+        if ((pvp && sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVP)) ||
+                (!pvp && sWorld.getConfig(CONFIG_BOOL_DEATH_CORPSE_RECLAIM_DELAY_PVE)))
+        {
+            count = uint32(m_deathExpireTime - corpse->GetGhostTime()) / DEATH_EXPIRE_STEP;
+            if (count >= MAX_DEATH_COUNT)
+            {
+                count = MAX_DEATH_COUNT - 1;
+            }
+        }
+        else
+        {
+            count = 0;
+        }
+
+        time_t expected_time = corpse->GetGhostTime() + corpseReclaimDelay[count];
+
+        time_t now = time(NULL);
+        if (now >= expected_time)
+        {
+            return;
+        }
+
+        delay = uint32(expected_time - now);
+    }
+    else
+    {
+        delay = GetCorpseReclaimDelay(corpse->GetType() == CORPSE_RESURRECTABLE_PVP);
+    }
+
+    //! corpse reclaim delay 30 * 1000ms or longer at often deaths
+    WorldPacket data(SMSG_CORPSE_RECLAIM_DELAY, 4);
+    data << uint32(delay * IN_MILLISECONDS);
+    GetSession()->SendPacket(&data);
 }

--- a/src/game/Object/PlayerQuest.cpp
+++ b/src/game/Object/PlayerQuest.cpp
@@ -3105,3 +3105,63 @@ void Player::UpdateForQuestWorldObjects()
     udata.BuildPacket(&packet);
     GetSession()->SendPacket(&packet);
 }
+
+void Player::SetDailyQuestStatus(uint32 quest_id)
+{
+    for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
+    {
+        if (!GetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx))
+        {
+            SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx, quest_id);
+            m_DailyQuestChanged = true;
+            break;
+        }
+    }
+}
+
+void Player::SetWeeklyQuestStatus(uint32 quest_id)
+{
+    m_weeklyquests.insert(quest_id);
+    m_WeeklyQuestChanged = true;
+}
+
+void Player::SetMonthlyQuestStatus(uint32 quest_id)
+{
+    m_monthlyquests.insert(quest_id);
+    m_MonthlyQuestChanged = true;
+}
+
+void Player::ResetDailyQuestStatus()
+{
+    for (uint32 quest_daily_idx = 0; quest_daily_idx < PLAYER_MAX_DAILY_QUESTS; ++quest_daily_idx)
+    {
+        SetUInt32Value(PLAYER_FIELD_DAILY_QUESTS_1 + quest_daily_idx, 0);
+    }
+
+    // DB data deleted in caller
+    m_DailyQuestChanged = false;
+}
+
+void Player::ResetWeeklyQuestStatus()
+{
+    if (m_weeklyquests.empty())
+    {
+        return;
+    }
+
+    m_weeklyquests.clear();
+    // DB data deleted in caller
+    m_WeeklyQuestChanged = false;
+}
+
+void Player::ResetMonthlyQuestStatus()
+{
+    if (m_monthlyquests.empty())
+    {
+        return;
+    }
+
+    m_monthlyquests.clear();
+    // DB data deleted in caller
+    m_MonthlyQuestChanged = false;
+}


### PR DESCRIPTION
Continues the Player.cpp cohesion-split campaign (#143–#163). Two method groups moved into their existing cohesive translation units (no new files), mirroring the taxi→PlayerTaxi.cpp consolidation in #155.

**Into PlayerDeath.cpp** — corpse-reclaim-delay handling (joins the death/corpse methods already there):
- `GetCorpseReclaimDelay`, `UpdateCorpseReclaimDelay`, `SendCorpseReclaimDelay`
- The file-local `DEATH_EXPIRE_STEP` / `MAX_DEATH_COUNT` / `corpseReclaimDelay[]` definitions move with them (Player.cpp no longer references them).

**Into PlayerQuest.cpp** — daily/weekly/monthly quest-status (joins the quest methods already there):
- `SetDailyQuestStatus`, `SetWeeklyQuestStatus`, `SetMonthlyQuestStatus`, `ResetDailyQuestStatus`, `ResetWeeklyQuestStatus`, `ResetMonthlyQuestStatus`

Pure moves — no behavior change. Declarations in `Player.h` are untouched.

**Player.cpp: −178 lines.** Release build verified clean (warnings-as-errors).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/164)
<!-- Reviewable:end -->
