### PR TITLE
[Extractor] Treat MWMO as optional in WDT parsing

### DIFF
--- a/dep/loadlib/sl/wdt.cpp
+++ b/dep/loadlib/sl/wdt.cpp
@@ -55,8 +55,15 @@ bool WDT_file::prepareLoadedData()
     main = (wdt_MAIN*)((uint8*)mphd + mphd->size + 8);
     if (!main->prepareLoadedData())
         return false;
-    wmo = (wdt_MWMO*)((uint8*)main + main->size + 8);
-    if (!wmo->prepareLoadedData())
-        return false;
+
+    // Terrain WDTs may end right after MAIN (Cata-exported maps); MWMO+MODF only exist on WMO-only maps.
+    uint8* next = (uint8*)main + main->size + 8;
+    if (next + 8 <= GetData() + GetDataSize())
+    {
+        wmo = (wdt_MWMO*)next;
+        if (!wmo->prepareLoadedData())
+            return false;
+    }
+
     return true;
 }


### PR DESCRIPTION
## Problem

Cata re-exported terrain WDTs (Azeroth, Kalimdor, AlteracValley, ShadowfangKeep, Stratholme) end immediately after `MAIN`. The trailing `MWMO` chunk only exists on WMO-only maps and on terrain maps written by older exporters. The hard-coded `MVER → MPHD → MAIN → MWMO` chain read past the end of the file buffer and failed on the fourcc; once `loadFile` started honouring `prepareLoadedData` failures, `ExtractMapsFromMpq` skipped these five maps entirely — **dropping 1930 of 7192 tiles**.

## Fix

Only read `MWMO` when at least a chunk header remains after `MAIN`, which also removes the out-of-bounds read. `wmo` stays null otherwise (no consumer reads it). Malformed input still fails: `MVER`/`MPHD`/`MAIN` checks are unchanged and a present-but-bad `MWMO` still rejects the file.

## Verification

Full re-extraction writes 7192/7192 tiles. Restored tiles match the known-good backup byte-for-byte in area, height and holes sections (liquid differs only by the separate Cata MH2O fix).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/232)
<!-- Reviewable:end -->
