### PR TITLE
[Movemap] Build ADT floor under liquid

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
@@ -448,12 +448,6 @@ namespace MMAP
                         }
                     }
 
-                    // terrain under the liquid?
-                    if (minLLevel > maxTLevel)
-                    {
-                        useTerrain = false;
-                    }
-
                     //liquid under the terrain?
                     if (minTLevel > maxLLevel)
                     {


### PR DESCRIPTION
`TerrainBuilder` discarded the terrain mesh whenever it sat entirely below the liquid surface:

```cpp
// terrain under the liquid?
if (minLLevel > maxTLevel)
    useTerrain = false;
```

This leaves **no walkable navmesh floor under water bodies** (lake/river bottoms), so pathing breaks near and under water. Remove the block so the ADT floor is built under liquid, the same way WMO floors below liquid already are. The complementary `minTLevel > maxLLevel → useLiquid = false` check (liquid entirely under terrain) is kept.

Precedent: both **mangoszero** and **mangostwo** already removed this exact block — mangosthree was the lone fork still carrying it. The block is legacy (no deliberate Cata rationale in history).

No `MMAP_VERSION` change: the mmap format is unchanged; a re-extraction simply gains the under-water floor. Builds warning-clean (mmap-extractor).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/228)
<!-- Reviewable:end -->
