### PR TITLE
[Vmap] Extract WMO interior doodad collision

### DIFF
--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -217,23 +217,48 @@ namespace VMAP
             // <====
 
             // Write map tile files, similar to ADT files, only with extra BSP tree node info
+            // Walk unique tileIDs via equal_range instead of the old hand-rolled
+            // inner ++tile dance: when a tile holds a MOD_WORLDSPAWN spawn AND others
+            // (tile 65/65 once WMO interior doodads are extracted), the inner ++tile
+            // walked past end() -> UB. MOD_WORLDSPAWN spawns belong in the .vmtree
+            // global block, not in .vmtile files, so they are filtered out here.
             TileMap& tileEntries = map_iter->second->TileEntries;
-            TileMap::iterator tile;
-            for (tile = tileEntries.begin(); tile != tileEntries.end(); ++tile)
+            TileMap::iterator tile = tileEntries.begin();
+            while (tile != tileEntries.end())
             {
-                const ModelSpawn& spawn = map_iter->second->UniqueEntries[tile->second];
-                if (spawn.flags & MOD_WORLDSPAWN)           // WDT spawn, saved as tile 65/65 currently...
+                uint32 tileID = tile->first;
+                std::pair<TileMap::iterator, TileMap::iterator> range = tileEntries.equal_range(tileID);
+                // Advance the outer iterator past this tile up front.
+                tile = range.second;
+
+                std::vector<uint32> spawnIDs;
+                for (TileMap::iterator it = range.first; it != range.second; ++it)
+                {
+                    const ModelSpawn& spawn = map_iter->second->UniqueEntries[it->second];
+                    if (spawn.flags & MOD_WORLDSPAWN)       // WDT spawn, saved as tile 65/65
+                    {
+                        continue;
+                    }
+                    spawnIDs.push_back(it->second);
+                }
+                if (spawnIDs.empty())
                 {
                     continue;
                 }
-                uint32 nSpawns = tileEntries.count(tile->first);
+
                 std::stringstream tilefilename;
                 tilefilename.fill('0');
                 tilefilename << iDestDir << "/" << std::setw(3) << map_iter->first << "_";
                 uint32 x, y;
-                StaticMapTree::unpackTileID(tile->first, x, y);
+                StaticMapTree::unpackTileID(tileID, x, y);
                 tilefilename << std::setw(2) << x << "_" << std::setw(2) << y << ".vmtile";
                 FILE* tilefile = fopen(tilefilename.str().c_str(), "wb");
+                if (!tilefile)
+                {
+                    success = false;
+                    continue;
+                }
+                uint32 nSpawns = uint32(spawnIDs.size());
                 // File header
                 if (success && fwrite(VMAP_MAGIC, 1, 8, tilefile) != 8)
                 {
@@ -247,11 +272,7 @@ namespace VMAP
                 // Write tile spawns
                 for (uint32 s = 0; s < nSpawns; ++s)
                 {
-                    if (s && tile != tileEntries.end())
-                    {
-                        ++tile;
-                    }
-                    const ModelSpawn& spawn2 = map_iter->second->UniqueEntries[tile->second];
+                    const ModelSpawn& spawn2 = map_iter->second->UniqueEntries[spawnIDs[s]];
                     success = success && ModelSpawn::WriteToFile(tilefile, spawn2);
                     // MapTree nodes to update when loading tile:
                     std::map<uint32, uint32>::iterator nIdx = modelNodeIdx.find(spawn2.ID);

--- a/src/tools/Extractor_projects/vmap-extractor/CMakeLists.txt
+++ b/src/tools/Extractor_projects/vmap-extractor/CMakeLists.txt
@@ -42,7 +42,7 @@ add_executable(${EXECUTABLE_NAME} ${EXECUTABLE_SRCS}
     ${CMAKE_SOURCE_DIR}/src/tools/Extractor_projects/shared/ExtractorCommon.cpp
 )
 
-target_link_libraries(${EXECUTABLE_NAME} loadlib bzip2 zlib storm)
+target_link_libraries(${EXECUTABLE_NAME} loadlib bzip2 zlib storm g3dlite)
 
 install(TARGETS ${EXECUTABLE_NAME} DESTINATION "${BIN_DIR}/${TOOLS_DIR}")
 

--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -111,6 +111,9 @@ uint32 CONF_max_build = 0;
 const char* szWorkDirWmo = "./Buildings";
 const char* szRawVMAPMagic = "VMAPc06";
 
+/// WMO basename (as stored under szWorkDirWmo) -> parsed interior doodad data.
+std::map<std::string, WMODoodadData> g_WmoDoodads;
+
 // Local testing functions
 
 bool FileExists(const char* file)
@@ -616,6 +619,12 @@ bool ExtractSingleWmo(std::string& fname)
     if (!file_ok)
     {
         remove(szLocalFile);
+    }
+    else
+    {
+        // Key by the exact (fixnamen'd) basename WMOInstance later opens
+        // under szWorkDirWmo, so store and lookup provably match.
+        g_WmoDoodads[szLocalFile + strlen(szWorkDirWmo) + 1] = std::move(froot.DoodadData);
     }
     return true;
 }

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -81,49 +81,31 @@ bool WMORoot::open()
             f.read(bbcorn1, 12);
             f.read(bbcorn2, 12);
             f.read(&liquidType, 4);
-            break;
         }
-        /*
-        else if (!strcmp(fourcc,"MOTX"))
+        else if (!strcmp(fourcc, "MODS")) // doodad sets
         {
+            DoodadData.Sets.resize(size / sizeof(WMODoodad::MODS));
+            if (size)
+            {
+                f.read(DoodadData.Sets.data(), size);
+            }
         }
-        else if (!strcmp(fourcc,"MOMT"))
+        else if (!strcmp(fourcc, "MODN")) // doodad name block
         {
+            if (size)
+            {
+                DoodadData.Paths.reset(new char[size]);
+                f.read(DoodadData.Paths.get(), size);
+            }
         }
-        else if (!strcmp(fourcc,"MOGN"))
+        else if (!strcmp(fourcc, "MODD")) // doodad definitions (40 bytes each)
         {
+            DoodadData.Spawns.resize(size / sizeof(WMODoodad::MODD));
+            if (size)
+            {
+                f.read(DoodadData.Spawns.data(), size);
+            }
         }
-        else if (!strcmp(fourcc,"MOGI"))
-        {
-        }
-        else if (!strcmp(fourcc,"MOLT"))
-        {
-        }
-        else if (!strcmp(fourcc,"MODN"))
-        {
-        }
-        else if (!strcmp(fourcc,"MODS"))
-        {
-        }
-        else if (!strcmp(fourcc,"MODD"))
-        {
-        }
-        else if (!strcmp(fourcc,"MOSB"))
-        {
-        }
-        else if (!strcmp(fourcc,"MOPV"))
-        {
-        }
-        else if (!strcmp(fourcc,"MOPT"))
-        {
-        }
-        else if (!strcmp(fourcc,"MOPR"))
-        {
-        }
-        else if (!strcmp(fourcc,"MFOG"))
-        {
-        }
-        */
         f.seek((int)nextpos);
     }
     f.close();

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -27,6 +27,7 @@
 #include "vmapexport.h"
 #include "wmo.h"
 #include "vec3d.h"
