### PR TITLE
[DBC] Populate localized DBCString fields in AutoProduceStrings

### DIFF
--- a/src/shared/DataStores/DBCFileLoader.cpp
+++ b/src/shared/DataStores/DBCFileLoader.cpp
@@ -387,12 +387,14 @@ char* DBCFileLoader::AutoProduceStrings(const char* format, char* dataTable, Loc
                     break;
                 case DBC_FF_STRING:
                 {
-                    // fill only not filled entries
-                    char** slot = (char**)(&dataTable[offset]);
-                    if (!*slot || !** slot)
+                    // The dataTable field points to this record's MAX_LOCALE holder
+                    // array (set up by AutoProduceStringsArrayHolders). Fill the slot
+                    // for the locale being loaded; empty entries keep their "" default.
+                    char const** holder = *(char const***)(&dataTable[offset]);
+                    char const* st = getRecord(y).getString(x);
+                    if (st && *st)
                     {
-                        const char* st = getRecord(y).getString(x);
-                        *slot = stringPool + (st - (const char*)stringTable);
+                        holder[loc] = stringPool + (st - (const char*)stringTable);
                     }
                     offset += sizeof(char*);
                     break;


### PR DESCRIPTION
`DBCFileLoader::AutoProduceStrings` wrote the loaded string straight into the `DBCString` field as a single `char*` — the pre-multilocale layout — instead of into the per-locale holder array that `AutoProduceStringsArrayHolders` allocates. Its skip-condition (`if (!*slot || !**slot)`) also tested the first byte of the *holder-array pointer*, so it always skipped.

Net effect: every localized DBC string (`SpellName`, faction/area/skill names, …) stayed `""` server-side. `.lookup spell` / `.lookup faction` / `.lookup area` returned nothing, and reading a null locale slot could crash the server.

**Fix:** write the real string into `holder[loc]` (the slot for the locale being loaded); empty entries keep their `""` default.

Verified in-game: `Spell.dbc` / `Faction.dbc` names now populate (spell 133 → "Fireball", faction 72 → "Stormwind") and the lookup commands return results again. Server boots clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/229)
<!-- Reviewable:end -->
