### PR TITLE
[Vmap] Fix WMO MOPY collision-flag scheme to the 4.3.4 layout

### DIFF
--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -353,9 +353,11 @@ int WMOGroup::ConvertToVMAPGroupWmo(FILE* output, WMORoot* rootWMO, bool pPrecis
         memset(IndexRenum, 0xFF, nVertices * sizeof(int));
         for (int i = 0; i < nTriangles; ++i)
         {
-            // Skip no collision triangles
-            if (MOPY[2 * i]&WMO_MATERIAL_NO_COLLISION ||
-                !(MOPY[2 * i] & (WMO_MATERIAL_HINT | WMO_MATERIAL_COLLIDE_HIT)))
+            // Keep collidable triangles only: collision faces, or rendered
+            // non-detail faces (wowdev SMOPoly::isCollidable).
+            bool isRenderFace = (MOPY[2 * i] & WMO_MATERIAL_RENDER) && !(MOPY[2 * i] & WMO_MATERIAL_DETAIL);
+            bool isCollision = (MOPY[2 * i] & WMO_MATERIAL_COLLISION) || isRenderFace;
+            if (!isCollision)
             {
                 continue;
             }

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.h
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.h
@@ -33,14 +33,15 @@
 #include "vec3d.h"
 #include "mpqfile.h"
 
-// MOPY flags
-#define WMO_MATERIAL_NOCAMCOLLIDE    0x01
-#define WMO_MATERIAL_DETAIL          0x02
-#define WMO_MATERIAL_NO_COLLISION    0x04
-#define WMO_MATERIAL_HINT            0x08
-#define WMO_MATERIAL_RENDER          0x10
-#define WMO_MATERIAL_COLLIDE_HIT     0x20
+// MOPY flags (wowdev WMO/MOPY SMOPoly::flags, 4.3.4)
+#define WMO_MATERIAL_UNK01           0x01
+#define WMO_MATERIAL_NOCAMCOLLIDE    0x02
+#define WMO_MATERIAL_DETAIL          0x04
+#define WMO_MATERIAL_COLLISION       0x08
+#define WMO_MATERIAL_HINT            0x10
+#define WMO_MATERIAL_RENDER          0x20
 #define WMO_MATERIAL_WALL_SURFACE    0x40
+#define WMO_MATERIAL_COLLIDE_HIT     0x80
 
 class WMOInstance;
 class WMOManager;


### PR DESCRIPTION
## Problem

The MOPY material-flag defines were shifted one bit (`DETAIL=0x02`, `NO_COLLISION=0x04`, …) — a pre-WotLK scheme. Per wowdev `SMOPoly` the 4.3.4 bits are `NOCAMCOLLIDE=0x02`, `DETAIL=0x04`, `COLLISION=0x08`, `RENDER=0x20`, `COLLIDE_HIT=0x80`. The old filter dropped any face with `COLLISION+DETAIL` (`0x0c`/`0x2c`) set, losing real collision/LoS geometry.

## Fix

Realign the defines and use the canonical test: a face is collidable if `COLLISION` is set, or it is rendered and not detail-only.

Reference: wowdev WMO MOPY / `SMOPoly`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/235)
<!-- Reviewable:end -->