+#include "adtfile.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cassert>
@@ -35,6 +36,9 @@
 #undef min
 #undef max
 #include "mpqfile.h"
+#include <G3D/Matrix3.h>
+#include <G3D/Quat.h>
+#include <G3D/Vector3.h>
 
 using namespace std;
 extern uint16* LiqType;
@@ -96,6 +100,32 @@ bool WMORoot::open()
             {
                 DoodadData.Paths.reset(new char[size]);
                 f.read(DoodadData.Paths.get(), size);
+                DoodadData.Paths[size - 1] = '\0'; // no-op for well-formed MODN, guards strlen on corrupt data
+                DoodadData.PathsLen = size;
+                // Extract every referenced model now, so doodad spawn emission
+                // can find its collision geometry under szWorkDirWmo later.
+                StringSet failedDoodadPaths;
+                char* ptr = DoodadData.Paths.get();
+                char* end = ptr + size;
+                while (ptr < end)
+                {
+                    size_t len = 0;
+                    while (ptr + len < end && ptr[len])
+                    {
+                        ++len;
+                    }
+                    std::string path(ptr, len);
+                    ptr += len + 1;
+                    if (path.length() < 4 || !GetExtension(GetPlainName(path.c_str())))
+                    {
+                        continue;
+                    }
+                    fixnamen(&path[0], path.length());
+                    char* s = GetPlainName(&path[0]);
+                    fixname2(s, strlen(s));
+                    std::string uName;
+                    ExtractSingleModel(path, uName, failedDoodadPaths);
+                }
             }
         }
         else if (!strcmp(fourcc, "MODD")) // doodad definitions (40 bytes each)
