### PR TITLE
[Decomp][Player] Extract death-knight rune system into RuneMgr

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -305,7 +305,7 @@ UpdateMask Player::updateVisualBits;
  *
  * @param session The owning world session.
  */
-Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_petMgr(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this), m_honorMgr(this), m_currencyMgr(this)
+Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_petMgr(this), m_achievementMgr(this), m_reputationMgr(this), m_glyphMgr(this), m_honorMgr(this), m_currencyMgr(this), m_runeMgr(this)
 {
     m_transport = 0;
 
@@ -530,7 +530,6 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
 
     // Initialize declined name to NULL
     m_declinedname = NULL;
-    m_runes = NULL;
 
     // Initialize last fall time to 0
     m_lastFallTime = 0;
@@ -597,7 +596,6 @@ Player::~Player()
         }
 
     delete m_declinedname;
-    delete m_runes;
 }
 
 /**

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -59,6 +59,7 @@
 #include "GlyphMgr.h"   // GlyphMgr is held by value on Player; brings in Glyph struct + GlyphUpdateState enum
 #include "HonorMgr.h"   // HonorMgr is held by value on Player; owns daily-kill rollover + RewardHonor calculation
 #include "CurrencyMgr.h" // CurrencyMgr is held by value on Player; brings in PlayerCurrency struct + PlayerCurrencyState/Flag enums + PlayerCurrenciesMap typedef
+#include "RuneMgr.h"    // RuneMgr is held by value on Player; brings in RuneType/RuneInfo/Runes + owns death-knight rune state
 
 #include "Database/DatabaseEnv.h"
 #include "NPCHandler.h"
@@ -359,60 +360,7 @@ struct Areas
     float y2;        // Y2 coordinate
 };
 
-#define MAX_RUNES               6
-
-enum RuneCooldowns
-{
-    RUNE_BASE_COOLDOWN          = 10000,
-    RUNE_MISS_COOLDOWN          = 1500     // cooldown applied on runes when the spell misses
-};
-
-enum RuneType
-{
-    RUNE_BLOOD                  = 0,
-    RUNE_UNHOLY                 = 1,
-    RUNE_FROST                  = 2,
-    RUNE_DEATH                  = 3,
-    NUM_RUNE_TYPES              = 4
-};
-
-static RuneType runeSlotTypes[MAX_RUNES] =
-{
-    /*0*/ RUNE_BLOOD,
-    /*1*/ RUNE_BLOOD,
-    /*2*/ RUNE_UNHOLY,
-    /*3*/ RUNE_UNHOLY,
-    /*4*/ RUNE_FROST,
-    /*5*/ RUNE_FROST
-};
-
-struct RuneInfo
-{
-    uint8  BaseRune;
-    uint8  CurrentRune;
-    uint16 BaseCooldown;
-    uint16 Cooldown;                                        // msec
-    Aura const* ConvertAura;
-};
-
-struct Runes
-{
-    RuneInfo runes[MAX_RUNES];
-    uint8 runeState;                                        // mask of available runes
-    uint32 lastUsedRuneMask;
-
-    void SetRuneState(uint8 index, bool set = true)
-    {
-        if (set)
-        {
-            runeState |= (1 << index);                      // usable
-        }
-        else
-        {
-            runeState &= ~(1 << index);                     // on cooldown
-        }
-    }
-};
+// Rune system types (MAX_RUNES / RuneType / RuneInfo / Runes) moved to RuneMgr.h
 
 struct EnchantDuration
 {
@@ -3775,32 +3723,32 @@ class Player : public Unit
 
         DeclinedName const* GetDeclinedNames() const { return m_declinedname; }
 
-        // Rune functions, need check  getClass() == CLASS_DEATH_KNIGHT before access
-        uint8 GetRunesState() const { return m_runes->runeState; }
-        RuneType GetBaseRune(uint8 index) const { return RuneType(m_runes->runes[index].BaseRune); }
-        RuneType GetCurrentRune(uint8 index) const { return RuneType(m_runes->runes[index].CurrentRune); }
-        uint16 GetRuneCooldown(uint8 index) const { return m_runes->runes[index].Cooldown; }
-        uint16 GetBaseRuneCooldown(uint8 index) const { return m_runes->runes[index].BaseCooldown; }
-        uint8 GetRuneCooldownFraction(uint8 index) const;
-        void UpdateRuneRegen(RuneType rune);
-        void UpdateRuneRegen();
-        bool IsBaseRuneSlotsOnCooldown(RuneType runeType) const;
-        void ClearLastUsedRuneMask() { m_runes->lastUsedRuneMask = 0; }
-        bool IsLastUsedRune(uint8 index) const { return (m_runes->lastUsedRuneMask & (1 << index)) != 0; }
-        void SetLastUsedRune(RuneType type) { m_runes->lastUsedRuneMask |= 1 << uint32(type); }
-        void SetBaseRune(uint8 index, RuneType baseRune) { m_runes->runes[index].BaseRune = baseRune; }
-        void SetCurrentRune(uint8 index, RuneType currentRune) { m_runes->runes[index].CurrentRune = currentRune; }
-        void SetRuneCooldown(uint8 index, uint16 cooldown) { m_runes->runes[index].Cooldown = cooldown; m_runes->SetRuneState(index, (cooldown == 0) ? true : false); }
-        void SetBaseRuneCooldown(uint8 index, uint16 cooldown) { m_runes->runes[index].BaseCooldown = cooldown; }
-        void SetRuneConvertAura(uint8 index, Aura const* aura) { m_runes->runes[index].ConvertAura = aura; }
-        void AddRuneByAuraEffect(uint8 index, RuneType newType, Aura const* aura);
-        void RemoveRunesByAuraEffect(Aura const* aura);
-        void RestoreBaseRune(uint8 index);
-        void ConvertRune(uint8 index, RuneType newType);
-        bool ActivateRunes(RuneType type, uint32 count);
-        void ResyncRunes();
-        void AddRunePower(uint8 index);
-        void InitRunes();
+        // Rune functions (delegated to m_runeMgr), need check getClass() == CLASS_DEATH_KNIGHT before access
+        uint8 GetRunesState() const { return m_runeMgr.GetRunesState(); }
+        RuneType GetBaseRune(uint8 index) const { return m_runeMgr.GetBaseRune(index); }
+        RuneType GetCurrentRune(uint8 index) const { return m_runeMgr.GetCurrentRune(index); }
+        uint16 GetRuneCooldown(uint8 index) const { return m_runeMgr.GetRuneCooldown(index); }
+        uint16 GetBaseRuneCooldown(uint8 index) const { return m_runeMgr.GetBaseRuneCooldown(index); }
+        uint8 GetRuneCooldownFraction(uint8 index) const { return m_runeMgr.GetRuneCooldownFraction(index); }
+        void UpdateRuneRegen(RuneType rune) { m_runeMgr.UpdateRuneRegen(rune); }
+        void UpdateRuneRegen() { m_runeMgr.UpdateRuneRegen(); }
+        bool IsBaseRuneSlotsOnCooldown(RuneType runeType) const { return m_runeMgr.IsBaseRuneSlotsOnCooldown(runeType); }
+        void ClearLastUsedRuneMask() { m_runeMgr.ClearLastUsedRuneMask(); }
+        bool IsLastUsedRune(uint8 index) const { return m_runeMgr.IsLastUsedRune(index); }
+        void SetLastUsedRune(RuneType type) { m_runeMgr.SetLastUsedRune(type); }
+        void SetBaseRune(uint8 index, RuneType baseRune) { m_runeMgr.SetBaseRune(index, baseRune); }
+        void SetCurrentRune(uint8 index, RuneType currentRune) { m_runeMgr.SetCurrentRune(index, currentRune); }
+        void SetRuneCooldown(uint8 index, uint16 cooldown) { m_runeMgr.SetRuneCooldown(index, cooldown); }
+        void SetBaseRuneCooldown(uint8 index, uint16 cooldown) { m_runeMgr.SetBaseRuneCooldown(index, cooldown); }
+        void SetRuneConvertAura(uint8 index, Aura const* aura) { m_runeMgr.SetRuneConvertAura(index, aura); }
+        void AddRuneByAuraEffect(uint8 index, RuneType newType, Aura const* aura) { m_runeMgr.AddRuneByAuraEffect(index, newType, aura); }
+        void RemoveRunesByAuraEffect(Aura const* aura) { m_runeMgr.RemoveRunesByAuraEffect(aura); }
+        void RestoreBaseRune(uint8 index) { m_runeMgr.RestoreBaseRune(index); }
+        void ConvertRune(uint8 index, RuneType newType) { m_runeMgr.ConvertRune(index, newType); }
+        bool ActivateRunes(RuneType type, uint32 count) { return m_runeMgr.ActivateRunes(type, count); }
+        void ResyncRunes() { m_runeMgr.ResyncRunes(); }
+        void AddRunePower(uint8 index) { m_runeMgr.AddRunePower(index); }
+        void InitRunes() { m_runeMgr.Init(); }
 
         AchievementMgr const& GetAchievementMgr() const { return m_achievementMgr; }
         AchievementMgr& GetAchievementMgr() { return m_achievementMgr; }
@@ -4114,7 +4062,7 @@ class Player : public Unit
         float m_summon_z; // Summon Z coordinate
 
         DeclinedName* m_declinedname;
-        Runes* m_runes;
+        RuneMgr m_runeMgr;
         EquipmentSets m_EquipmentSets;
         uint8 m_slot;
 

--- a/src/game/Object/RuneMgr.cpp
+++ b/src/game/Object/RuneMgr.cpp
@@ -22,66 +22,30 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
+#include "RuneMgr.h"
 #include "Player.h"
-#include "Language.h"
-#include "Database/DatabaseEnv.h"
 #include "Log.h"
 #include "Opcodes.h"
 #include "SpellMgr.h"
 #include "World.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
-#include "UpdateMask.h"
-#include "SkillDiscovery.h"
-#include "QuestDef.h"
-#include "GossipDef.h"
-#include "UpdateData.h"
-#include "Channel.h"
-#include "ChannelMgr.h"
-#include "MapManager.h"
-#include "MapPersistentStateMgr.h"
-#include "InstanceData.h"
-#include "GridNotifiers.h"
-#include "GridNotifiersImpl.h"
-#include "CellImpl.h"
-#include "ObjectMgr.h"
-#include "ObjectAccessor.h"
-#include "CreatureAI.h"
-#include "Formulas.h"
-#include "Group.h"
-#include "Guild.h"
-#include "GuildMgr.h"
-#include "Pet.h"
-#include "Util.h"
-#include "Transports.h"
-#include "Weather.h"
-#include "BattleGround/BattleGround.h"
-#include "BattleGround/BattleGroundMgr.h"
-#include "BattleGround/BattleGroundAV.h"
-#include "OutdoorPvP/OutdoorPvP.h"
-#include "ArenaTeam.h"
-#include "Chat.h"
-#include "revision_data.h"
-#include "Database/DatabaseImpl.h"
-#include "Spell.h"
-#include "ScriptMgr.h"
-#include "SocialMgr.h"
-#include "AchievementMgr.h"
-#include "Mail.h"
 #include "SpellAuras.h"
-#include "DBCStores.h"
-#include "DB2Stores.h"
-#include "SQLStorages.h"
-#include "Vehicle.h"
-#include "Calendar.h"
-#include "DisableMgr.h"
-#ifdef ENABLE_ELUNA
-#include "LuaEngine.h"
-#endif /* ENABLE_ELUNA */
+#include "Unit.h"
 
 #include <cmath>
 
-void Player::UpdateRuneRegen(RuneType rune)
+static RuneType runeSlotTypes[MAX_RUNES] =
+{
+    /*0*/ RUNE_BLOOD,
+    /*1*/ RUNE_BLOOD,
+    /*2*/ RUNE_UNHOLY,
+    /*3*/ RUNE_UNHOLY,
+    /*4*/ RUNE_FROST,
+    /*5*/ RUNE_FROST
+};
+
+void RuneMgr::UpdateRuneRegen(RuneType rune)
 {
     if (rune >= RUNE_DEATH)
     {
@@ -118,7 +82,7 @@ void Player::UpdateRuneRegen(RuneType rune)
     }
 
     float auraMod = 1.0f;
-    Unit::AuraList const& regenAuras = GetAurasByType(SPELL_AURA_MOD_POWER_REGEN_PERCENT);
+    Unit::AuraList const& regenAuras = m_owner->GetAurasByType(SPELL_AURA_MOD_POWER_REGEN_PERCENT);
     for (Unit::AuraList::const_iterator i = regenAuras.begin(); i != regenAuras.end(); ++i)
         if ((*i)->GetMiscValue() == POWER_RUNE && (*i)->GetSpellEffect()->EffectMiscValueB == rune)
         {
@@ -126,18 +90,18 @@ void Player::UpdateRuneRegen(RuneType rune)
         }
 
     // Unholy Presence
-    if (Aura* aura = GetAura(48265, EFFECT_INDEX_0))
+    if (Aura* aura = m_owner->GetAura(48265, EFFECT_INDEX_0))
     {
         auraMod *= (100.0f + aura->GetModifier()->m_amount) / 100.0f;
     }
 
     // Runic Corruption
-    if (Aura* aura = GetAura(51460, EFFECT_INDEX_0))
+    if (Aura* aura = m_owner->GetAura(51460, EFFECT_INDEX_0))
     {
         auraMod *= (100.0f + aura->GetModifier()->m_amount) / 100.0f;
     }
 
-    float hastePct = (100.0f - GetRatingBonusValue(CR_HASTE_MELEE)) / 100.0f;
+    float hastePct = (100.0f - m_owner->GetRatingBonusValue(CR_HASTE_MELEE)) / 100.0f;
     if (hastePct < 0)
     {
         hastePct = 1.0f;
@@ -146,10 +110,10 @@ void Player::UpdateRuneRegen(RuneType rune)
     cooldown *= hastePct / auraMod;
 
     float value = float(1 * IN_MILLISECONDS) / cooldown;
-    SetFloatValue(PLAYER_RUNE_REGEN_1 + uint8(actualRune), value);
+    m_owner->SetFloatValue(PLAYER_RUNE_REGEN_1 + uint8(actualRune), value);
 }
 
-void Player::UpdateRuneRegen()
+void RuneMgr::UpdateRuneRegen()
 {
     for (uint8 i = 0; i < NUM_RUNE_TYPES; ++i)
     {
@@ -157,7 +121,7 @@ void Player::UpdateRuneRegen()
     }
 }
 
-uint8 Player::GetRuneCooldownFraction(uint8 index) const
+uint8 RuneMgr::GetRuneCooldownFraction(uint8 index) const
 {
     uint16 baseCd = GetBaseRuneCooldown(index);
     if (!baseCd || !GetRuneCooldown(index))
@@ -172,22 +136,22 @@ uint8 Player::GetRuneCooldownFraction(uint8 index) const
     return uint8(float(baseCd - GetRuneCooldown(index)) / baseCd * 255);
 }
 
-void Player::AddRuneByAuraEffect(uint8 index, RuneType newType, Aura const* aura)
+void RuneMgr::AddRuneByAuraEffect(uint8 index, RuneType newType, Aura const* aura)
 {
     // Item - Death Knight T11 DPS 4P Bonus
-    if (newType == RUNE_DEATH && HasAura(90459))
+    if (newType == RUNE_DEATH && m_owner->HasAura(90459))
     {
-        CastSpell(this, 90507, true);   // Death Eater
+        m_owner->CastSpell(m_owner, 90507, true);   // Death Eater
     }
 
     SetRuneConvertAura(index, aura); ConvertRune(index, newType);
 }
 
-void Player::RemoveRunesByAuraEffect(Aura const* aura)
+void RuneMgr::RemoveRunesByAuraEffect(Aura const* aura)
 {
     for (uint8 i = 0; i < MAX_RUNES; ++i)
     {
-        if (m_runes->runes[i].ConvertAura == aura)
+        if (m_data.runes[i].ConvertAura == aura)
         {
             ConvertRune(i, GetBaseRune(i));
             SetRuneConvertAura(i, NULL);
@@ -195,9 +159,9 @@ void Player::RemoveRunesByAuraEffect(Aura const* aura)
     }
 }
 
-void Player::RestoreBaseRune(uint8 index)
+void RuneMgr::RestoreBaseRune(uint8 index)
 {
-    Aura const* aura = m_runes->runes[index].ConvertAura;
+    Aura const* aura = m_data.runes[index].ConvertAura;
     // If rune was converted by a non-pasive aura that still active we should keep it converted
     if (aura && !IsPassiveSpell(aura->GetSpellProto()))
     {
@@ -205,7 +169,7 @@ void Player::RestoreBaseRune(uint8 index)
     }
 
     // Blood of the North
-    if (aura->GetId() == 54637 && HasAura(54637))
+    if (aura->GetId() == 54637 && m_owner->HasAura(54637))
     {
         return;
     }
@@ -219,7 +183,7 @@ void Player::RestoreBaseRune(uint8 index)
     }
 
     for (uint8 i = 0; i < MAX_RUNES; ++i)
-        if (aura == m_runes->runes[i].ConvertAura)
+        if (aura == m_data.runes[i].ConvertAura)
         {
             return;
         }
@@ -230,17 +194,17 @@ void Player::RestoreBaseRune(uint8 index)
     }
 }
 
-void Player::ConvertRune(uint8 index, RuneType newType)
+void RuneMgr::ConvertRune(uint8 index, RuneType newType)
 {
     SetCurrentRune(index, newType);
 
     WorldPacket data(SMSG_CONVERT_RUNE, 2);
     data << uint8(index);
     data << uint8(newType);
-    GetSession()->SendPacket(&data);
+    m_owner->GetSession()->SendPacket(&data);
 }
 
-bool Player::ActivateRunes(RuneType type, uint32 count)
+bool RuneMgr::ActivateRunes(RuneType type, uint32 count)
 {
     bool modify = false;
     for (uint32 j = 0; count > 0 && j < MAX_RUNES; ++j)
@@ -256,7 +220,7 @@ bool Player::ActivateRunes(RuneType type, uint32 count)
     return modify;
 }
 
-void Player::ResyncRunes()
+void RuneMgr::ResyncRunes()
 {
     WorldPacket data(SMSG_RESYNC_RUNES, 4 + MAX_RUNES * 2);
     data << uint32(MAX_RUNES);
@@ -265,42 +229,40 @@ void Player::ResyncRunes()
         data << uint8(GetCurrentRune(i));                   // rune type
         data << uint8(GetRuneCooldownFraction(i));
     }
-    GetSession()->SendPacket(&data);
+    m_owner->GetSession()->SendPacket(&data);
 }
 
