### PR TITLE
[Movemap] Fix tile-coordinate swap in mmtile filename and VMap loading

### DIFF
--- a/src/game/WorldHandlers/MoveMapSharedDefines.h
+++ b/src/game/WorldHandlers/MoveMapSharedDefines.h
@@ -29,7 +29,7 @@
 #include "Platform/Define.h"
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
-#define MMAP_VERSION 3
+#define MMAP_VERSION 4
 
 struct MmapTileHeader
 {

--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -245,7 +245,7 @@ namespace MMAP
         m_terrainBuilder->loadMap(mapID, tileX, tileY, meshData);
 
         // get model data
-        m_terrainBuilder->loadVMap(mapID, tileY, tileX, meshData);
+        m_terrainBuilder->loadVMap(mapID, tileX, tileY, meshData);
 
         // if there is no data, give up now
         if (!meshData.solidVerts.size() && !meshData.liquidVerts.size())
@@ -746,7 +746,7 @@ namespace MMAP
 
             // file output
             char fileName[255];
-            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
             FILE* file = fopen(fileName, "wb");
             if (!file)
             {
@@ -931,7 +931,7 @@ namespace MMAP
     bool MapBuilder::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
-        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
+        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
         FILE* file = fopen(fileName, "rb");
         if (!file)
         {


### PR DESCRIPTION
Fixes a tile-coordinate swap in the Movemap generator (ported from mangostwo — Extractor_projects #35 / MadMax).

**Bug.** In `MapBuilder::buildMoveMapTile`, terrain and collision were loaded with swapped tile coordinates:
```cpp
m_terrainBuilder->loadMap(mapID, tileX, tileY, meshData);   // terrain for (x,y)
m_terrainBuilder->loadVMap(mapID, tileY, tileX, meshData);  // collision for (y,x)  <-- swapped
```
and the `.mmtile` filename was written/skip-checked as `(mapID, tileY, tileX)`, while the **server reads it as `(mapId, x, y)`** (`MoveMap.cpp:308`). Net effect on every off-diagonal tile (x≠y): the navmesh fuses the wrong heightmap+geometry, and is stored under a transposed filename the server then mis-loads. Symmetric tiles (x==y) are unaffected, which is why it stayed latent.

**Fix.** Three one-line swaps so `loadVMap` matches `loadMap` and the filename matches the server's read order (`tileX, tileY`).

`MMAP_VERSION` bumped 3 → 4 so existing (transposed) mmaps are rejected and regenerated — re-extraction is required after this lands.

Builds warning-clean (MSVC, warnings-as-errors): `mmap-extractor` and `mangosd`. mangostwo shipped the same fix and bumped its lineage 4 → 5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/226)
<!-- Reviewable:end -->