@@ -569,4 +599,125 @@ WMOInstance::WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint
     fwrite(&nlen, sizeof(uint32), 1, pDirfile);
     fwrite(WmoInstName, sizeof(char), nlen, pDirfile);
 
+    ExtractDoodadSet(WmoInstName, mapID, tileX, tileY, pDirfile);
+}
+
+/// Stable per-(WMO instance, doodad index) spawn ids from the top half of the
+/// uint32 range, so they cannot collide with client MODF/MDDF unique ids.
+static uint32 GenerateDoodadUniqueId(uint32 wmoUniqueId, uint32 doodadIndex)
+{
+    static std::map<std::pair<uint32, uint32>, uint32> doodadIdMap;
+    static uint32 nextId = 0x80000000;
+
+    uint32& uid = doodadIdMap[std::make_pair(wmoUniqueId, doodadIndex)];
+    if (uid == 0)
+    {
+        uid = nextId++;
+    }
+    return uid;
+}
+
+void WMOInstance::ExtractDoodadSet(const char* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile)
+{
+    std::map<std::string, WMODoodadData>::const_iterator doodadItr = g_WmoDoodads.find(WmoInstName);
+    if (doodadItr == g_WmoDoodads.end())
+    {
+        return;
+    }
+
+    const WMODoodadData& doodadData = doodadItr->second;
+    if (doodadData.Sets.empty() || !doodadData.Paths)
+    {
+        return;
+    }
+
+    // Only the always-active doodad set 0 (Set_$DefaultGlobal) for now.
+    const WMODoodad::MODS& set = doodadData.Sets[0];
+
+    // pos is already fixCoords'd above; rot is the raw MODF Euler degrees.
+    G3D::Vector3 wmoPos(pos.x, pos.y, pos.z);
+    G3D::Matrix3 wmoRot = G3D::Matrix3::fromEulerAnglesZYX(G3D::toRadians(rot.y), G3D::toRadians(rot.x), G3D::toRadians(rot.z));
+
+    size_t spawnEnd = size_t(set.StartIndex) + set.Count;
+    if (spawnEnd > doodadData.Spawns.size())
+    {
+        spawnEnd = doodadData.Spawns.size();
+    }
+
+    for (size_t i = set.StartIndex; i < spawnEnd; ++i)
+    {
+        const WMODoodad::MODD& doodad = doodadData.Spawns[i];
+        if (doodad.NameIndex >= doodadData.PathsLen)
+        {
+            continue;
+        }
+
+        char ModelInstName[1024];
+        const char* plainName = GetPlainName(&doodadData.Paths[doodad.NameIndex]);
+        uint32 nlen = strlen(plainName);
+        if (nlen <= 3 || nlen >= sizeof(ModelInstName))
+        {
+            continue;
+        }
+        strcpy(ModelInstName, plainName);
+        fixnamen(ModelInstName, nlen);
+        fixname2(ModelInstName, nlen);
+        // Extracted models are stored as .m2
+        char* extension = &ModelInstName[nlen - 4];
+        if (!strcmp(extension, ".mdx") || !strcmp(extension, ".mdl"))
+        {
+            ModelInstName[nlen - 2] = '2';
+            ModelInstName[nlen - 1] = '\0';
+            --nlen;
+        }
+
+        // Skip doodads without extracted collision geometry.
+        char tempname[1036];
+        sprintf(tempname, "%s/%s", szWorkDirWmo, ModelInstName);
+        FILE* input = fopen(tempname, "r+b");
+        if (!input)
+        {
+            continue;
+        }
+        fseek(input, 8, SEEK_SET); // get the correct no of vertices
+        int nVertices = 0;
+        size_t count = fread(&nVertices, sizeof(int), 1, input);
+        fclose(input);
+        if (count != 1 || nVertices == 0)
+        {
+            continue;
+        }
+
+        G3D::Vector3 worldPos = wmoPos + wmoRot * G3D::Vector3(doodad.Position.x, doodad.Position.y, doodad.Position.z);
+        Vec3D position(worldPos.x, worldPos.y, worldPos.z);
+
+        Vec3D rotation;
+        (G3D::Quat(doodad.RotX, doodad.RotY, doodad.RotZ, doodad.RotW).toRotationMatrix() * wmoRot)
+            .toEulerAnglesXYZ(rotation.z, rotation.x, rotation.y);
+        rotation.x = G3D::toDegrees(rotation.x);
+        rotation.y = G3D::toDegrees(rotation.y);
+        rotation.z = G3D::toDegrees(rotation.z);
+
+        uint16 adtId = 0; // not used for models
+        uint32 uniqueId = GenerateDoodadUniqueId(id, uint32(i));
+        uint32 flags = MOD_M2;
+        if (tileX == 65 && tileY == 65)
+        {
+            flags |= MOD_WORLDSPAWN;
+        }
+        float scale = doodad.Scale; // MODD scale is a direct float, unlike MDDF
+
+        //write mapID, tileX, tileY, Flags, ID, Pos, Rot, Scale, name
+        fwrite(&mapID, sizeof(uint32), 1, pDirfile);
+        fwrite(&tileX, sizeof(uint32), 1, pDirfile);
+        fwrite(&tileY, sizeof(uint32), 1, pDirfile);
+        fwrite(&flags, sizeof(uint32), 1, pDirfile);
+        fwrite(&adtId, sizeof(uint16), 1, pDirfile);
+        fwrite(&uniqueId, sizeof(uint32), 1, pDirfile);
+        fwrite(&position, sizeof(float), 3, pDirfile);
+        fwrite(&rotation, sizeof(float), 3, pDirfile);
+        fwrite(&scale, sizeof(float), 1, pDirfile);
+        fwrite(&nlen, sizeof(uint32), 1, pDirfile);
+        fwrite(ModelInstName, sizeof(char), nlen, pDirfile);
+    }
 }

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.h
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.h
@@ -30,6 +30,8 @@
 
 #include <string>
 #include <set>