-void Player::AddRunePower(uint8 index)
+void RuneMgr::AddRunePower(uint8 index)
 {
     WorldPacket data(SMSG_ADD_RUNE_POWER, 4);
     data << uint32(1 << index);                             // mask (0x00-0x3F probably)
-    GetSession()->SendPacket(&data);
+    m_owner->GetSession()->SendPacket(&data);
 }
 
-void Player::InitRunes()
+void RuneMgr::Init()
 {
-    if (getClass() != CLASS_DEATH_KNIGHT)
+    if (m_owner->getClass() != CLASS_DEATH_KNIGHT)
     {
         return;
     }
 
-    m_runes = new Runes;
-
-    m_runes->runeState = 0;
+    m_data.runeState = 0;
 
     for (uint32 i = 0; i < MAX_RUNES; ++i)
     {
         SetBaseRune(i, runeSlotTypes[i]);                   // init base types
         SetCurrentRune(i, runeSlotTypes[i]);                // init current types
         SetRuneCooldown(i, 0);                              // reset cooldowns
-        m_runes->SetRuneState(i);
+        m_data.SetRuneState(i);
     }
 
     for (uint32 i = 0; i < NUM_RUNE_TYPES; ++i)
     {
-        SetFloatValue(PLAYER_RUNE_REGEN_1 + i, 0.1f);
+        m_owner->SetFloatValue(PLAYER_RUNE_REGEN_1 + i, 0.1f);
     }
 }
 
