### PR TITLE
[Decomp][Player] Cohesion split: extract group-membership methods to PlayerGroup.cpp

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2335,85 +2335,6 @@ void Player::SetGMVisible(bool on)
 }
 
 /**
- * @brief Checks whether another player should be visible through group visibility rules.
- *
- * @param p The player to test visibility against.
- * @return True if the player is group-visible; otherwise, false.
- */
-bool Player::IsGroupVisibleFor(Player* p) const
-{
-    switch (sWorld.getConfig(CONFIG_UINT32_GROUP_VISIBILITY))
-    {
-        default:
-            return IsInSameGroupWith(p);
-        case 1:
-            return IsInSameRaidWith(p);
-        case 2:
-            return GetTeam() == p->GetTeam();
-    }
-}
-
-/**
- * @brief Checks whether this player and another player are in the same subgroup.
- *
- * @param p The other player to compare.
- * @return True if both players share the same group context; otherwise, false.
- */
-bool Player::IsInSameGroupWith(Player const* p) const
-{
-    return (p == this || (GetGroup() != NULL &&
-                          GetGroup()->SameSubGroup(this, p)));
-}
-
-///- If the player is invited, remove him. If the group if then only 1 person, disband the group.
-/// \todo Shouldn't we also check if there is no other invitees before disbanding the group?
-void Player::UninviteFromGroup()
-{
-    Group* group = GetGroupInvite();
-    if (!group)
-    {
-        return;
-    }
-
-    group->RemoveInvite(this);
-
-    if (group->GetMembersCount() <= 1)                      // group has just 1 member => disband
-    {
-        if (group->IsCreated())
-        {
-            group->Disband(true);
-            sObjectMgr.RemoveGroup(group);
-        }
-        else
-        {
-            group->RemoveAllInvites();
-        }
-
-        delete group;
-    }
-}
-
-/**
- * @brief Removes a member from a group and disposes of the group if it becomes empty.
- *
- * @param group The group to remove the member from.
- * @param guid The GUID of the member to remove.
- */
-void Player::RemoveFromGroup(Group* group, ObjectGuid guid)
-{
-    if (group)
-    {
-        if (group->RemoveMember(guid, 0) <= 1)
-        {
-            // group->Disband(); already disbanded in RemoveMember
-            sObjectMgr.RemoveGroup(group);
-            delete group;
-            // RemoveMember sets the player's group pointer to NULL
-        }
-    }
-}
-
-/**
  * @brief Sends the experience gain log packet to the client.
  *
  * @param GivenXP The base amount of experience awarded.
@@ -4906,27 +4827,6 @@ void Player::InitPrimaryProfessions()
     SetFreePrimaryProfessions(sWorld.getConfig(CONFIG_UINT32_MAX_PRIMARY_TRADE_SKILL));
 }
 
-/**
- * @brief Assigns the player to a group and subgroup.
- *
- * @param group The group to join, or NULL to clear membership.
- * @param subgroup The subgroup index when joining a group.
- */
-void Player::SetGroup(Group* group, int8 subgroup)
-{
-    if (group == NULL)
-    {
-        m_group.unlink();
-    }
-    else
-    {
-        // never use SetGroup without a subgroup unless you specify NULL for group
-        MANGOS_ASSERT(subgroup >= 0);
-        m_group.link(group, this);
-        m_group.setSubGroup((uint8)subgroup);
-    }
-}
-
 void Player::SendInitialPacketsBeforeAddToMap()
 {
     GetSocial()->SendSocialList();
@@ -5049,28 +4949,6 @@ void Player::SendInitialPacketsAfterAddToMap()
     UpdateSpeed(MOVE_RUN, true, 1.0f, true);
     UpdateSpeed(MOVE_SWIM, true, 1.0f, true);
     UpdateSpeed(MOVE_FLIGHT, true, 1.0f, true);
-}
-
-/**
- * @brief Flushes pending group update data to out-of-range group members.
- */
-void Player::SendUpdateToOutOfRangeGroupMembers()
-{
-    if (m_groupUpdateMask == GROUP_UPDATE_FLAG_NONE)
-    {
-        return;
-    }
-    if (Group* group = GetGroup())
-    {
-        group->UpdatePlayerOutOfRange(this);
-    }
-
-    m_groupUpdateMask = GROUP_UPDATE_FLAG_NONE;
-    m_auraUpdateMask = 0;
-    if (Pet* pet = GetPet())
-    {
-        pet->ResetAuraUpdateMask();
-    }
 }
 
 /**
@@ -5768,107 +5646,6 @@ uint32 Player::GetNextResetTalentsCost()    const
             }
             return new_cost;
         }
-    }
-}
-
-/**
- * @brief Selects a random nearby raid member within a radius.
- *
- * @param radius The maximum search radius.
- * @return A random eligible raid member, or NULL if none are found.
- */
-Player* Player::GetNextRandomRaidMember(float radius)
-{
-    Group* pGroup = GetGroup();
-    if (!pGroup)
-    {
-        return NULL;
-    }
-
-    std::vector<Player*> nearMembers;
-    nearMembers.reserve(pGroup->GetMembersCount());
-
-    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
-    {
-        Player* Target = itr->getSource();
-
-        // IsHostileTo check duel and controlled by enemy
-        if (Target && Target != this && IsWithinDistInMap(Target, radius) &&
-                !Target->HasInvisibilityAura() && !IsHostileTo(Target))
-                {
-                    nearMembers.push_back(Target);
-                }
-    }
-
-    if (nearMembers.empty())
-    {
-        return NULL;
-    }
-
-    uint32 randTarget = urand(0, nearMembers.size() - 1);
-    return nearMembers[randTarget];
-}
-
-/**
- * @brief Checks whether the player is allowed to uninvite someone from the group.
- *
- * @return The party result code describing whether uninvite is allowed.
- */
-PartyResult Player::CanUninviteFromGroup() const
-{
-    const Group* grp = GetGroup();
-    if (!grp)
-    {
-        return ERR_NOT_IN_GROUP;
-    }
-
-    if (!grp->IsLeader(GetObjectGuid()) && !grp->IsAssistant(GetObjectGuid()))
-    {
-        return ERR_NOT_LEADER;
-    }
-
-    if (InBattleGround())
-    {
-        return ERR_INVITE_RESTRICTED;
-    }
-
-    return ERR_PARTY_RESULT_OK;
-}
-
-void Player::UpdateGroupLeaderFlag(const bool remove /*= false*/)
-{
-    const Group* group = GetGroup();
-    if (HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER))
-    {
-        if (remove || !group || group->GetLeaderGuid() != GetObjectGuid())
-        {
-            RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER);
-        }
-    }
-    else if (!remove && group && group->GetLeaderGuid() == GetObjectGuid())
-    {
-        SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER);
-    }
-}
-
-/**
- * @brief Stores the player's original non-battleground group reference.
- *
- * @param group The original group, or NULL to clear it.
- * @param subgroup The original subgroup index.
- */
-void Player::SetOriginalGroup(Group* group, int8 subgroup)
-{
-    if (group == NULL)
-    {
-        m_originalGroup.unlink();
-    }
-    else
-    {
-        // never use SetOriginalGroup without a subgroup unless you specify NULL for group
-        MANGOS_ASSERT(subgroup >= 0);
-        m_originalGroup.link(group, this);
-        m_originalGroup.setSubGroup((uint8)subgroup);
     }
 }
 

