### PR TITLE
[Decomp][Spell] Cohesion split: extract effect dispatch to SpellEffectDispatch.cpp

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -81,8 +81,6 @@
 #include "LuaEngine.h"
 #endif /* ENABLE_ELUNA */
 
-extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];
-
 class PrioritizeManaUnitWraper
 {
     public:
@@ -665,126 +663,6 @@ bool Spell::IsAliveUnitPresentInTargetList()
 
     // is all effects from m_needAliveTargetMask have alive targets
     return needAliveTargetMask == 0;
-}
-
-/**
- * @brief Dispatches one spell effect against the current resolved targets.
- *
- * @param pUnitTarget The unit target, if any.
- * @param pItemTarget The item target, if any.
- * @param pGOTarget The game object target, if any.
- * @param i The effect index to process.
- * @param DamageMultiplier The damage multiplier to apply for the effect.
- */
-void Spell::HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOTarget, SpellEffectIndex i, float DamageMultiplier)
-{
-    unitTarget = pUnitTarget;
-    itemTarget = pItemTarget;
-    gameObjTarget = pGOTarget;
-
-    SpellEffectEntry const* spellEffect = m_spellInfo->GetSpellEffect(SpellEffectIndex(i));
-
-    damage = int32(CalculateDamage(i, unitTarget) * DamageMultiplier);
-
-    if (spellEffect)
-    {
-        if (spellEffect->Effect < TOTAL_SPELL_EFFECTS)
-        {
-            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u Effect%d : %u Targets: %s, %s, %s",
-                m_spellInfo->Id, i, spellEffect->Effect,
-                unitTarget ? unitTarget->GetGuidStr().c_str() : "-",
-                itemTarget ? itemTarget->GetGuidStr().c_str() : "-",
-                gameObjTarget ? gameObjTarget->GetGuidStr().c_str() : "-");
-
-            (*this.*SpellEffects[spellEffect->Effect])(spellEffect);
-        }
-        else
-        {
-            sLog.outError("WORLD: Spell %u Effect%d : %u > TOTAL_SPELL_EFFECTS", m_spellInfo->Id, i, spellEffect->Effect);
-        }
-    }
-    else
-    {
-        sLog.outError("WORLD: Spell %u has no effect at index %u", m_spellInfo->Id, i);
-    }
-}
-
-/**
- * @brief Queues a spell to be triggered after successful completion.
- *
- * @param spellId The triggered spell identifier.
- */
-void Spell::AddTriggeredSpell(uint32 spellId)
-{
-    SpellEntry const* spellInfo = sSpellStore.LookupEntry(spellId);
-
-    if (!spellInfo)
-    {
-        sLog.outError("Spell::AddTriggeredSpell: unknown spell id %u used as triggred spell for spell %u)", spellId, m_spellInfo->Id);
-        return;
-    }
-
-    m_TriggerSpells.push_back(spellInfo);
-}
-
-/**
- * @brief Queues a spell to be cast before applying effects to each target.
- *
- * @param spellId The precast spell identifier.
- */
-void Spell::AddPrecastSpell(uint32 spellId)
-{
-    SpellEntry const* spellInfo = sSpellStore.LookupEntry(spellId);
-
-    if (!spellInfo)
-    {
-        sLog.outError("Spell::AddPrecastSpell: unknown spell id %u used as pre-cast spell for spell %u)", spellId, m_spellInfo->Id);
-        return;
-    }
-
-    m_preCastSpells.push_back(spellInfo);
-}
-
-/**
- * @brief Casts spells queued to trigger after the main spell completes successfully.
- */
-void Spell::CastTriggerSpells()
-{
-    for (SpellInfoList::const_iterator si = m_TriggerSpells.begin(); si != m_TriggerSpells.end(); ++si)
-    {
-        Spell* spell = new Spell(m_caster, (*si), true, m_originalCasterGUID);
-        spell->SpellStart(&m_targets);                         // use original spell original targets
-    }
-}
-
-/**
- * @brief Casts queued precast spells on the provided target.
- *
- * @param target The unit target for the precast spells.
- */
-void Spell::CastPreCastSpells(Unit* target)
-{
-    for (SpellInfoList::const_iterator si = m_preCastSpells.begin(); si != m_preCastSpells.end(); ++si)
-    {
-        m_caster->CastSpell(target, (*si), true, m_CastItem);
-    }
-}
-
-/**
- * @brief Gets the first queued unit target guid for an effect, falling back to the explicit target guid.
- *
- * @param effIndex The effect index to inspect.
- * @return The matching unit target guid, or the explicit unit target guid when none is queued.
- */
-Unit* Spell::GetPrefilledUnitTargetOrUnitTarget(SpellEffectIndex effIndex) const
-{
-    for (TargetList::const_iterator itr = m_UniqueTargetInfo.begin(); itr != m_UniqueTargetInfo.end(); ++itr)
-        if (itr->effectMask & (1 << effIndex))
-        {
-            return m_caster->GetMap()->GetUnit(itr->targetGUID);
-        }
-
-    return m_targets.getUnitTarget();
 }
 
 /**

--- a/src/game/WorldHandlers/SpellEffectDispatch.cpp
+++ b/src/game/WorldHandlers/SpellEffectDispatch.cpp
@@ -1,0 +1,204 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+/**
+ * @file Spell.cpp
+ * @brief Spell casting and effect implementation
+ *
+ * This file implements the Spell class which handles spell casting:
+ * - Spell validation and casting requirements
+ * - Spell effect execution (damage, healing, summon, etc.)
+ * - Spell targeting and area effects
+ * - Spell cooldowns and resource costs
+ * - Spell interruption and pushback
+ * - Spell aura application
+ * - Spell hit/miss calculations
+ *
+ * Spells are the primary combat mechanic in WoW, encompassing
+ * abilities, talents, and item effects.
+ *
+ * @see Spell for the spell class
+ * @see SpellAura for spell auras
+ * @see SpellMgr for spell management
+ */
+
+#include "Spell.h"
+#include "Database/DatabaseEnv.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "Opcodes.h"
+#include "Log.h"
+#include "UpdateMask.h"
+#include "World.h"
+#include "ObjectMgr.h"
+#include "SpellMgr.h"
+#include "Player.h"
+#include "Pet.h"
+#include "Unit.h"
+#include "DynamicObject.h"
+#include "Group.h"
+#include "UpdateData.h"
+#include "MapManager.h"
+#include "ObjectAccessor.h"
+#include "CellImpl.h"
+#include "Policies/Singleton.h"
+#include "SharedDefines.h"
+#include "LootMgr.h"
+#include "VMapFactory.h"
+#include "BattleGround/BattleGround.h"
+#include "Util.h"
+#include "Chat.h"
+#include "DB2Stores.h"
+#include "SQLStorages.h"
+#include "Vehicle.h"
+#include "TemporarySummon.h"
+#include "SQLStorages.h"
+#include "DisableMgr.h"
+#ifdef ENABLE_ELUNA
+#include "LuaEngine.h"
+#endif /* ENABLE_ELUNA */
+
+extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];
+
+/**
+ * @brief Dispatches one spell effect against the current resolved targets.
+ *
+ * @param pUnitTarget The unit target, if any.
+ * @param pItemTarget The item target, if any.
+ * @param pGOTarget The game object target, if any.
+ * @param i The effect index to process.
+ * @param DamageMultiplier The damage multiplier to apply for the effect.
+ */
+void Spell::HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOTarget, SpellEffectIndex i, float DamageMultiplier)
+{
+    unitTarget = pUnitTarget;
+    itemTarget = pItemTarget;
+    gameObjTarget = pGOTarget;
+
+    SpellEffectEntry const* spellEffect = m_spellInfo->GetSpellEffect(SpellEffectIndex(i));
+
+    damage = int32(CalculateDamage(i, unitTarget) * DamageMultiplier);
+
+    if (spellEffect)
+    {
+        if (spellEffect->Effect < TOTAL_SPELL_EFFECTS)
+        {
+            DEBUG_FILTER_LOG(LOG_FILTER_SPELL_CAST, "Spell %u Effect%d : %u Targets: %s, %s, %s",
+                m_spellInfo->Id, i, spellEffect->Effect,
+                unitTarget ? unitTarget->GetGuidStr().c_str() : "-",
+                itemTarget ? itemTarget->GetGuidStr().c_str() : "-",
+                gameObjTarget ? gameObjTarget->GetGuidStr().c_str() : "-");
+
+            (*this.*SpellEffects[spellEffect->Effect])(spellEffect);
+        }
+        else
+        {
+            sLog.outError("WORLD: Spell %u Effect%d : %u > TOTAL_SPELL_EFFECTS", m_spellInfo->Id, i, spellEffect->Effect);
+        }
+    }
+    else
+    {
+        sLog.outError("WORLD: Spell %u has no effect at index %u", m_spellInfo->Id, i);
+    }
+}
+
+/**
+ * @brief Queues a spell to be triggered after successful completion.
+ *
+ * @param spellId The triggered spell identifier.
+ */
+void Spell::AddTriggeredSpell(uint32 spellId)
+{
+    SpellEntry const* spellInfo = sSpellStore.LookupEntry(spellId);
+
+    if (!spellInfo)
+    {
+        sLog.outError("Spell::AddTriggeredSpell: unknown spell id %u used as triggred spell for spell %u)", spellId, m_spellInfo->Id);
+        return;
+    }
+
+    m_TriggerSpells.push_back(spellInfo);
+}
+
+/**
+ * @brief Queues a spell to be cast before applying effects to each target.
+ *
+ * @param spellId The precast spell identifier.
+ */
+void Spell::AddPrecastSpell(uint32 spellId)
+{
+    SpellEntry const* spellInfo = sSpellStore.LookupEntry(spellId);
+
+    if (!spellInfo)
+    {
+        sLog.outError("Spell::AddPrecastSpell: unknown spell id %u used as pre-cast spell for spell %u)", spellId, m_spellInfo->Id);
+        return;
+    }
+
+    m_preCastSpells.push_back(spellInfo);
+}
+
+/**
+ * @brief Casts spells queued to trigger after the main spell completes successfully.
+ */
+void Spell::CastTriggerSpells()
+{
+    for (SpellInfoList::const_iterator si = m_TriggerSpells.begin(); si != m_TriggerSpells.end(); ++si)
+    {
+        Spell* spell = new Spell(m_caster, (*si), true, m_originalCasterGUID);
+        spell->SpellStart(&m_targets);                         // use original spell original targets
+    }
+}
+
+/**
+ * @brief Casts queued precast spells on the provided target.
+ *
+ * @param target The unit target for the precast spells.
+ */
+void Spell::CastPreCastSpells(Unit* target)
+{
+    for (SpellInfoList::const_iterator si = m_preCastSpells.begin(); si != m_preCastSpells.end(); ++si)
+    {
+        m_caster->CastSpell(target, (*si), true, m_CastItem);
+    }
+}
+
+/**
+ * @brief Gets the first queued unit target guid for an effect, falling back to the explicit target guid.
+ *
+ * @param effIndex The effect index to inspect.
+ * @return The matching unit target guid, or the explicit unit target guid when none is queued.
+ */
+Unit* Spell::GetPrefilledUnitTargetOrUnitTarget(SpellEffectIndex effIndex) const
+{
+    for (TargetList::const_iterator itr = m_UniqueTargetInfo.begin(); itr != m_UniqueTargetInfo.end(); ++itr)
+        if (itr->effectMask & (1 << effIndex))
+        {
+            return m_caster->GetMap()->GetUnit(itr->targetGUID);
+        }
+
+    return m_targets.getUnitTarget();
+}


### PR DESCRIPTION
Continues the Spell.cpp cohesion split (follows #197–#204).

Moves the effect-dispatch cluster into a new `SpellEffectDispatch.cpp` TU:

- `HandleEffects` (the per-effect dispatcher)
- `AddTriggeredSpell`, `AddPrecastSpell`
- `CastTriggerSpells`, `CastPreCastSpells`
- `GetPrefilledUnitTargetOrUnitTarget`

Pure file move: method bodies are byte-identical, declarations stay in `Spell.h`. The `extern pEffect SpellEffects[TOTAL_SPELL_EFFECTS];` declaration for the dispatch table (defined TU-local in SpellEffects.cpp) travels with `HandleEffects`, its only consumer — so it moves out of Spell.cpp too. `game/CMakeLists.txt` GLOBs the directory; no manual edit.

Spell.cpp: 2,172 → 2,050 lines. New SpellEffectDispatch.cpp: 204 lines.

Build: `mangosd` Release, warning-clean (the lone C4457 is pre-existing in untouched `CheckTarget`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/205)
<!-- Reviewable:end -->