+#include <vector>
+#include <memory>
 #include "vec3d.h"
 #include "mpqfile.h"
 
@@ -49,6 +51,35 @@ class MPQFile;
 /* for whatever reason a certain company just can't stick to one coordinate system... */
 static inline Vec3D fixCoords(const Vec3D& v) { return Vec3D(v.z, v.x, v.y); }
 
+// WMO interior doodad sets (wowdev WMO MODS/MODN/MODD, 4.3.4).
+namespace WMODoodad
+{
+    struct MODS                          // doodad set, 32 bytes
+    {
+        char Name[20];
+        uint32 StartIndex;               // first MODD index in this set
+        uint32 Count;                    // number of doodads in this set
+        char _pad[4];
+    };
+
+    struct MODD                          // doodad instance, 40 bytes
+    {
+        uint32 NameIndex : 24;           // byte offset into the MODN name block
+        uint32 Flags : 8;
+        Vec3D Position;                  // WMO-local (Z-up)
+        float RotX, RotY, RotZ, RotW;    // orientation quaternion
+        float Scale;
+        uint32 Color;
+    };
+}
+
+struct WMODoodadData
+{
+    std::vector<WMODoodad::MODS> Sets;
+    std::unique_ptr<char[]> Paths;       // MODN name block
+    std::vector<WMODoodad::MODD> Spawns; // MODD
+};
+
 /**
  * @brief
  *
@@ -60,6 +91,7 @@ class WMORoot
         unsigned int col; /**< TODO */
         float bbcorn1[3]; /**< TODO */
         float bbcorn2[3]; /**< TODO */
