### PR TITLE
[Decomp][Player] Cohesion split: extract battleground/arena methods to PlayerBattleGround.cpp

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -1936,18 +1936,6 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 }
 
 /**
- * @brief Teleports the player back to the saved battleground entry point.
- *
- * @return true if the teleport was initiated successfully; otherwise, false.
- */
-bool Player::TeleportToBGEntryPoint()
-{
-    ScheduleDelayedOperation(DELAYED_BG_MOUNT_RESTORE);
-    ScheduleDelayedOperation(DELAYED_BG_TAXI_RESTORE);
-    return TeleportTo(m_bgData.joinPos);
-}
-
-/**
  * @brief Executes queued delayed player operations.
  */
 void Player::ProcessDelayedOperations()
@@ -5008,25 +4996,6 @@ void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
     GetSession()->SendPacket(&data);
 }
 
-void Player::FillBGWeekendWorldStates(WorldPacket& data, uint32& count)
-{
-    for (uint32 i = 1; i < sBattlemasterListStore.GetNumRows(); ++i)
-    {
-        BattlemasterListEntry const* bl = sBattlemasterListStore.LookupEntry(i);
-        if (bl && bl->HolidayWorldStateId)
-        {
-            if (BattleGroundMgr::IsBGWeekend(BattleGroundTypeId(bl->id)))
-            {
-                FillInitialWorldState(data, count, bl->HolidayWorldStateId, 1);
-            }
-            else
-            {
-                FillInitialWorldState(data, count, bl->HolidayWorldStateId, 0);
-            }
-        }
-    }
-}
-
 /**
  * @brief Consumes and returns the rested experience bonus for an XP award.
  *
@@ -5709,29 +5678,6 @@ void Player::RemovePetitionsAndSigns(ObjectGuid guid)
     CharacterDatabase.CommitTransaction();
 }
 
-void Player::LeaveAllArenaTeams(ObjectGuid guid)
-{
-    uint32 lowguid = guid.GetCounter();
-    QueryResult* result = CharacterDatabase.PQuery("SELECT `arena_team_member`.`arenateamid` FROM `arena_team_member` JOIN `arena_team` ON `arena_team_member`.`arenateamid` = `arena_team`.`arenateamid` WHERE `guid`='%u'", lowguid);
-    if (!result)
-    {
-        return;
-    }
-
-    do
-    {
-        Field* fields = result->Fetch();
-        if (uint32 at_id = fields[0].GetUInt32())
-            if (ArenaTeam* at = sObjectMgr.GetArenaTeamById(at_id))
-            {
-                at->DelMember(guid);
-            }
-    }
-    while (result->NextRow());
-
-    delete result;
-}
-
 /**
  * @brief Sets the player's accumulated rested experience bonus.
  *
@@ -6225,148 +6171,6 @@ void Player::ToggleMetaGemsActive(uint8 exceptslot, bool apply)
             {
                 ApplyEnchantment(pItem, EnchantmentSlot(enchant_slot), apply);
             }
-        }
-    }
-}
-
-/**
- * @brief Stores the location used to return the player after leaving a battleground.
- */
-void Player::SetBattleGroundEntryPoint()
-{
-    // Taxi path store
-    if (!m_taxi.empty())
-    {
-        m_bgData.mountSpell  = 0;
-        m_bgData.taxiPath[0] = m_taxi.GetTaxiSource();
-        m_bgData.taxiPath[1] = m_taxi.GetTaxiDestination();
-
-        // On taxi we don't need check for dungeon
-        m_bgData.joinPos = WorldLocation(GetMapId(), GetPositionX(), GetPositionY(), GetPositionZ(), GetOrientation());
-        m_bgData.m_needSave = true;
-        return;
-    }
-    else
-    {
-        m_bgData.ClearTaxiPath();
-
-        // Mount spell id storing
-        if (IsMounted())
-        {
-            AuraList const& auras = GetAurasByType(SPELL_AURA_MOUNTED);
-            if (!auras.empty())
-            {
-                m_bgData.mountSpell = (*auras.begin())->GetId();
-            }
-        }
-        else
-        {
-            m_bgData.mountSpell = 0;
-        }
-
-        // If map is dungeon find linked graveyard
-        if (GetMap()->IsDungeon())
-        {
-            if (const WorldSafeLocsEntry* entry = sObjectMgr.GetClosestGraveYard(GetPositionX(), GetPositionY(), GetPositionZ(), GetMapId(), GetTeam()))
-            {
-                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, 0.0f);
-                m_bgData.m_needSave = true;
-                return;
-            }
-            else
-            {
-                sLog.outError("SetBattleGroundEntryPoint: Dungeon map %u has no linked graveyard, setting home location as entry point.", GetMapId());
-            }
-        }
-        // If new entry point is not BG or arena set it
-        else if (!GetMap()->IsBattleGroundOrArena())
-        {
-            m_bgData.joinPos = WorldLocation(GetMapId(), GetPositionX(), GetPositionY(), GetPositionZ(), GetOrientation());
-            m_bgData.m_needSave = true;
-            return;
-        }
-    }
-
-    // In error cases use homebind position
-    m_bgData.joinPos = WorldLocation(m_homebindMapId, m_homebindX, m_homebindY, m_homebindZ, 0.0f);
-    m_bgData.m_needSave = true;
-}
-
-/**
- * @brief Removes the player from the battleground and handles deserter penalties.
- *
- * @param teleportToEntryPoint True to teleport the player back to the saved entry point.
- */
-void Player::LeaveBattleground(bool teleportToEntryPoint)
-{
-    if (BattleGround* bg = GetBattleGround())
-    {
-        bg->RemovePlayerAtLeave(GetObjectGuid(), teleportToEntryPoint, true);
-
-        // call after remove to be sure that player resurrected for correct cast
-        if (bg->isBattleGround() && !isGameMaster() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
-        {
-            if (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN)
-            {
-                // lets check if player was teleported from BG and schedule delayed Deserter spell cast
-                if (IsBeingTeleportedFar())
-                {
-                    ScheduleDelayedOperation(DELAYED_SPELL_CAST_DESERTER);
-                    return;
-                }
-
-                CastSpell(this, 26013, true);               // Deserter
-            }
-        }
-    }
-}
-
-/**
- * @brief Checks whether the player may currently join a battleground.
- *
- * @return True if the player can join; otherwise, false.
- */
-bool Player::CanJoinToBattleground() const
-{
-    // check Deserter debuff
-    if (GetDummyAura(26013))
-    {
-        return false;
-    }
-
-    return true;
-}
-
-bool Player::CanReportAfkDueToLimit()
-{
-    // a player can complain about 15 people per 5 minutes
-    if (m_bgData.bgAfkReportedCount++ >= 15)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-/// This player has been blamed to be inactive in a battleground
-void Player::ReportedAfkBy(Player* reporter)
-{
-    BattleGround* bg = GetBattleGround();
-    if (!bg || bg != reporter->GetBattleGround() || GetTeam() != reporter->GetTeam())
-    {
-        return;
-    }
-
-    // check if player has 'Idle' or 'Inactive' debuff
-    if (m_bgData.bgAfkReporter.find(reporter->GetGUIDLow()) == m_bgData.bgAfkReporter.end() && !HasAura(43680, EFFECT_INDEX_0) && !HasAura(43681, EFFECT_INDEX_0) && reporter->CanReportAfkDueToLimit())
-    {
-        m_bgData.bgAfkReporter.insert(reporter->GetGUIDLow());
-        // 3 players have to complain to apply debuff
-        if (m_bgData.bgAfkReporter.size() >= 3)
-        {
-            // cast 'Idle' spell
-            CastSpell(this, 43680, true);
-            m_bgData.bgAfkReporter.clear();
         }
     }
 }
@@ -6866,62 +6670,6 @@ void Player::ResetMonthlyQuestStatus()
     m_monthlyquests.clear();
     // DB data deleted in caller
     m_MonthlyQuestChanged = false;
-}
-
-/**
- * @brief Gets the battleground instance the player is currently associated with.
- *
- * @return The active battleground instance, or NULL if none exists.
- */
-BattleGround* Player::GetBattleGround() const
-{
-    if (GetBattleGroundId() == 0)
-    {
-        return NULL;
-    }
-
-    return sBattleGroundMgr.GetBattleGround(GetBattleGroundId(), m_bgData.bgTypeID);
-}
-
-bool Player::InArena() const
-{
-    BattleGround* bg = GetBattleGround();
-    if (!bg || !bg->isArena())
-    {
-        return false;
-    }
-
-    return true;
-}
-
-/**
- * @brief Checks whether the player's level fits a battleground's allowed range.
- *
- * @param bgTypeId The battleground type to evaluate.
- * @return True if the player's level is within range; otherwise, false.
- */
-bool Player::GetBGAccessByLevel(BattleGroundTypeId bgTypeId) const
-{
-    // get a template bg instead of running one
-    BattleGround* bg = sBattleGroundMgr.GetBattleGroundTemplate(bgTypeId);
-    if (!bg)
-    {
-        return false;
-    }
-
-    // limit check leel to dbc compatible level range
-    uint32 level = getLevel();
-    if (level > DEFAULT_MAX_LEVEL)
-    {
-        level = DEFAULT_MAX_LEVEL;
-    }
-
-    if (level < bg->GetMinLevel() || level > bg->GetMaxLevel())
-    {
-        return false;
-    }
-
-    return true;
 }
 
 /**
@@ -7849,37 +7597,6 @@ void Player::UpdateGroupLeaderFlag(const bool remove /*= false*/)
 }
 
 /**
- * @brief Moves the player into a battleground raid group.
- *
- * @param group The battleground raid group.
- * @param subgroup The battleground subgroup index.
- */
-void Player::SetBattleGroundRaid(Group* group, int8 subgroup)
-{
-    // we must move references from m_group to m_originalGroup
-    SetOriginalGroup(GetGroup(), GetSubGroup());
-
-    m_group.unlink();
-    m_group.link(group, this);
-    m_group.setSubGroup((uint8)subgroup);
-}
-
-/**
- * @brief Restores the player's original group after leaving a battleground raid.
- */
-void Player::RemoveFromBattleGroundRaid()
-{
-    // remove existing reference
-    m_group.unlink();
-    if (Group* group = GetOriginalGroup())
-    {
-        m_group.link(group, this);
-        m_group.setSubGroup(GetOriginalSubGroup());
-    }
-    SetOriginalGroup(NULL);
-}
-
-/**
  * @brief Stores the player's original non-battleground group reference.
  *
  * @param group The original group, or NULL to clear it.
@@ -8077,24 +7794,6 @@ bool ItemPosCount::isContainedIn(ItemPosCountVec const& vec) const
         }
 
     return false;
-}
-
-/**
- * @brief Checks whether the player can interact with a battleground object.
- *
- * @return True if the player can use the object; otherwise, false.
- */
-bool Player::CanUseBattleGroundObject()
-{
-    // TODO : some spells gives player ForceReaction to one faction (ReputationMgr::ApplyForceReaction)
-    // maybe gameobject code should handle that ForceReaction usage
-    // BUG: sometimes when player clicks on flag in AB - client won't send gameobject_use, only gameobject_report_use packet
-    return (IsAlive() &&                                    // living
-            // the following two are incorrect, because invisible/stealthed players should get visible when they click on flag
-            !HasStealthAura() &&                            // not stealthed
-            !HasInvisibilityAura() &&                       // visible
-            !isTotalImmune() &&                             // vulnerable (not immune)
-            !HasAura(SPELL_RECENTLY_DROPPED_FLAG, EFFECT_INDEX_0));
 }
 
 uint32 Player::GetBarberShopCost(uint8 newhairstyle, uint8 newhaircolor, uint8 newfacialhair, uint32 newskintone)
