### PR TITLE
[Warnings] Fix C4457 spellEffect shadow in GetSpellRangeAndRadius

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -2078,9 +2078,9 @@ void Spell::GetSpellRangeAndRadius(SpellEffectEntry const* spellEffect, float& r
                {
                     for(int i = 0; i < MAX_EFFECT_INDEX; ++i)
                     {
-                        if (SpellEffectEntry const* spellEffect = currSpell->m_spellInfo->GetSpellEffect(SpellEffectIndex(i)))
+                        if (SpellEffectEntry const* currEffect = currSpell->m_spellInfo->GetSpellEffect(SpellEffectIndex(i)))
                         {
-                            if (spellEffect->EffectChainTarget > 0)
+                            if (currEffect->EffectChainTarget > 0)
                             {
                                 EffectChainTarget = 0;      // no chain targets
                             }


### PR DESCRIPTION
Fixes the lone `/W4` warning the tree still emits.

`Spell::GetSpellRangeAndRadius` takes a `SpellEffectEntry const* spellEffect` parameter. Inside the Seal of Command (20424) special case, a nested loop declared a local with the same name:

```cpp
if (SpellEffectEntry const* spellEffect = currSpell->m_spellInfo->GetSpellEffect(SpellEffectIndex(i)))
```

which hid the parameter → **C4457**. Renamed the local to `currEffect` (used only inside its own `if`); the parameter and its other uses are untouched. No behaviour change.

Shadow-var cleanup per the coding standard's fast-track. Build: `mangosd` Release now warning-clean (C4457 was the only remaining warning).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/209)
<!-- Reviewable:end -->
