### PR TITLE
[Extractor] Harden extractor toolchain against corrupt input

### DIFF
--- a/dep/loadlib/sl/adt.cpp
+++ b/dep/loadlib/sl/adt.cpp
@@ -19,6 +19,7 @@ bool isHole(int holes, int i, int j)
 ADT_file::ADT_file()
 {
     a_grid = 0;
+    memset(cells, 0, sizeof(cells));
 }
 
 ADT_file::~ADT_file()

--- a/dep/loadlib/sl/loadlib.cpp
+++ b/dep/loadlib/sl/loadlib.cpp
@@ -282,12 +282,12 @@ bool FileLoader::loadFile(char* filename, bool log)
 
     SFileCloseFile(fileHandle);
 
-    // ToDo: Fix WDT errors...
     if (!prepareLoadedData())
     {
-        //printf("Error loading %s\n\n", filename);
-        //free();
-        return true;
+        if (log)
+            printf("Error loading %s\n", filename);
+        free();
+        return false;
     }
 
     return true;

--- a/src/game/vmap/MapTree.cpp
+++ b/src/game/vmap/MapTree.cpp
@@ -549,18 +549,25 @@ namespace VMAP
                     }
 
                     // Update tree
+                    // TODO(format): align with TC's iSpawnIndices table (validated index stored
+                    // in the .vmtree) instead of reading referencedVal raw; needs a .vmtile/.vmtree format+version bump.
                     uint32 referencedVal;
 
-                    size_t fileRead = fread(&referencedVal, sizeof(uint32), 1, tf);
-                    if (!iLoadedSpawns.count(referencedVal) || fileRead <= 0)
+                    if (fread(&referencedVal, sizeof(uint32), 1, tf) != 1)
                     {
-#ifdef VMAP_DEBUG
-                        if (referencedVal > iNTreeValues)
-                        {
-                            DEBUG_LOG("invalid tree element! (%u/%u)", referencedVal, iNTreeValues);
-                            continue;
-                        }
-#endif
+                        result = false;
+                        break;
+                    }
+                    // referencedVal indexes iTreeValues and is read straight from the file: validate before use.
+                    if (referencedVal >= iNTreeValues)
+                    {
+                        ERROR_LOG("StaticMapTree::LoadMapTile(): invalid tree element (%u/%u) in tile [%u, %u]", referencedVal, iNTreeValues, tileX, tileY);
+                        result = false;
+                        break;
+                    }
+
+                    if (!iLoadedSpawns.count(referencedVal))
+                    {
                         iTreeValues[referencedVal] = ModelInstance(spawn, model);
                         iLoadedSpawns[referencedVal] = 1;
                     }

--- a/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
@@ -95,7 +95,13 @@ namespace MMAP
         }
 
         GridMapFileHeader fheader;