+        WMODoodadData DoodadData; ///< Parsed MODS/MODN/MODD interior doodads.
 
         /**
          * @brief

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.h
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <set>
+#include <map>
 #include <vector>
 #include <memory>
 #include "vec3d.h"
@@ -77,8 +78,12 @@ struct WMODoodadData
 {
     std::vector<WMODoodad::MODS> Sets;
     std::unique_ptr<char[]> Paths;       // MODN name block
+    uint32 PathsLen = 0;                 // size of the MODN block, for NameIndex bounds checks
     std::vector<WMODoodad::MODD> Spawns; // MODD
 };
+
+/// WMO basename (as stored under szWorkDirWmo) -> parsed interior doodad data.
+extern std::map<std::string, WMODoodadData> g_WmoDoodads;
 
 /**
  * @brief
@@ -240,6 +245,17 @@ class WMOInstance
          * @param pDirfile
          */
         WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
+
+        /**
+         * @brief Emits collision spawns for the instance's set-0 interior doodads.
+         *
+         * @param WmoInstName
+         * @param mapID
+         * @param tileX
+         * @param tileY
+         * @param pDirfile
+         */
+        void ExtractDoodadSet(const char* WmoInstName, uint32 mapID, uint32 tileX, uint32 tileY, FILE* pDirfile);
 
         /**
          * @brief


### PR DESCRIPTION
## Problem

51% of 4.3.4 WMOs carry interior doodads (~326k placements), but vmap extraction stopped at `MOHD` and never emitted their collision — so furniture, pillars and props inside buildings had no LoS/navmesh footprint.

## Fix (three commits)

1. **Parse `MODS`/`MODN`/`MODD`** into `WMODoodadData`; link g3dlite for the WMO-matrix × doodad-quaternion transform (matches the runtime `ModelInstance` `G3D::fromEulerAnglesZYX` convention).
2. **Emit doodad collision spawns:** extract every `MODN`-referenced M2 under `Buildings/`, emit set 0 after the WMO's own spawn row (world transform = `wmoPos + wmoRot * localPos`, rotation = `(doodadQuat * wmoRot)` Euler degrees, `MODD` scale as a direct float). Synthetic unique ids from the top half of the `uint32` range so they can't collide with client MODF/MDDF ids and stay dedupable across tiles. Bounds-checked against corrupt set ranges / name offsets.
3. **TileAssembler walk-past-end fix:** a tile holding a `MOD_WORLDSPAWN` spawn *plus* others (now happens at 65/65 once interior doodads exist) made the hand-rolled inner `++tile` walk past `end()` → UB (assembler wedged on instance maps). Walk unique tile IDs via `equal_range` and filter `MOD_WORLDSPAWN`. Ports vetted fix `4d9391200`.

Output-changing; takes effect at the next re-extract.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/236)
<!-- Reviewable:end -->
