### PR TITLE
[Movemap] discoverTiles: parse .map files with 4-digit map id

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -79,7 +79,8 @@ namespace MMAP
         getDirContents(files, "maps");
         for (uint32 i = 0; i < files.size(); ++i)
         {
-            mapID = uint32(atoi(files[i].substr(0, 3).c_str()));
+            // .map files use a 4-digit map id (vmaps still use 3)
+            mapID = uint32(atoi(files[i].substr(0, 4).c_str()));
             if (m_tiles.find(mapID) == m_tiles.end())
             {
                 m_tiles.insert(pair<uint32, set<uint32>*>(mapID, new set<uint32>));
@@ -117,13 +118,14 @@ namespace MMAP
                 count++;
             }
 
-            sprintf(filter, "%03u*", mapID);
+            // .map files use a 4-digit map id, so tile coords start one char later
+            sprintf(filter, "%04u*", mapID);
             files.clear();
             getDirContents(files, "maps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
-                tileY = uint32(atoi(files[i].substr(3, 2).c_str()));
-                tileX = uint32(atoi(files[i].substr(5, 2).c_str()));
+                tileY = uint32(atoi(files[i].substr(4, 2).c_str()));
+                tileX = uint32(atoi(files[i].substr(6, 2).c_str()));
                 tileID = StaticMapTree::packTileID(tileX, tileY);
 
                 if (tiles->insert(tileID).second)


### PR DESCRIPTION
`MapBuilder::discoverTiles()` parsed `.map` filenames assuming a 3-digit map id, but the map-extractor writes them with a **4-digit** id (`maps/%04u%02u%02u.map`, e.g. `00002035.map`) and every reader (`TerrainBuilder`, server `GridMap`) already uses `%04u`. So the discovery code:

- read the map id from `substr(0,3)` (wrong for any id whose 4-digit padding shifts the digits),
- filtered map files with `"%03u*"` (misses/mismatches files), and
- read tile coords from `substr(3,2)`/`substr(5,2)` (one char early → garbage tile ids).

Net effect: **terrain-only tiles** (those with a `.map` but no `.vmtile`) are mis-discovered, so they get no navmesh. The `.vmtile` branch masks it for tiles that also have vmaps, and the `getGridBounds` fallback only fires for maps with *zero* discovered tiles — so model-free terrain tiles fall through.

Fix: parse the `.map` branch at its real 4-digit width (`substr(0,4)`, `"%04u*"`, `substr(4,2)`/`substr(6,2)`). The `.vmtree`/`.vmtile` branches are left at 3-digit because those files **are** 3-digit on disk — this PR only realigns the `.map` parser with the `.map` writer.

No `MMAP_VERSION` change: the mmap format is unchanged; a re-extraction simply discovers the previously-missed terrain-only tiles. Builds warning-clean (mmap-extractor).

Note: widening **all** tile files (vmtree/vmtile/mmtile) to 4-digit map ids for MoP (ids > 999) is a larger, separate change with full vmap+mmap re-extraction — intentionally out of scope here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/227)
<!-- Reviewable:end -->
