### PR TITLE
[Player] Trainer skill check no longer force-REDs profession spells

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -3180,20 +3180,19 @@ TrainerSpellState Player::GetTrainerSpellState(TrainerSpell const* trainer_spell
     // TC-Preservation and compare the player's level against the
     // effective required level instead.
     //
-    // The bare `prof ||` short-circuit-RED has been dropped: it forced
-    // profession spells to RED unconditionally, which never matched
-    // observed behaviour (the destructive bug was that the level check
-    // was a no-op, masking that line entirely for class spells where
-    // prof == false). mangostwo additionally gates the level check on a
-    // GM-trade-skill-bypass config; that is out of scope here.
-    bool prof = SpellMgr::IsProfessionSpell(trainer_spell->spell);
+    // The bare `prof ||` short-circuit-RED forced profession spells to RED
+    // unconditionally on both the level and skill checks (introduced by
+    // #192, which flattened mangostwo's two guarded checks into flat ORs).
+    // Both short-circuits are dropped so the actual requirements decide.
+    // mangostwo additionally gates these on a GM-trade-skill-bypass config;
+    // that is out of scope here.
     if (getLevel() < reqLevel)
     {
         return TRAINER_SPELL_RED;
     }
 
     // check skill requirement
-    if (prof || trainer_spell->reqSkill && GetBaseSkillValue(trainer_spell->reqSkill) < trainer_spell->reqSkillValue)
+    if (trainer_spell->reqSkill && GetBaseSkillValue(trainer_spell->reqSkill) < trainer_spell->reqSkillValue)
     {
         return TRAINER_SPELL_RED;
     }


### PR DESCRIPTION
Finishes the trainer-spell-state fix begun in `691d08d4e`.

**Background.** `Player::GetTrainerSpellState` was mangled by #192 (`2e4111aed`), which flattened mangostwo's two *guarded* checks —

```cpp
if (!prof || GetSession()->GetSecurity() < ...GMIGNORE_LEVEL)
    if (getLevel() < reqLevel) return RED;
if (!prof || GetSession()->GetSecurity() < ...GMIGNORE_SKILL)
    if (reqSkill && GetBaseSkillValue(reqSkill) < reqSkillValue) return RED;
```

— into flat `if (prof || cond) return RED;` lines. That introduced two bugs: a no-op level comparison (`trainer_spell->reqLevel < reqLevel`, both derive from `trainer_spell` → always false), and a `prof ||` short-circuit that forces **every profession spell to RED** on both lines.

`691d08d4e` already fixed the level line (`if (getLevel() < reqLevel)`). This PR finishes the job by dropping the same `prof ||` short-circuit from the **skill** line, so the actual skill requirement decides:

```cpp
if (trainer_spell->reqSkill && GetBaseSkillValue(trainer_spell->reqSkill) < trainer_spell->reqSkillValue)
    return TRAINER_SPELL_RED;
```

The now-unused `bool prof` is removed and the comment updated. Behaviour for normal players matches mangostwo; the GM-trade-skill-bypass config (removed by #192) stays out of scope, consistent with the level fix.

**Re: PR #82** — that change flips `prof` → `!prof` on the same flat ORs, which makes every *non*-profession (class) spell RED (the regression i-am-fyre reported). This is the correct fix instead; #82 can be closed.

Builds warning-clean (MSVC, warnings-as-errors). +5/-7, single file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/225)
<!-- Reviewable:end -->