--- a/src/game/Object/PlayerGroup.cpp
+++ b/src/game/Object/PlayerGroup.cpp
@@ -1,0 +1,304 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "Player.h"
+#include "Language.h"
+#include "Database/DatabaseEnv.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "SpellMgr.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "UpdateMask.h"
+#include "SkillDiscovery.h"
+#include "QuestDef.h"
+#include "GossipDef.h"
+#include "UpdateData.h"
+#include "Channel.h"
+#include "ChannelMgr.h"
+#include "MapManager.h"
+#include "MapPersistentStateMgr.h"
+#include "InstanceData.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+#include "ObjectMgr.h"
+#include "ObjectAccessor.h"
+#include "CreatureAI.h"
+#include "Formulas.h"
+#include "Group.h"
+#include "Guild.h"
+#include "GuildMgr.h"
+#include "Pet.h"
+#include "Util.h"
+#include "Transports.h"
+#include "Weather.h"
+#include "BattleGround/BattleGround.h"
+#include "BattleGround/BattleGroundMgr.h"
+#include "BattleGround/BattleGroundAV.h"
+#include "OutdoorPvP/OutdoorPvP.h"
+#include "ArenaTeam.h"
+#include "Chat.h"
+#include "revision_data.h"
+#include "Database/DatabaseImpl.h"
+#include "Spell.h"
+#include "ScriptMgr.h"
+#include "SocialMgr.h"
+#include "AchievementMgr.h"
+#include "Mail.h"
+#include "SpellAuras.h"
+#include "DBCStores.h"
+#include "DB2Stores.h"
+#include "SQLStorages.h"
+#include "Vehicle.h"
+#include "Calendar.h"
+#include "DisableMgr.h"
+#ifdef ENABLE_ELUNA
+#include "LuaEngine.h"
+#endif /* ENABLE_ELUNA */
+
+#include <cmath>
+/**
+ * @brief Checks whether another player should be visible through group visibility rules.
+ *
+ * @param p The player to test visibility against.
+ * @return True if the player is group-visible; otherwise, false.
+ */
+bool Player::IsGroupVisibleFor(Player* p) const
+{
+    switch (sWorld.getConfig(CONFIG_UINT32_GROUP_VISIBILITY))
+    {
+        default:
+            return IsInSameGroupWith(p);
+        case 1:
+            return IsInSameRaidWith(p);
+        case 2:
+            return GetTeam() == p->GetTeam();
+    }
+}
+
+/**
+ * @brief Checks whether this player and another player are in the same subgroup.
+ *
+ * @param p The other player to compare.
+ * @return True if both players share the same group context; otherwise, false.
+ */
+bool Player::IsInSameGroupWith(Player const* p) const
+{
+    return (p == this || (GetGroup() != NULL &&
+                          GetGroup()->SameSubGroup(this, p)));
+}
+
+///- If the player is invited, remove him. If the group if then only 1 person, disband the group.
+/// \todo Shouldn't we also check if there is no other invitees before disbanding the group?
+void Player::UninviteFromGroup()
+{
+    Group* group = GetGroupInvite();
+    if (!group)
+    {
+        return;
+    }
+
+    group->RemoveInvite(this);
+
+    if (group->GetMembersCount() <= 1)                      // group has just 1 member => disband
+    {
+        if (group->IsCreated())
+        {
+            group->Disband(true);
+            sObjectMgr.RemoveGroup(group);
+        }
+        else
+        {
+            group->RemoveAllInvites();
+        }
+
+        delete group;
+    }
+}
+
+/**
+ * @brief Removes a member from a group and disposes of the group if it becomes empty.
+ *
+ * @param group The group to remove the member from.
+ * @param guid The GUID of the member to remove.
+ */
+void Player::RemoveFromGroup(Group* group, ObjectGuid guid)
+{
+    if (group)
+    {
+        if (group->RemoveMember(guid, 0) <= 1)
+        {
+            // group->Disband(); already disbanded in RemoveMember
+            sObjectMgr.RemoveGroup(group);
+            delete group;
+            // RemoveMember sets the player's group pointer to NULL
+        }
+    }
+}
+
+/**
+ * @brief Assigns the player to a group and subgroup.
+ *
+ * @param group The group to join, or NULL to clear membership.
+ * @param subgroup The subgroup index when joining a group.
+ */
+void Player::SetGroup(Group* group, int8 subgroup)
+{
+    if (group == NULL)
+    {
+        m_group.unlink();
+    }
+    else
+    {
+        // never use SetGroup without a subgroup unless you specify NULL for group
+        MANGOS_ASSERT(subgroup >= 0);
+        m_group.link(group, this);
+        m_group.setSubGroup((uint8)subgroup);
+    }
+}
+
+/**
+ * @brief Flushes pending group update data to out-of-range group members.
+ */
+void Player::SendUpdateToOutOfRangeGroupMembers()
+{
+    if (m_groupUpdateMask == GROUP_UPDATE_FLAG_NONE)
+    {
+        return;
+    }
+    if (Group* group = GetGroup())
+    {
+        group->UpdatePlayerOutOfRange(this);
+    }
+
+    m_groupUpdateMask = GROUP_UPDATE_FLAG_NONE;
+    m_auraUpdateMask = 0;
+    if (Pet* pet = GetPet())
+    {
+        pet->ResetAuraUpdateMask();
+    }
+}
+
+/**
+ * @brief Selects a random nearby raid member within a radius.
+ *
+ * @param radius The maximum search radius.
+ * @return A random eligible raid member, or NULL if none are found.
+ */
+Player* Player::GetNextRandomRaidMember(float radius)
+{
+    Group* pGroup = GetGroup();
+    if (!pGroup)
+    {
+        return NULL;
+    }
+
+    std::vector<Player*> nearMembers;
+    nearMembers.reserve(pGroup->GetMembersCount());
+
+    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
+    {
+        Player* Target = itr->getSource();
+
+        // IsHostileTo check duel and controlled by enemy
+        if (Target && Target != this && IsWithinDistInMap(Target, radius) &&
+                !Target->HasInvisibilityAura() && !IsHostileTo(Target))
+                {
+                    nearMembers.push_back(Target);
+                }
+    }
+
+    if (nearMembers.empty())
+    {
+        return NULL;
+    }
+
+    uint32 randTarget = urand(0, nearMembers.size() - 1);
+    return nearMembers[randTarget];
+}
+
+/**
+ * @brief Checks whether the player is allowed to uninvite someone from the group.
+ *
+ * @return The party result code describing whether uninvite is allowed.
+ */
+PartyResult Player::CanUninviteFromGroup() const
+{
+    const Group* grp = GetGroup();
+    if (!grp)
+    {
+        return ERR_NOT_IN_GROUP;
+    }
+
+    if (!grp->IsLeader(GetObjectGuid()) && !grp->IsAssistant(GetObjectGuid()))
+    {
+        return ERR_NOT_LEADER;
+    }
+
+    if (InBattleGround())
+    {
+        return ERR_INVITE_RESTRICTED;
+    }
+
+    return ERR_PARTY_RESULT_OK;
+}
+
+void Player::UpdateGroupLeaderFlag(const bool remove /*= false*/)
+{
+    const Group* group = GetGroup();
+    if (HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER))
+    {
+        if (remove || !group || group->GetLeaderGuid() != GetObjectGuid())
+        {
+            RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER);
+        }
+    }
+    else if (!remove && group && group->GetLeaderGuid() == GetObjectGuid())
+    {
+        SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_GROUP_LEADER);
+    }
+}
+
+/**
+ * @brief Stores the player's original non-battleground group reference.
+ *
+ * @param group The original group, or NULL to clear it.
+ * @param subgroup The original subgroup index.
+ */
+void Player::SetOriginalGroup(Group* group, int8 subgroup)
+{
+    if (group == NULL)
+    {
+        m_originalGroup.unlink();
+    }
+    else
+    {
+        // never use SetOriginalGroup without a subgroup unless you specify NULL for group
+        MANGOS_ASSERT(subgroup >= 0);
+        m_originalGroup.link(group, this);
+        m_originalGroup.setSubGroup((uint8)subgroup);
+    }
+}


### PR DESCRIPTION
Continues the Player.cpp cohesion-split campaign. Single-concern extraction of the group-membership method set into its own translation unit.

**PlayerGroup.cpp** — 10 group/raid membership method bodies:
- Visibility/membership: `IsGroupVisibleFor`, `IsInSameGroupWith`, `UninviteFromGroup`, `RemoveFromGroup`, `SetGroup`, `SetOriginalGroup`
- Raid: `GetNextRandomRaidMember`, `CanUninviteFromGroup`, `UpdateGroupLeaderFlag`
- Sync: `SendUpdateToOutOfRangeGroupMembers`

These were scattered across Player.cpp (lines 2343–6175); consolidated into one cohesive TU. Pure move — no behavior change. Declarations in `Player.h` are untouched, so all call sites are unaffected. (The battleground raid-group helpers `SetBattleGroundRaid`/`RemoveFromBattleGroundRaid` were already extracted to PlayerBattleGround.cpp in #165.)

Verified: extracted method bodies are byte-identical to the originals (201 non-blank lines, zero diff), and the `game` library builds clean in Release (warnings-as-errors).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/166)
<!-- Reviewable:end -->