@@ -9233,34 +8932,6 @@ void Player::_fillGearScoreData(Item* item, GearScoreVec* gearScore, uint32& two
 // Player::ModifyCurrencyCount / SetCurrencyCount / _LoadCurrencies / _SaveCurrencies /
 // SetCurrencyFlags / ResetCurrencyWeekCounts moved to CurrencyMgr (2026-05-12);
 // thin delegating wrappers live inline in Player.h.
-
-void Player::SendPvPRewards()
-{
-    // Placeholder
-
-    WorldPacket data(SMSG_PVP_REWARDS, 6 * 4);
-    data << uint32(1650);   // rbg conquest cap
-    data << uint32(0);      // total conquest earned
-    data << uint32(1350);   // arena conquest cap
-    data << uint32(0);      // rbg conquest earned
-    data << uint32(0);      // arena conquest earned
-    data << uint32(1650);   // total conquest cap
-
-    SendDirectMessage(&data);
-}
-
-void Player::SendRatedBGStats()
-{
-    // Placeholder
-
-    WorldPacket data(SMSG_RATED_BG_STATS, 18 * 4);
-    for (int i = 0; i < 18; ++i)
-    {
-        data << uint32(0);
-    }
-
-    SendDirectMessage(&data);
-}
 
 /**
  * @brief Evaluates whether the player can use an area trigger into another map.

--- a/src/game/Object/PlayerBattleGround.cpp
+++ b/src/game/Object/PlayerBattleGround.cpp
@@ -1,0 +1,410 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "Player.h"
+#include "Language.h"
+#include "Database/DatabaseEnv.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "SpellMgr.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "UpdateMask.h"
+#include "SkillDiscovery.h"
+#include "QuestDef.h"
+#include "GossipDef.h"
+#include "UpdateData.h"
+#include "Channel.h"
+#include "ChannelMgr.h"
+#include "MapManager.h"
+#include "MapPersistentStateMgr.h"
+#include "InstanceData.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+#include "ObjectMgr.h"
+#include "ObjectAccessor.h"
+#include "CreatureAI.h"
+#include "Formulas.h"
+#include "Group.h"
+#include "Guild.h"
+#include "GuildMgr.h"
+#include "Pet.h"
+#include "Util.h"
+#include "Transports.h"
+#include "Weather.h"
+#include "BattleGround/BattleGround.h"
+#include "BattleGround/BattleGroundMgr.h"
+#include "BattleGround/BattleGroundAV.h"
+#include "OutdoorPvP/OutdoorPvP.h"
+#include "ArenaTeam.h"
+#include "Chat.h"
+#include "revision_data.h"
+#include "Database/DatabaseImpl.h"
+#include "Spell.h"
+#include "ScriptMgr.h"
+#include "SocialMgr.h"
+#include "AchievementMgr.h"
+#include "Mail.h"
+#include "SpellAuras.h"
+#include "DBCStores.h"
+#include "DB2Stores.h"
+#include "SQLStorages.h"
+#include "Vehicle.h"
+#include "Calendar.h"
+#include "DisableMgr.h"
+#ifdef ENABLE_ELUNA
+#include "LuaEngine.h"
+#endif /* ENABLE_ELUNA */
+
+#include <cmath>
+/**
+ * @brief Teleports the player back to the saved battleground entry point.
+ *
+ * @return true if the teleport was initiated successfully; otherwise, false.
+ */
+bool Player::TeleportToBGEntryPoint()
+{
+    ScheduleDelayedOperation(DELAYED_BG_MOUNT_RESTORE);
+    ScheduleDelayedOperation(DELAYED_BG_TAXI_RESTORE);
+    return TeleportTo(m_bgData.joinPos);
+}
+
+void Player::FillBGWeekendWorldStates(WorldPacket& data, uint32& count)
+{
+    for (uint32 i = 1; i < sBattlemasterListStore.GetNumRows(); ++i)
+    {
+        BattlemasterListEntry const* bl = sBattlemasterListStore.LookupEntry(i);
+        if (bl && bl->HolidayWorldStateId)
+        {
+            if (BattleGroundMgr::IsBGWeekend(BattleGroundTypeId(bl->id)))
+            {
+                FillInitialWorldState(data, count, bl->HolidayWorldStateId, 1);
+            }
+            else
+            {
+                FillInitialWorldState(data, count, bl->HolidayWorldStateId, 0);
+            }
+        }
+    }
+}
+
+void Player::LeaveAllArenaTeams(ObjectGuid guid)
+{
+    uint32 lowguid = guid.GetCounter();
+    QueryResult* result = CharacterDatabase.PQuery("SELECT `arena_team_member`.`arenateamid` FROM `arena_team_member` JOIN `arena_team` ON `arena_team_member`.`arenateamid` = `arena_team`.`arenateamid` WHERE `guid`='%u'", lowguid);
+    if (!result)
+    {
+        return;
+    }
+
+    do
+    {
+        Field* fields = result->Fetch();
+        if (uint32 at_id = fields[0].GetUInt32())
+            if (ArenaTeam* at = sObjectMgr.GetArenaTeamById(at_id))
+            {
+                at->DelMember(guid);
+            }
+    }
+    while (result->NextRow());
+
+    delete result;
+}
+
+/**
+ * @brief Stores the location used to return the player after leaving a battleground.
+ */
+void Player::SetBattleGroundEntryPoint()
+{
+    // Taxi path store
+    if (!m_taxi.empty())
+    {
+        m_bgData.mountSpell  = 0;
+        m_bgData.taxiPath[0] = m_taxi.GetTaxiSource();
+        m_bgData.taxiPath[1] = m_taxi.GetTaxiDestination();
+
+        // On taxi we don't need check for dungeon
+        m_bgData.joinPos = WorldLocation(GetMapId(), GetPositionX(), GetPositionY(), GetPositionZ(), GetOrientation());
+        m_bgData.m_needSave = true;
+        return;
+    }
+    else
+    {
+        m_bgData.ClearTaxiPath();
+
+        // Mount spell id storing
+        if (IsMounted())
+        {
+            AuraList const& auras = GetAurasByType(SPELL_AURA_MOUNTED);
+            if (!auras.empty())
+            {
+                m_bgData.mountSpell = (*auras.begin())->GetId();
+            }
+        }
+        else
+        {
+            m_bgData.mountSpell = 0;
+        }
+
+        // If map is dungeon find linked graveyard
+        if (GetMap()->IsDungeon())
+        {
+            if (const WorldSafeLocsEntry* entry = sObjectMgr.GetClosestGraveYard(GetPositionX(), GetPositionY(), GetPositionZ(), GetMapId(), GetTeam()))
+            {
+                m_bgData.joinPos = WorldLocation(entry->map_id, entry->x, entry->y, entry->z, 0.0f);
+                m_bgData.m_needSave = true;
+                return;
+            }
+            else
+            {
+                sLog.outError("SetBattleGroundEntryPoint: Dungeon map %u has no linked graveyard, setting home location as entry point.", GetMapId());
+            }
+        }
+        // If new entry point is not BG or arena set it
+        else if (!GetMap()->IsBattleGroundOrArena())
+        {
+            m_bgData.joinPos = WorldLocation(GetMapId(), GetPositionX(), GetPositionY(), GetPositionZ(), GetOrientation());
+            m_bgData.m_needSave = true;
+            return;
+        }
+    }
+
+    // In error cases use homebind position
+    m_bgData.joinPos = WorldLocation(m_homebindMapId, m_homebindX, m_homebindY, m_homebindZ, 0.0f);
+    m_bgData.m_needSave = true;
+}
+
+/**
+ * @brief Removes the player from the battleground and handles deserter penalties.
+ *
+ * @param teleportToEntryPoint True to teleport the player back to the saved entry point.
+ */
+void Player::LeaveBattleground(bool teleportToEntryPoint)
+{
+    if (BattleGround* bg = GetBattleGround())
+    {
+        bg->RemovePlayerAtLeave(GetObjectGuid(), teleportToEntryPoint, true);
+
+        // call after remove to be sure that player resurrected for correct cast
+        if (bg->isBattleGround() && !isGameMaster() && sWorld.getConfig(CONFIG_BOOL_BATTLEGROUND_CAST_DESERTER))
+        {
+            if (bg->GetStatus() == STATUS_IN_PROGRESS || bg->GetStatus() == STATUS_WAIT_JOIN)
+            {
+                // lets check if player was teleported from BG and schedule delayed Deserter spell cast
+                if (IsBeingTeleportedFar())
+                {
+                    ScheduleDelayedOperation(DELAYED_SPELL_CAST_DESERTER);
+                    return;
+                }
+
+                CastSpell(this, 26013, true);               // Deserter
+            }
+        }
+    }
+}
+
+/**
+ * @brief Checks whether the player may currently join a battleground.
+ *
+ * @return True if the player can join; otherwise, false.
+ */
+bool Player::CanJoinToBattleground() const
+{
+    // check Deserter debuff
+    if (GetDummyAura(26013))
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool Player::CanReportAfkDueToLimit()
+{
+    // a player can complain about 15 people per 5 minutes
+    if (m_bgData.bgAfkReportedCount++ >= 15)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+/// This player has been blamed to be inactive in a battleground
+void Player::ReportedAfkBy(Player* reporter)
+{
+    BattleGround* bg = GetBattleGround();
+    if (!bg || bg != reporter->GetBattleGround() || GetTeam() != reporter->GetTeam())
+    {
+        return;
+    }
+
+    // check if player has 'Idle' or 'Inactive' debuff
+    if (m_bgData.bgAfkReporter.find(reporter->GetGUIDLow()) == m_bgData.bgAfkReporter.end() && !HasAura(43680, EFFECT_INDEX_0) && !HasAura(43681, EFFECT_INDEX_0) && reporter->CanReportAfkDueToLimit())
+    {
+        m_bgData.bgAfkReporter.insert(reporter->GetGUIDLow());
+        // 3 players have to complain to apply debuff
+        if (m_bgData.bgAfkReporter.size() >= 3)
+        {
+            // cast 'Idle' spell
+            CastSpell(this, 43680, true);
+            m_bgData.bgAfkReporter.clear();
+        }
+    }
+}
+
+/**
+ * @brief Gets the battleground instance the player is currently associated with.
+ *
+ * @return The active battleground instance, or NULL if none exists.
+ */
+BattleGround* Player::GetBattleGround() const
+{
+    if (GetBattleGroundId() == 0)
+    {
+        return NULL;
+    }
+
+    return sBattleGroundMgr.GetBattleGround(GetBattleGroundId(), m_bgData.bgTypeID);
+}
+
+bool Player::InArena() const
+{
+    BattleGround* bg = GetBattleGround();
+    if (!bg || !bg->isArena())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Checks whether the player's level fits a battleground's allowed range.
+ *
+ * @param bgTypeId The battleground type to evaluate.
+ * @return True if the player's level is within range; otherwise, false.
+ */
+bool Player::GetBGAccessByLevel(BattleGroundTypeId bgTypeId) const
+{
+    // get a template bg instead of running one
+    BattleGround* bg = sBattleGroundMgr.GetBattleGroundTemplate(bgTypeId);
+    if (!bg)
+    {
+        return false;
+    }
+
+    // limit check leel to dbc compatible level range
+    uint32 level = getLevel();
+    if (level > DEFAULT_MAX_LEVEL)
+    {
+        level = DEFAULT_MAX_LEVEL;
+    }
+
+    if (level < bg->GetMinLevel() || level > bg->GetMaxLevel())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Moves the player into a battleground raid group.
+ *
+ * @param group The battleground raid group.
+ * @param subgroup The battleground subgroup index.
+ */
+void Player::SetBattleGroundRaid(Group* group, int8 subgroup)
+{
+    // we must move references from m_group to m_originalGroup
+    SetOriginalGroup(GetGroup(), GetSubGroup());
+
+    m_group.unlink();
+    m_group.link(group, this);
+    m_group.setSubGroup((uint8)subgroup);
+}
+
+/**
+ * @brief Restores the player's original group after leaving a battleground raid.
+ */
+void Player::RemoveFromBattleGroundRaid()
+{
+    // remove existing reference
+    m_group.unlink();
+    if (Group* group = GetOriginalGroup())
+    {
+        m_group.link(group, this);
+        m_group.setSubGroup(GetOriginalSubGroup());
+    }
+    SetOriginalGroup(NULL);
+}
+
+/**
+ * @brief Checks whether the player can interact with a battleground object.
+ *
+ * @return True if the player can use the object; otherwise, false.
+ */
+bool Player::CanUseBattleGroundObject()
+{
+    // TODO : some spells gives player ForceReaction to one faction (ReputationMgr::ApplyForceReaction)
+    // maybe gameobject code should handle that ForceReaction usage
+    // BUG: sometimes when player clicks on flag in AB - client won't send gameobject_use, only gameobject_report_use packet
+    return (IsAlive() &&                                    // living
+            // the following two are incorrect, because invisible/stealthed players should get visible when they click on flag
+            !HasStealthAura() &&                            // not stealthed
+            !HasInvisibilityAura() &&                       // visible
+            !isTotalImmune() &&                             // vulnerable (not immune)
+            !HasAura(SPELL_RECENTLY_DROPPED_FLAG, EFFECT_INDEX_0));
+}
+
+void Player::SendPvPRewards()
+{
+    // Placeholder
+
+    WorldPacket data(SMSG_PVP_REWARDS, 6 * 4);
+    data << uint32(1650);   // rbg conquest cap
+    data << uint32(0);      // total conquest earned
+    data << uint32(1350);   // arena conquest cap
+    data << uint32(0);      // rbg conquest earned
+    data << uint32(0);      // arena conquest earned
+    data << uint32(1650);   // total conquest cap
+
+    SendDirectMessage(&data);
+}
+
+void Player::SendRatedBGStats()
+{
+    // Placeholder
+
+    WorldPacket data(SMSG_RATED_BG_STATS, 18 * 4);
+    for (int i = 0; i < 18; ++i)
+    {
+        data << uint32(0);
+    }
+
+    SendDirectMessage(&data);
+}


### PR DESCRIPTION
Continues the Player.cpp cohesion-split campaign (#143–#164). Single-concern extraction of the battleground/arena method set into its own translation unit.

**PlayerBattleGround.cpp** — all 16 battleground/arena method bodies:
- Entry/exit: `TeleportToBGEntryPoint`, `SetBattleGroundEntryPoint`, `LeaveBattleground`, `CanJoinToBattleground`, `CanUseBattleGroundObject`
- Queries: `GetBattleGround`, `InArena`, `GetBGAccessByLevel`
- BG raid group: `SetBattleGroundRaid`, `RemoveFromBattleGroundRaid`
- AFK reporting: `CanReportAfkDueToLimit`, `ReportedAfkBy`
- World state / rewards: `FillBGWeekendWorldStates`, `SendPvPRewards`, `SendRatedBGStats`
- Arena: `LeaveAllArenaTeams`

These were scattered across Player.cpp (lines 1943–9252); consolidated into one cohesive TU. Pure move — no behavior change. Declarations in `Player.h` are untouched, so all call sites are unaffected.

Verified: extracted method bodies are byte-identical to the originals (292 non-blank lines, zero diff), and the `game` library builds clean in Release (warnings-as-errors).

**Player.cpp: −329 lines.**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/165)
<!-- Reviewable:end -->
