### PR TITLE
[Decomp][Player] Cohesion split: extract rested-XP system to PlayerRest.cpp

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4293,27 +4293,6 @@ void Player::SendInitWorldStates(uint32 zoneid, uint32 areaid)
 }
 
 /**
- * @brief Consumes and returns the rested experience bonus for an XP award.
- *
- * @param xp The base experience amount being awarded.
- * @return The rested bonus experience amount.
- */
-uint32 Player::GetXPRestBonus(uint32 xp)
-{
-    uint32 rested_bonus = (uint32)GetRestBonus();           // xp for each rested bonus
-
-    if (rested_bonus > xp)                                  // max rested_bonus == xp or (r+x) = 200% xp
-    {
-        rested_bonus = xp;
-    }
-
-    SetRestBonus(GetRestBonus() - rested_bonus);
-
-    DETAIL_LOG("Player gain %u xp (+ %u Rested Bonus). Rested points=%f", xp + rested_bonus, rested_bonus, GetRestBonus());
-    return rested_bonus;
-}
-
-/**
  * @brief Sends a bind point confirmation prompt to the client.
  *
  * @param guid The binder NPC GUID.
@@ -4623,49 +4602,6 @@ void Player::RemovePetitionsAndSigns(ObjectGuid guid)
     CharacterDatabase.PExecute("DELETE FROM `petition` WHERE `ownerguid` = '%u'", lowguid);
     CharacterDatabase.PExecute("DELETE FROM `petition_sign` WHERE `ownerguid` = '%u'", lowguid);
     CharacterDatabase.CommitTransaction();
-}
-
-/**
- * @brief Sets the player's accumulated rested experience bonus.
- *
- * @param rest_bonus_new The new rested bonus amount.
- */
-void Player::SetRestBonus(float rest_bonus_new)
-{
-    // Prevent resting on max level
-    if (getLevel() >= sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
-    {
-        rest_bonus_new = 0;
-    }
-
-    if (rest_bonus_new < 0)
-    {
-        rest_bonus_new = 0;
-    }
-
-    float rest_bonus_max = (float)GetUInt32Value(PLAYER_NEXT_LEVEL_XP) * 1.5f / 2.0f;
-
-    if (rest_bonus_new > rest_bonus_max)
-    {
-        m_rest_bonus = rest_bonus_max;
-    }
-    else
-    {
-        m_rest_bonus = rest_bonus_new;
-    }
-
-    // update data for client
-    if (m_rest_bonus > 10)
-    {
-        SetByteValue(PLAYER_BYTES_2, 3, REST_STATE_RESTED);
-    }
-    else if (m_rest_bonus <= 1)
-    {
-        SetByteValue(PLAYER_BYTES_2, 3, REST_STATE_NORMAL);
-    }
-
-    // RestTickUpdate
-    SetUInt32Value(PLAYER_REST_STATE_EXPERIENCE, uint32(m_rest_bonus));
 }
 
 /**
@@ -6931,40 +6867,6 @@ Object* Player::GetObjectByTypeMask(ObjectGuid guid, TypeMask typemask)
     return NULL;
 }
 
-/**
- * @brief Updates the player's current resting state.
- *
- * @param n_r_type The new rest type.
- * @param areaTriggerId The inn or rest area trigger identifier, if applicable.
- */
-void Player::SetRestType(RestType n_r_type, uint32 areaTriggerId /*= 0*/)
-{
-    rest_type = n_r_type;
-
-    if (rest_type == REST_TYPE_NO)
-    {
-        RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
-
-        // Set player to FFA PVP when not in rested environment.
-        if (sWorld.IsFFAPvPRealm())
-        {
-            SetFFAPvP(true);
-        }
-    }
-    else
-    {
-        SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
-
-        inn_trigger_id = areaTriggerId;
-        time_inn_enter = time(NULL);
-
-        if (sWorld.IsFFAPvPRealm())
-        {
-            SetFFAPvP(false);
-        }
-    }
-}
-
 // Player::SendCurrencies / Get/SendCurrencyWeekCap / GetCurrencyTotalCap / Get*Count moved
 // to CurrencyMgr (2026-05-12); thin delegating wrappers live inline in Player.h.
 
@@ -7288,41 +7190,6 @@ bool Player::FitArmorSpecializationRules(SpellEntry const * spellProto) const
     }
 
     return true;
