### PR TITLE
[Visibility] Add periodic observer-side visibility sweep

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -313,6 +313,8 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
     m_speakCount = 0;
     m_isOptingOutOfLoot = false;
 
+    m_visibilityObserverSweepTimer = World::GetVisibilityObserverSweepInterval();
+
     m_objectType |= TYPEMASK_PLAYER;
     m_objectTypeId = TYPEID_PLAYER;
 
@@ -997,6 +999,28 @@ void Player::Update(uint32 update_diff, uint32 p_time)
     SetCanDelayTeleport(true);
     Unit::Update(update_diff, p_time);
     SetCanDelayTeleport(false);
+
+    // Periodic observer-side visibility maintenance.
+    // The owner's visible set is otherwise refreshed only when the player moves
+    // (Camera::UpdateVisibilityForOwner via OnRelocated), while an object moving
+    // out of range only re-notifies observers still near that object. A
+    // near-stationary player therefore never gets an out-of-range update for an
+    // active object that walks away, leaving it frozen on the client. Sweep the
+    // owner's visible set on an interval so out-of-range objects are dropped even
+    // when the player stands still. Skipped mid-teleport (visibility is rebuilt
+    // by the teleport path) and gated by config.
+    if (World::GetVisibilityObserverSweepEnabled() && !IsBeingTeleported())
+    {
+        if (m_visibilityObserverSweepTimer <= update_diff)
+        {
+            m_visibilityObserverSweepTimer = World::GetVisibilityObserverSweepInterval();
+            GetCamera().UpdateVisibilityForOwner();
+        }
+        else
+        {
+            m_visibilityObserverSweepTimer -= update_diff;
+        }
+    }
 
     // Update player-only attacks
     if (uint32 ranged_att = getAttackTimer(RANGED_ATTACK))

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -4106,6 +4106,9 @@ class Player : public Unit
         // The player's camera
         Camera m_camera;
 
+        // Countdown (ms) for the periodic observer-side visibility sweep
+        uint32 m_visibilityObserverSweepTimer;
+
         // Grid reference for the player
         GridReference<Player> m_gridRef;
 

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -133,6 +133,9 @@ float World::m_VisibleObjectGreyDistance      = 0;
 float  World::m_relocation_lower_limit_sq     = 10.f * 10.f;
 uint32 World::m_relocation_ai_notify_delay    = 1000u;
 