-bool Player::IsBaseRuneSlotsOnCooldown(RuneType runeType) const
+bool RuneMgr::IsBaseRuneSlotsOnCooldown(RuneType runeType) const
 {
     for (uint32 i = 0; i < MAX_RUNES; ++i)
         if (GetBaseRune(i) == runeType && GetRuneCooldown(i) == 0)

--- a/src/game/Object/RuneMgr.h
+++ b/src/game/Object/RuneMgr.h
@@ -1,0 +1,121 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_RUNEMGR
+#define MANGOS_H_RUNEMGR
+
+#include "Common.h"
+
+class Player;
+class Aura;
+
+#define MAX_RUNES               6
+
+enum RuneCooldowns
+{
+    RUNE_BASE_COOLDOWN          = 10000,
+    RUNE_MISS_COOLDOWN          = 1500     // cooldown applied on runes when the spell misses
+};
+
+enum RuneType
+{
+    RUNE_BLOOD                  = 0,
+    RUNE_UNHOLY                 = 1,
+    RUNE_FROST                  = 2,
+    RUNE_DEATH                  = 3,
+    NUM_RUNE_TYPES              = 4
+};
+
+struct RuneInfo
+{
+    uint8  BaseRune;
+    uint8  CurrentRune;
+    uint16 BaseCooldown;
+    uint16 Cooldown;                                        // msec
+    Aura const* ConvertAura;
+};
+
+struct Runes
+{
+    RuneInfo runes[MAX_RUNES];
+    uint8 runeState;                                        // mask of available runes
+    uint32 lastUsedRuneMask;
+
+    void SetRuneState(uint8 index, bool set = true)
+    {
+        if (set)
+        {
+            runeState |= (1 << index);                      // usable
+        }
+        else
+        {
+            runeState &= ~(1 << index);                     // on cooldown
+        }
+    }
+};
+
+/**
+ * @brief Owns a death knight player's rune state and rune-system behaviour.
+ *
+ * Held by value on Player as m_runeMgr; rune state is runtime-only (rebuilt by
+ * Init() on create/login, never persisted). All access requires the owner to be
+ * a death knight - see callers' getClass() checks.
+ */
+class RuneMgr
+{
+    public:
+        explicit RuneMgr(Player* owner) : m_owner(owner) {}
+
+        uint8 GetRunesState() const { return m_data.runeState; }
+        RuneType GetBaseRune(uint8 index) const { return RuneType(m_data.runes[index].BaseRune); }
+        RuneType GetCurrentRune(uint8 index) const { return RuneType(m_data.runes[index].CurrentRune); }
+        uint16 GetRuneCooldown(uint8 index) const { return m_data.runes[index].Cooldown; }
+        uint16 GetBaseRuneCooldown(uint8 index) const { return m_data.runes[index].BaseCooldown; }
+        uint8 GetRuneCooldownFraction(uint8 index) const;
+        void UpdateRuneRegen(RuneType rune);
+        void UpdateRuneRegen();
+        bool IsBaseRuneSlotsOnCooldown(RuneType runeType) const;
+        void ClearLastUsedRuneMask() { m_data.lastUsedRuneMask = 0; }
+        bool IsLastUsedRune(uint8 index) const { return (m_data.lastUsedRuneMask & (1 << index)) != 0; }
+        void SetLastUsedRune(RuneType type) { m_data.lastUsedRuneMask |= 1 << uint32(type); }
+        void SetBaseRune(uint8 index, RuneType baseRune) { m_data.runes[index].BaseRune = baseRune; }
+        void SetCurrentRune(uint8 index, RuneType currentRune) { m_data.runes[index].CurrentRune = currentRune; }
+        void SetRuneCooldown(uint8 index, uint16 cooldown) { m_data.runes[index].Cooldown = cooldown; m_data.SetRuneState(index, (cooldown == 0) ? true : false); }
+        void SetBaseRuneCooldown(uint8 index, uint16 cooldown) { m_data.runes[index].BaseCooldown = cooldown; }
+        void SetRuneConvertAura(uint8 index, Aura const* aura) { m_data.runes[index].ConvertAura = aura; }
+        void AddRuneByAuraEffect(uint8 index, RuneType newType, Aura const* aura);
+        void RemoveRunesByAuraEffect(Aura const* aura);
+        void RestoreBaseRune(uint8 index);
+        void ConvertRune(uint8 index, RuneType newType);
+        bool ActivateRunes(RuneType type, uint32 count);
+        void ResyncRunes();
+        void AddRunePower(uint8 index);
+        void Init();
+
+    private:
+        Player* m_owner;
+        Runes m_data;
+};
+
+#endif


### PR DESCRIPTION
Resumes the **manager-extraction** track of the Player decomposition (GlyphMgr / HonorMgr / CurrencyMgr / PetMgr pattern) — moving cohesive *state + behaviour* out of the Player class, not just relocating method bodies.

**New `RuneMgr` (`RuneMgr.{h,cpp}`)** owns the death-knight rune system:
- State: the `Runes`/`RuneInfo` data + `RuneType`/`RuneCooldowns`/`MAX_RUNES` (moved out of Player.h), held **by value** — so the old raw `Runes* m_runes` pointer and its manual `new`/`delete` in Player's ctor/dtor are gone.
- Behaviour: the 12 rune methods (`UpdateRuneRegen` ×2, `ConvertRune`, `ActivateRunes`, `ResyncRunes`, `RestoreBaseRune`, `AddRuneByAuraEffect`, `RemoveRunesByAuraEffect`, `AddRunePower`, `GetRuneCooldownFraction`, `IsBaseRuneSlotsOnCooldown`, `Init`) — relocated from `PlayerRune.cpp` (which this PR removes) into `RuneMgr.cpp`, calling back through a `Player* m_owner`.

Player keeps the exact same public rune API as **thin inline delegates** to `m_runeMgr`, so **every call site is unchanged** (Spell / SpellAuras / SpellEffects, etc.). No DB migration — rune state is runtime-only (`Init()` rebuilds it on create/login).

**Verified:**
- `game` lib **and full `mangosd.exe`** build clean in Release (warnings-as-errors).
- Logic-preservation checked by a normalized diff of the moved methods vs the originals — the only delta is the required `CastSpell(this,…)` → `CastSpell(m_owner,…)` owner substitution; everything else is byte-identical.

Net: removes a raw owning pointer + a struct + ~13 internal accessors from the Player class surface, with zero behavioural change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/170)
<!-- Reviewable:end -->