-}
-
-/**
- * @brief Computes rested experience gained over a period of time.
- *
- * @param timePassed The elapsed time in seconds.
- * @param offline True when the gain is being computed for offline time.
- * @param inRestPlace True when the player is in a rest area while offline.
- * @return The amount of rested experience bonus gained.
- */
-float Player::ComputeRest(time_t timePassed, bool offline /*= false*/, bool inRestPlace /*= false*/)
-{
-    // Every 8h in resting zone we gain a bubble
-    // A bubble is 5% of the total xp so there are 20 bubbles
-    // So we gain (total XP/20 every 8h) (8h = 288800 sec)
-    // (TotalXP/20)/28800; simplified to (TotalXP/576000) per second
-    // Client automatically double the value sent so we have to divide it by 2
-    // So final formula (TotalXP/1152000)
-    float bonus = timePassed * (GetUInt32Value(PLAYER_NEXT_LEVEL_XP) / 1152000.0f); // Get the gained rest xp for given second
-    if (!offline)
-    {
-        bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_INGAME);                   // Apply the custom setting
-    }
-    else
-    {
-        if (inRestPlace)
-        {
-            bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_OFFLINE_IN_TAVERN_OR_CITY);
-        }
-        else
-        {
-            bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_OFFLINE_IN_WILDERNESS) / 4.0f; // bonus is reduced by 4 when not in rest place
-        }
-    }
-    return bonus;
 }
 
 float Player::GetCollisionHeight(bool mounted) const

