### PR TITLE
[Extractor] Fix MH2O liquid format and dark-water for Cata

### DIFF
--- a/dep/loadlib/sl/adt.h
+++ b/dep/loadlib/sl/adt.h
@@ -180,13 +180,15 @@ class adt_MCIN
         }
 };
 
-#define ADT_LIQUID_HEADER_FULL_LIGHT   0x01
-#define ADT_LIQUID_HEADER_NO_HIGHT     0x02
-
 struct adt_liquid_header
 {
     uint16 liquidType;             // Index from LiquidType.dbc
-    uint16 formatFlags;
+    // LiquidVertexFormat enum (4.3.4): 0=height+depth, 1=height+uv,
+    // 2=depth-only (height is 0.0), 3=height+uv+depth.
+    // TODO(MoP): 5.x adds a LiquidObject indirection - a value >= 42 is a
+    // LiquidObject.dbc id (resolve LiquidObject->LiquidType->LiquidMaterial->LVF,
+    // needs those DBC loaders) and width/height/offsets then default to 8,8,0,0.
+    uint16 liquidVertexFormat;
     float  heightLevel1;
     float  heightLevel2;
     uint8  xOffset;
@@ -228,36 +230,21 @@ class adt_MH2O
 
         float* getLiquidHeightMap(adt_liquid_header* h)
         {
-            if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
+            // LVF 2 is depth-only (height is 0.0); 0/1/3 begin with the float heightmap.
+            if (h->liquidVertexFormat == 2)
                 return 0;
             if (h->offsData2b)
                 return (float*)((uint8*)this + 8 + h->offsData2b);
             return 0;
         }
 
-        uint8* getLiquidLightMap(adt_liquid_header* h)
+        // Per-chunk Cata "deep" attribute (8x8 bitmask) -> fatigue / dark water.
+        // mh2o_chunk_attributes { uint64 fishable; uint64 deep; } at offset_attributes
+        // (liquid[x][y].offsData2); omitted (0) means all-0, i.e. not deep.
+        uint64 getLiquidDeepMap(int x, int y)
         {
-            if (h->formatFlags & ADT_LIQUID_HEADER_FULL_LIGHT)
-                return 0;
-            if (h->offsData2b)
-            {
-                if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
-                    return (uint8*)((uint8*)this + 8 + h->offsData2b);
-                return (uint8*)((uint8*)this + 8 + h->offsData2b + (h->width + 1) * (h->height + 1) * 4);
-            }
-            return 0;
-        }
-
-        uint32* getLiquidFullLightMap(adt_liquid_header* h)
-        {
-            if (!(h->formatFlags & ADT_LIQUID_HEADER_FULL_LIGHT))
-                return 0;
-            if (h->offsData2b)
-            {
-                if (h->formatFlags & ADT_LIQUID_HEADER_NO_HIGHT)
-                    return (uint32*)((uint8*)this + 8 + h->offsData2b);
-                return (uint32*)((uint8*)this + 8 + h->offsData2b + (h->width + 1) * (h->height + 1) * 4);
-            }
+            if (liquid[x][y].offsData2)
+                return *((uint64*)((uint8*)this + 8 + liquid[x][y].offsData2 + sizeof(uint64)));
             return 0;
         }
 

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -997,14 +997,10 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
                         printf("\nCan not find liquid type %u for map %s\nchunk %d,%d\n", h->liquidType, filename, i, j);
                         break;
                 }
-                // Dark water detect
-                if (liqType == LIQUID_TYPE_OCEAN)
+                // Dark water detect (Cata "deep" attribute, not a light-map heuristic)
+                if (liqType == LIQUID_TYPE_OCEAN && h2o->getLiquidDeepMap(i, j))
                 {
-                    uint8* lm = h2o->getLiquidLightMap(h);
-                    if (!lm)
-                    {
-                        liquid_flags[i][j] |= MAP_LIQUID_TYPE_DARK_WATER;
-                    }
+                    liquid_flags[i][j] |= MAP_LIQUID_TYPE_DARK_WATER;
                 }
 
                 if (!count && liquid_flags[i][j])
@@ -1026,7 +1022,8 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
                         }
                         else
                         {
-                            liquid_height[cy][cx] = h->heightLevel1;
+                            // LVF 2 carries no heightmap and its height is always 0.0.
+                            liquid_height[cy][cx] = (h->liquidVertexFormat == 2) ? 0.0f : h->heightLevel1;
                         }
                         pos++;
                     }


### PR DESCRIPTION
## Problem

The `MH2O` instance's second `uint16` is the `LiquidVertexFormat` enum (0–3) in 4.3.4, **not** a bitmask. The old code tested it as `& 0x02`, so LVF3 (height+uv+depth) was misread as "no height" and the per-vertex heightmap was discarded → flat liquid.

## Fix

Read it as the enum: heightmap is present for LVF 0/1/3, and LVF 2 (depth-only) height is `0.0`.

Dark water now reads the Cata `deep` attribute (`mh2o_chunk_attributes`, 8×8 bitmask at `offset_attributes`) instead of the old light-map null heuristic. Removed the unused, wrong-model light-map accessors.

A `TODO(MoP)` marks the 5.x `LiquidObject` (≥ 42) indirection.

Reference: wowdev ADT/v18 MH2O.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/237)
<!-- Reviewable:end -->