-        fread(&fheader, sizeof(GridMapFileHeader), 1, mapFile);
+        size_t file_read = fread(&fheader, sizeof(GridMapFileHeader), 1, mapFile);
+        if (file_read <= 0)
+        {
+            fclose(mapFile);
+            printf("Could not read map data from %s.\n", mapFileName);
+            return false;
+        }
 
         if (fheader.versionMagic != *((uint32 const*)(MAP_VERSION_MAGIC)))
         {
@@ -106,7 +112,13 @@ namespace MMAP
 
         GridMapHeightHeader hheader;
         fseek(mapFile, fheader.heightMapOffset, SEEK_SET);
-        fread(&hheader, sizeof(GridMapHeightHeader), 1, mapFile);
+        file_read = fread(&hheader, sizeof(GridMapHeightHeader), 1, mapFile);
+        if (file_read <= 0)
+        {
+            fclose(mapFile);
+            printf("Could not read map data from %s.\n", mapFileName);
+            return false;
+        }
 
         bool haveTerrain = !(hheader.flags & MAP_HEIGHT_NO_HEIGHT);
         bool haveLiquid = fheader.liquidMapOffset && !m_skipLiquid;
@@ -137,8 +149,20 @@ namespace MMAP
             {
                 uint8 v9[V9_SIZE_SQ];
                 uint8 v8[V8_SIZE_SQ];
-                fread(v9, sizeof(uint8), V9_SIZE_SQ, mapFile);
-                fread(v8, sizeof(uint8), V8_SIZE_SQ, mapFile);
+                file_read = fread(v9, sizeof(uint8), V9_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
+                file_read = fread(v8, sizeof(uint8), V8_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
                 heightMultiplier = (hheader.gridMaxHeight - hheader.gridHeight) / 255;
 
                 for (i = 0; i < V9_SIZE_SQ; ++i)
@@ -155,8 +179,20 @@ namespace MMAP
             {
                 uint16 v9[V9_SIZE_SQ];
                 uint16 v8[V8_SIZE_SQ];
-                fread(v9, sizeof(uint16), V9_SIZE_SQ, mapFile);
-                fread(v8, sizeof(uint16), V8_SIZE_SQ, mapFile);
+                file_read = fread(v9, sizeof(uint16), V9_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
+                file_read = fread(v8, sizeof(uint16), V8_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
                 heightMultiplier = (hheader.gridMaxHeight - hheader.gridHeight) / 65535;
 
                 for (i = 0; i < V9_SIZE_SQ; ++i)
@@ -171,14 +207,38 @@ namespace MMAP
             }
             else
             {
-                fread(V9, sizeof(float), V9_SIZE_SQ, mapFile);
-                fread(V8, sizeof(float), V8_SIZE_SQ, mapFile);
+                file_read = fread(V9, sizeof(float), V9_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
+                file_read = fread(V8, sizeof(float), V8_SIZE_SQ, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
             }
 
             // hole data
+            if (fheader.holesSize > sizeof(holes))
+            {
+                fclose(mapFile);
+                printf("Invalid holes block in %s.\n", mapFileName);
+                return false;
+            }
             memset(holes, 0, fheader.holesSize);
             fseek(mapFile, fheader.holesOffset, SEEK_SET);
-            fread(holes, fheader.holesSize, 1, mapFile);
+            file_read = fread(holes, fheader.holesSize, 1, mapFile);
+            if (file_read <= 0)
+            {
+                fclose(mapFile);
+                printf("Could not read map data from %s.\n", mapFileName);
+                return false;
+            }
 
             int count = meshData.solidVerts.size() / 3;
             float xoffset = (float(tileX) - 32) * GRID_SIZE;
@@ -219,19 +279,38 @@ namespace MMAP
         {
             GridMapLiquidHeader lheader;
             fseek(mapFile, fheader.liquidMapOffset, SEEK_SET);
-            fread(&lheader, sizeof(GridMapLiquidHeader), 1, mapFile);
+            file_read = fread(&lheader, sizeof(GridMapLiquidHeader), 1, mapFile);
+            if (file_read <= 0)
+            {
+                fclose(mapFile);
+                printf("Could not read map data from %s.\n", mapFileName);
+                return false;
+            }
 
             float* liquid_map = NULL;
 
             if (!(lheader.flags & MAP_LIQUID_NO_TYPE))
             {
-                fread(liquid_type, sizeof(liquid_type), 1, mapFile);
+                file_read = fread(liquid_type, sizeof(liquid_type), 1, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
             }
 
             if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
             {
                 liquid_map = new float [lheader.width * lheader.height];
-                fread(liquid_map, sizeof(float), lheader.width * lheader.height, mapFile);
+                file_read = fread(liquid_map, sizeof(float), lheader.width * lheader.height, mapFile);
+                if (file_read <= 0)
+                {
+                    delete[] liquid_map;
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
             }
 
             if (liquid_type && liquid_map)

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -84,6 +84,7 @@ typedef struct
 map_id* map_ids;                    /**< TODO */
 uint16* areas;                      /**< TODO */
 uint16* LiqType;                    /**< TODO */
+uint32 LiqType_maxid = 0;           ///< Highest LiquidType.dbc id; bounds LiqType[].
 char output_path[128] = ".";        /**< TODO */
 char input_path[128] = ".";         /**< TODO */
 uint32 maxAreaId = 0;               /**< TODO */
@@ -173,7 +174,8 @@ void HandleArgs(int argc, char* arg[])
             case 'i':
                 if (c + 1 < argc)                           // all ok
                 {
-                    strcpy(input_path, arg[(c++) + 1]);
+                    strncpy(input_path, arg[(c++) + 1], sizeof(input_path) - 1);
+                    input_path[sizeof(input_path) - 1] = '\0';
                 }
                 else
                 {
@@ -183,7 +185,8 @@ void HandleArgs(int argc, char* arg[])
             case 'o':
                 if (c + 1 < argc)                           // all ok
                 {
-                    strcpy(output_path, arg[(c++) + 1]);
+                    strncpy(output_path, arg[(c++) + 1], sizeof(output_path) - 1);
+                    output_path[sizeof(output_path) - 1] = '\0';
                 }
                 else
                 {
@@ -448,7 +451,7 @@ void ReadLiquidTypeTableDBC(int const locale)
     }
 
     size_t LiqType_count = dbc.getRecordCount();
-    size_t LiqType_maxid = dbc.getMaxId();
+    LiqType_maxid = uint32(dbc.getMaxId());
     LiqType = new uint16[LiqType_maxid + 1];
     memset(LiqType, 0xff, (LiqType_maxid + 1) * sizeof(uint16));
 
@@ -983,7 +986,8 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
                 }
 
                 liquid_entry[i][j] = h->liquidType;
-                switch (LiqType[h->liquidType])
+                uint16 liqType = (h->liquidType <= LiqType_maxid) ? LiqType[h->liquidType] : 0xffff;
+                switch (liqType)
                 {
                     case LIQUID_TYPE_WATER: liquid_flags[i][j] |= MAP_LIQUID_TYPE_WATER; break;
                     case LIQUID_TYPE_OCEAN: liquid_flags[i][j] |= MAP_LIQUID_TYPE_OCEAN; break;
@@ -994,7 +998,7 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
                         break;
                 }
                 // Dark water detect
-                if (LiqType[h->liquidType] == LIQUID_TYPE_OCEAN)
+                if (liqType == LIQUID_TYPE_OCEAN)
                 {
                     uint8* lm = h2o->getLiquidLightMap(h);
                     if (!lm)

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -618,6 +618,11 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
         for (int j = 0; j < ADT_CELLS_PER_GRID; j++)
         {
             adt_MCNK* cell = adt.cells[i][j];
+            if (!cell)
+            {
+                area_flags[i][j] = 0xffff;
+                continue;
+            }
             uint32 areaid = cell->areaid;
             if (areaid && areaid <= maxAreaId)
             {

--- a/src/tools/Extractor_projects/map-extractor/dbcfile.cpp
+++ b/src/tools/Extractor_projects/map-extractor/dbcfile.cpp
@@ -98,6 +98,16 @@ bool DBCFile::open()
         return false;
     }
 
+    // Reject a corrupt header whose declared sizes can't fit the file before
+    // attempting an absurd allocation (each field is bounded by the file size).
+    DWORD fileSize = SFileGetFileSize(fileHandle, NULL);
+    if (recordSize > fileSize || recordCount > fileSize || stringSize > fileSize)
+    {
+        SFileCloseFile(fileHandle);
+        printf("DBCFile %s has invalid header sizes.\n", filename.c_str());
+        return false;
+    }
+
     data = new unsigned char[recordSize * recordCount + stringSize];
     stringTable = data + recordSize * recordCount;
 

--- a/src/tools/Extractor_projects/vmap-extractor/adtfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/adtfile.cpp
@@ -142,6 +142,13 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
 
         size_t nextpos = ADT.getPos() + size;
 
+        // A corrupt/truncated chunk header can declare a size past the end of
+        // the file; stop here rather than drive a wild new[]/read off it.
+        if (nextpos > ADT.getSize())
+        {
+            break;
+        }
+
         if (!strcmp(fourcc, "MCIN"))
         {
         }

--- a/src/tools/Extractor_projects/vmap-extractor/dbcfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/dbcfile.cpp
@@ -90,6 +90,14 @@ bool DBCFile::open()
         return false;
     }
 
+    // Reject a corrupt header whose declared sizes can't fit the file before
+    // attempting an absurd allocation (each field is bounded by the file size).
+    DWORD _fileSize = SFileGetFileSize(_file, NULL);
+    if (_recordSize > _fileSize || _recordCount > _fileSize || _stringSize > _fileSize)
+    {
+        return false;
+    }
+
     _data = new unsigned char[_recordSize * _recordCount + _stringSize];
     _stringTable = _data + _recordSize * _recordCount;
 

--- a/src/tools/Extractor_projects/vmap-extractor/wdtfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wdtfile.cpp
@@ -43,6 +43,10 @@ extern HANDLE WorldMpq;
 WDTFile::WDTFile(char* file_name, char* file_name1): WDT(WorldMpq, file_name)
 {
     filename.append(file_name1, strlen(file_name1));
+    gWmoInstansName = NULL;
+    gnWMO = 0;
+    nMaps = 0;
+    nWmoNames = 0;
 }
 
 bool WDTFile::init(char* map_id, unsigned int mapID)
@@ -75,6 +79,13 @@ bool WDTFile::init(char* map_id, unsigned int mapID)
 
         size_t nextpos = WDT.getPos() + size;
 
+        // A corrupt/truncated chunk header can declare a size past the end of
+        // the file; stop here rather than drive a wild new[]/read off it.
+        if (nextpos > WDT.getSize())
+        {
+            break;
+        }
+
         if (!strcmp(fourcc, "MAIN"))
         {
             // Do Nothing
@@ -97,6 +108,7 @@ bool WDTFile::init(char* map_id, unsigned int mapID)
                     p = p + strlen(p) + 1;
                     gWmoInstansName[q++] = s;
                 }
+                nWmoNames = q;
                 delete[] buf;
             }
         }
@@ -113,8 +125,15 @@ bool WDTFile::init(char* map_id, unsigned int mapID)
                 gWMO_mapname = fake_mapname + std::string(map_id);
                 for (int i = 0; i < gnWMO; ++i)
                 {
-                    int id;
+                    uint32 id;
                     WDT.read(&id, 4);
+                    // Index is read straight from the file; a corrupt MODF could
+                    // point past the parsed MWMO names. Stop rather than read OOB.
+                    if (id >= (uint32)nWmoNames)
+                    {
+                        printf("Warning: WDT MODF entry %d references invalid WMO name index %u in %s.\n", i, id, filename.c_str());
+                        break;
+                    }
                     WMOInstance inst(WDT, gWmoInstansName[id].c_str(), mapID, 65, 65, dirfile);
                 }
                 delete[] gWmoInstansName;

--- a/src/tools/Extractor_projects/vmap-extractor/wdtfile.h
+++ b/src/tools/Extractor_projects/vmap-extractor/wdtfile.h
@@ -62,6 +62,7 @@ class WDTFile
 
         std::string* gWmoInstansName; /**< TODO */
         int gnWMO, nMaps; /**< TODO */
+        int nWmoNames; ///< Count of names parsed from MWMO; bounds MODF indices.
 
         /**
          * @brief

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -172,6 +172,14 @@ bool WMOGroup::open()
         }
         fourcc[4] = 0;
         size_t nextpos = f.getPos() + size;
+
+        // A corrupt/truncated chunk header can declare a size past the end of
+        // the file; stop here rather than drive a wild new[]/read off it.
+        if (nextpos > f.getSize())
+        {
+            break;
+        }
+
         LiquEx_size = 0;
         liquflags = 0;
 
@@ -228,11 +236,24 @@ bool WMOGroup::open()
             hlq = new WMOLiquidHeader;
             f.read(hlq, 0x1E);
             LiquEx_size = sizeof(WMOLiquidVert) * hlq->xverts * hlq->yverts;
-            LiquEx = new WMOLiquidVert[hlq->xverts * hlq->yverts];
-            f.read(LiquEx, LiquEx_size);
             int nLiquBytes = hlq->xtiles * hlq->ytiles;
-            LiquBytes = new char[nLiquBytes];
-            f.read(LiquBytes, nLiquBytes);
+            // Validate the declared liquid geometry against the chunk size before
+            // allocating, so a corrupt MLIQ header can't drive a wild allocation.
+            if (hlq->xverts < 0 || hlq->yverts < 0 || hlq->xtiles < 0 || hlq->ytiles < 0 ||
+                0x1E + LiquEx_size + size_t(nLiquBytes) > size)
+            {
+                printf("Warning: skipping malformed MLIQ chunk in WMO group.\n");
+                liquflags &= ~1;
+                delete hlq;
+                hlq = 0;
+            }
+            else
+            {
+                LiquEx = new WMOLiquidVert[hlq->xverts * hlq->yverts];
+                f.read(LiquEx, LiquEx_size);
+                LiquBytes = new char[nLiquBytes];
+                f.read(LiquBytes, nLiquBytes);
+            }
 
             /* std::ofstream llog("Buildings/liquid.log", ios_base::out | ios_base::app);
             llog << filename;


### PR DESCRIPTION
## Summary

Defensive hardening across the extractor toolchain against corrupt/truncated input. **No-op on valid 4.3.4 data** — every change only affects malformed files that previously produced silent corruption or crashes.

## Commits

- **`loadFile` fails on parse error** — `FileLoader::loadFile` returned `true` even when `prepareLoadedData()` failed, leaking the buffer and feeding half-parsed data to callers (null `adt_MCNK` deref on bad ADT, `main==0` crash on bad WDT). Now frees and returns `false`, matching `ChunkedFile::loadFile`; both callers already skip on `false`. Also null-guards the area-flags loop and zero-inits `ADT_file::cells`.
- **Validate `.vmtile` node index** — `LoadMapTile` indexed `iTreeValues[referencedVal]` with the only bounds check under a never-defined `#ifdef`. Now rejects `referencedVal >= iNTreeValues` unconditionally before indexing, and properly checks the `fread` count.
- **Bound liquid-type index and option-path copies** (map-extractor).
- **Reject corrupt DBC headers before allocating.**
- **Cap chunk allocations and validate indices on corrupt input** (vmap).
- **Check `fread` results in `TerrainBuilder::loadMap`** (movemap).

Can be split per-tool (map / vmap / dbc / movemap) if preferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/234)
<!-- Reviewable:end -->
