### PR TITLE
[Command] Improve .lookup spell: shift-click links, subtext, null-safe names

### DIFF
--- a/src/game/ChatCommands/ListCommands.cpp
+++ b/src/game/ChatCommands/ListCommands.cpp
@@ -678,17 +678,24 @@ void ChatHandler::ShowSpellListHelper(Player* target, SpellEntry const* spellInf
 
     // send spell in "id - [name, rank N] [talent] [passive] [learn] [known]" format
     std::ostringstream ss;
+    char const* nameStr = (spellInfo->SpellName && spellInfo->SpellName[loc]) ? spellInfo->SpellName[loc] : "";
     if (m_session)
     {
-        ss << id << " - |cffffffff|Hspell:" << id << "|h[" << spellInfo->SpellName[loc];
+        ss << id << " - |cffffffff|Hspell:" << id << "|h[" << nameStr;
     }
     else
     {
-        ss << id << " - " << spellInfo->SpellName[loc];
+        ss << id << " - " << nameStr;
     }
 
-    // include rank in link name
-    if (rank)
+    // include the spell's subtext ("Rank N" / label) to distinguish same-named
+    // spells; fall back to the computed numeric rank when there is no subtext
+    char const* subText = spellInfo->Rank ? spellInfo->Rank[loc] : NULL;
+    if (subText && *subText)
+    {
+        ss << " " << subText;
+    }
+    else if (rank)
     {
         ss << GetMangosString(LANG_SPELL_RANK) << rank;
     }

--- a/src/game/ChatCommands/LookupCommands.cpp
+++ b/src/game/ChatCommands/LookupCommands.cpp
@@ -1121,6 +1121,19 @@ bool ChatHandler::HandleLookupSpellCommand(char* args)
     Player* target = getSelectedPlayer();
 
     std::string namepart = args;
+
+    // Accept a shift-clicked spell link: search by its caption text,
+    // e.g. "|cff..|Hspell:133|h[Fireball]|h|r" -> "Fireball"
+    size_t linkStart = namepart.find('[');
+    if (linkStart != std::string::npos)
+    {
+        size_t linkEnd = namepart.find(']', linkStart);
+        if (linkEnd != std::string::npos)
+        {
+            namepart = namepart.substr(linkStart + 1, linkEnd - linkStart - 1);
+        }
+    }
+
     std::wstring wnamepart;
 
     if (!Utf8toWStr(namepart, wnamepart))
@@ -1140,7 +1153,8 @@ bool ChatHandler::HandleLookupSpellCommand(char* args)
         if (spellInfo)
         {
             int loc = GetSessionDbcLocale();
-            std::string name = spellInfo->SpellName[loc];
+            char const* nameStr = spellInfo->SpellName ? spellInfo->SpellName[loc] : NULL;
+            std::string name = nameStr ? nameStr : "";
             if (name.empty())
             {
                 continue;
@@ -1156,7 +1170,8 @@ bool ChatHandler::HandleLookupSpellCommand(char* args)
                         continue;
                     }
 
-                    name = spellInfo->SpellName[loc];
+                    nameStr = spellInfo->SpellName ? spellInfo->SpellName[loc] : NULL;
+                    name = nameStr ? nameStr : "";
                     if (name.empty())
                     {
                         continue;


### PR DESCRIPTION
Three small improvements to `.lookup spell`:

- **Shift-click links**: searching by a shift-clicked spell link now works — the handler extracts the link's `[caption]` and searches that, so `.lookup spell [Fireball]` behaves like `.lookup spell fireball`. Previously the whole hyperlink was matched against spell names, so it always returned nothing.
- **Subtext**: spell-list output now shows the spell's subtext (`Rank N` / label, `m_nameSubtext_lang`) so same-named spells (e.g. the many "Fireball" variants) can be told apart; falls back to the computed numeric rank when there is no subtext.
- **Null-safe names**: `SpellName[loc]` is read defensively (null/empty → skip) so a missing locale string can't crash the iteration.

The empty-results cause is the unpopulated localized DBC strings fixed in the companion loader PR #229; this PR is the command-side UX + hardening and is safe to merge independently.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/230)
<!-- Reviewable:end -->