+bool   World::m_visibility_observer_sweep_enabled  = true;
+uint32 World::m_visibility_observer_sweep_interval = 2000u;
+
 /**
  * @brief World class constructor
  *
@@ -972,6 +975,9 @@ void World::LoadConfigSettings(bool reload)
 
     m_relocation_ai_notify_delay = sConfig.GetIntDefault("Visibility.AIRelocationNotifyDelay", 1000u);
     m_relocation_lower_limit_sq  = pow(sConfig.GetFloatDefault("Visibility.RelocationLowerLimit", 10), 2);
+
+    m_visibility_observer_sweep_enabled  = sConfig.GetBoolDefault("Visibility.ObserverSweep.Enable", true);
+    m_visibility_observer_sweep_interval = sConfig.GetIntDefault("Visibility.ObserverSweep.Interval", 2000);
 
     m_VisibleUnitGreyDistance = sConfig.GetFloatDefault("Visibility.Distance.Grey.Unit", 1);
     if (m_VisibleUnitGreyDistance >  MAX_VISIBILITY_DISTANCE)

--- a/src/game/WorldHandlers/World.h
+++ b/src/game/WorldHandlers/World.h
@@ -654,6 +654,8 @@ class World
         static float GetRelocationLowerLimitSq()            { return m_relocation_lower_limit_sq; }
         static uint32 GetRelocationAINotifyDelay()          { return m_relocation_ai_notify_delay; }
 
+        static bool   GetVisibilityObserverSweepEnabled()   { return m_visibility_observer_sweep_enabled; }
+        static uint32 GetVisibilityObserverSweepInterval()  { return m_visibility_observer_sweep_interval; }
         void ProcessCliCommands();
         void QueueCliCommand(CliCommandHolder* commandHolder) { std::lock_guard<std::mutex> guard(m_cliCommandQueueLock); m_cliCommandQueue.push_back(commandHolder); }
 
@@ -778,6 +780,9 @@ class World
 
         static float  m_relocation_lower_limit_sq;
         static uint32 m_relocation_ai_notify_delay;
+
+        static bool   m_visibility_observer_sweep_enabled;
+        static uint32 m_visibility_observer_sweep_interval;
 
         // CLI command holder to be thread safe
         std::mutex m_cliCommandQueueLock;

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -3,7 +3,7 @@
 ################################################################################
 
 [MangosdConf]
-ConfVersion=2023011700
+ConfVersion=2026060700
 
 ################################################################################
 # CONNECTIONS AND DIRECTORIES
@@ -1267,6 +1267,20 @@ GM.MaxSpeedFactor        = 10
 #        Delay time between creature AI reactions on nearby movements
 #        Default: 1000 (milliseconds)
 #
+#    Visibility.ObserverSweep.Enable
+#        Periodically rebuild each player's own visible-object set so that objects
+#        which move out of range while the player stands still are removed from the
+#        client. Without this, out-of-range cleanup is only driven by the observer
+#        moving or by the observed object moving (and the latter only notifies
+#        observers still near that object), so an active creature that walks away
+#        from a stationary player can stay frozen at the edge of view.
+#        Default: 1 (enabled)
+#
+#    Visibility.ObserverSweep.Interval
+#        Interval between observer-side visibility sweeps, applied per player.
+#        Lower values remove stale objects sooner; higher values use less CPU.
+#        Default: 2000 (milliseconds)
+#
 ################################################################################
 
 Visibility.GroupMode               = 0
@@ -1278,6 +1292,8 @@ Visibility.Distance.Grey.Unit      = 1
 Visibility.Distance.Grey.Object    = 10
 Visibility.RelocationLowerLimit    = 10
 Visibility.AIRelocationNotifyDelay = 1000
+Visibility.ObserverSweep.Enable    = 1
+Visibility.ObserverSweep.Interval  = 2000
 
 ################################################################################
 # SERVER RATES

--- a/src/shared/SystemConfig.h.in
+++ b/src/shared/SystemConfig.h.in
@@ -42,7 +42,7 @@
 // Format is YYYYMMDDRR where RR is the change in the conf file
 // for that day.
 #ifndef MANGOSD_CONFIG_VERSION
-# define MANGOSD_CONFIG_VERSION 2022031900
+# define MANGOSD_CONFIG_VERSION 2026060700
 #endif
 #ifndef REALMD_CONFIG_VERSION
 # define REALMD_CONFIG_VERSION 2010062001


### PR DESCRIPTION
Ports the periodic observer-side visibility sweep from mangostwo.

**Problem:** an object that moves out of range while a player stands still is never removed from that player's client. Visible-set cleanup is driven only by the observer moving (`Camera::UpdateVisibilityForOwner` via `OnRelocated`) or by the observed object moving (which only re-notifies observers still near it). A near-stationary player therefore never gets an out-of-range/destroy for an active creature that walked away — it stays frozen at the edge of view.

**Fix:** per-player periodic sweep re-runs the owner visibility update on an interval, so out-of-range objects drop even when the player doesn't move. Skipped mid-teleport (visibility is rebuilt by the teleport path) and gated by config.

New config keys (defaults preserve current behavior in spirit; sweep on by default):
- `Visibility.ObserverSweep.Enable` (default 1)
- `Visibility.ObserverSweep.Interval` (default 2000 ms)

`MANGOSD_CONFIG_VERSION` + dist `ConfVersion` bumped to `2026060700` for the new keys. Builds warning-clean (MSVC, warnings-as-errors), mangosd smoke pending.

Note: mangostwo wires its conf version through `@MANGOS_WORLD_VER@`; mangosthree has these hardcoded (that cmake var is vestigial here), so the bump is applied to the mangosthree mechanism rather than the cmake value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/224)
<!-- Reviewable:end -->
