### PR TITLE
[Movement] Port H0zen positive-angle and reachable-point fixes

### DIFF
--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -3098,25 +3098,39 @@ bool Map::GetReachableRandomPointOnGround(uint32 phaseMask, float& x, float& y, 
 //        return false;
 
     // here we have a valid position but the point can have a big Z in some case
-    // next code will check angle from 2 points
+    // next code will check angle from 2 points of view: x-axis and y-axis movement
     //        c
     //       /|
     //      / |
     //    b/__|a
 
     // project vector to get only positive value
-    float ab = fabs(x - i_x);
     float ac = fabs(z - i_z);
+    float delta = 0;
 
-    // slope represented by c angle (in radian)
+    // slope represented by b angle (in radian)
     float slope = 0;
     const float MAX_SLOPE_IN_RADIAN = 50.0f / 180.0f * M_PI_F;  // 50(degree) max seem best value for walkable slope
 
-    // check ab vector to avoid divide by 0
-    if (ab > 0.0f)
+    delta = fabs(x - i_x);  // check x-axis movement
+    if (delta > 0.0f)       // check to avoid divide by 0
     {
-        // compute c angle and convert it from radian to degree
-        slope = atan(ac / ab);
+        // compute slope
+        slope = atan(ac / delta);
+        if (slope < MAX_SLOPE_IN_RADIAN)
+        {
+            x = i_x;
+            y = i_y;
+            z = i_z;
+            return true;
+        }
+    }
+
+    delta = fabs(y - i_y);  // check y-axis movement
+    if (delta > 0.0f)       // check to avoid divide by 0
+    {
+        // compute slope
+        slope = atan(ac / delta);
         if (slope < MAX_SLOPE_IN_RADIAN)
         {
             x = i_x;

--- a/src/game/movement/MoveSpline.cpp
+++ b/src/game/movement/MoveSpline.cpp
@@ -90,6 +90,7 @@ namespace Movement
                 c.orientation = -c.orientation;
             }
         }
+        c.orientation = G3D::wrap(c.orientation, 0.f, (float)G3D::twoPi());
         return c;
     }
 


### PR DESCRIPTION
Ports the two engine fixes from H0zen's "Various external fixes - part 3a/3b"
(mangostwo `81de264f` / `100fc045`) that actually apply to this fork. The
other changes in those commits are already present in mangosthree
(GameObject::GetInteractionDistance, the SpellHandler distance gate, the
TaxiHandler ERR_TAXINOTVISITED checks) or are WotLK-specific, so they are not
included.

**1. `MoveSpline::ComputePosition` — wrap orientation to `[0, 2pi)`**
Spline-derived (`atan2`) and inverted orientations could be negative; the
client expects the WoW `[0, 2pi)` convention. Adds a single `G3D::wrap`.

**2. `Map::GetReachableRandomPointOnGround` — test both axes**
The old slope check only used the x-axis delta, so a y-dominant candidate
point (`x ~= i_x`) skipped the walkable-slope test entirely and was rejected.
Now checks x and y.

Note: H0zen's version shadows `slope` with an inner `float slope` in the
x-axis branch; dropped the redundant `float` so the move stays clean under
`-WX`.

Both are pure server-side math (no wire format, DBC, or opcode change).
Release build clean, no new warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/196)
<!-- Reviewable:end -->