--- a/src/game/Object/PlayerRest.cpp
+++ b/src/game/Object/PlayerRest.cpp
@@ -1,0 +1,214 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "Player.h"
+#include "Language.h"
+#include "Database/DatabaseEnv.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "SpellMgr.h"
+#include "World.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "UpdateMask.h"
+#include "SkillDiscovery.h"
+#include "QuestDef.h"
+#include "GossipDef.h"
+#include "UpdateData.h"
+#include "Channel.h"
+#include "ChannelMgr.h"
+#include "MapManager.h"
+#include "MapPersistentStateMgr.h"
+#include "InstanceData.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+#include "ObjectMgr.h"
+#include "ObjectAccessor.h"
+#include "CreatureAI.h"
+#include "Formulas.h"
+#include "Group.h"
+#include "Guild.h"
+#include "GuildMgr.h"
+#include "Pet.h"
+#include "Util.h"
+#include "Transports.h"
+#include "Weather.h"
+#include "BattleGround/BattleGround.h"
+#include "BattleGround/BattleGroundMgr.h"
+#include "BattleGround/BattleGroundAV.h"
+#include "OutdoorPvP/OutdoorPvP.h"
+#include "ArenaTeam.h"
+#include "Chat.h"
+#include "revision_data.h"
+#include "Database/DatabaseImpl.h"
+#include "Spell.h"
+#include "ScriptMgr.h"
+#include "SocialMgr.h"
+#include "AchievementMgr.h"
+#include "Mail.h"
+#include "SpellAuras.h"
+#include "DBCStores.h"
+#include "DB2Stores.h"
+#include "SQLStorages.h"
+#include "Vehicle.h"
+#include "Calendar.h"
+#include "DisableMgr.h"
+#ifdef ENABLE_ELUNA
+#include "LuaEngine.h"
+#endif /* ENABLE_ELUNA */
+
+#include <cmath>
+/**
+ * @brief Consumes and returns the rested experience bonus for an XP award.
+ *
+ * @param xp The base experience amount being awarded.
+ * @return The rested bonus experience amount.
+ */
+uint32 Player::GetXPRestBonus(uint32 xp)
+{
+    uint32 rested_bonus = (uint32)GetRestBonus();           // xp for each rested bonus
+
+    if (rested_bonus > xp)                                  // max rested_bonus == xp or (r+x) = 200% xp
+    {
+        rested_bonus = xp;
+    }
+
+    SetRestBonus(GetRestBonus() - rested_bonus);
+
+    DETAIL_LOG("Player gain %u xp (+ %u Rested Bonus). Rested points=%f", xp + rested_bonus, rested_bonus, GetRestBonus());
+    return rested_bonus;
+}
+
+/**
+ * @brief Sets the player's accumulated rested experience bonus.
+ *
+ * @param rest_bonus_new The new rested bonus amount.
+ */
+void Player::SetRestBonus(float rest_bonus_new)
+{
+    // Prevent resting on max level
+    if (getLevel() >= sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL))
+    {
+        rest_bonus_new = 0;
+    }
+
+    if (rest_bonus_new < 0)
+    {
+        rest_bonus_new = 0;
+    }
+
+    float rest_bonus_max = (float)GetUInt32Value(PLAYER_NEXT_LEVEL_XP) * 1.5f / 2.0f;
+
+    if (rest_bonus_new > rest_bonus_max)
+    {
+        m_rest_bonus = rest_bonus_max;
+    }
+    else
+    {
+        m_rest_bonus = rest_bonus_new;
+    }
+
+    // update data for client
+    if (m_rest_bonus > 10)
+    {
+        SetByteValue(PLAYER_BYTES_2, 3, REST_STATE_RESTED);
+    }
+    else if (m_rest_bonus <= 1)
+    {
+        SetByteValue(PLAYER_BYTES_2, 3, REST_STATE_NORMAL);
+    }
+
+    // RestTickUpdate
+    SetUInt32Value(PLAYER_REST_STATE_EXPERIENCE, uint32(m_rest_bonus));
+}
+
+/**
+ * @brief Updates the player's current resting state.
+ *
+ * @param n_r_type The new rest type.
+ * @param areaTriggerId The inn or rest area trigger identifier, if applicable.
+ */
+void Player::SetRestType(RestType n_r_type, uint32 areaTriggerId /*= 0*/)
+{
+    rest_type = n_r_type;
+
+    if (rest_type == REST_TYPE_NO)
+    {
+        RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
+
+        // Set player to FFA PVP when not in rested environment.
+        if (sWorld.IsFFAPvPRealm())
+        {
+            SetFFAPvP(true);
+        }
+    }
+    else
+    {
+        SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_RESTING);
+
+        inn_trigger_id = areaTriggerId;
+        time_inn_enter = time(NULL);
+
+        if (sWorld.IsFFAPvPRealm())
+        {
+            SetFFAPvP(false);
+        }
+    }
+}
+
+/**
+ * @brief Computes rested experience gained over a period of time.
+ *
+ * @param timePassed The elapsed time in seconds.
+ * @param offline True when the gain is being computed for offline time.
+ * @param inRestPlace True when the player is in a rest area while offline.
+ * @return The amount of rested experience bonus gained.
+ */
+float Player::ComputeRest(time_t timePassed, bool offline /*= false*/, bool inRestPlace /*= false*/)
+{
+    // Every 8h in resting zone we gain a bubble
+    // A bubble is 5% of the total xp so there are 20 bubbles
+    // So we gain (total XP/20 every 8h) (8h = 288800 sec)
+    // (TotalXP/20)/28800; simplified to (TotalXP/576000) per second
+    // Client automatically double the value sent so we have to divide it by 2
+    // So final formula (TotalXP/1152000)
+    float bonus = timePassed * (GetUInt32Value(PLAYER_NEXT_LEVEL_XP) / 1152000.0f); // Get the gained rest xp for given second
+    if (!offline)
+    {
+        bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_INGAME);                   // Apply the custom setting
+    }
+    else
+    {
+        if (inRestPlace)
+        {
+            bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_OFFLINE_IN_TAVERN_OR_CITY);
+        }
+        else
+        {
+            bonus *= sWorld.getConfig(CONFIG_FLOAT_RATE_REST_OFFLINE_IN_WILDERNESS) / 4.0f; // bonus is reduced by 4 when not in rest place
+        }
+    }
+    return bonus;
+}


### PR DESCRIPTION
Continues the Player.cpp cohesion-split campaign. Single-concern extraction of the rested-XP system into its own translation unit.

**PlayerRest.cpp** — rested-XP / resting-state methods:
- `GetXPRestBonus`, `SetRestBonus`, `SetRestType`, `ComputeRest`

These were scattered across Player.cpp (lines 4301–7603); consolidated into one cohesive TU. Pure move — no behavior change. Declarations in `Player.h` are untouched, so all call sites are unaffected. (`UpdateHomebindTime` is intentionally left in Player.cpp — it is a homebind-teleport-timer concern called from the main tick, not part of the rested-XP system.)

Verified: extracted method bodies are byte-identical to the originals (117 non-blank lines, zero diff), and the `game` library builds clean in Release (warnings-as-errors).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/167)
<!-- Reviewable:end -->
