### PR TITLE
[Movemap] Fix terrain and WMO liquid navmesh

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
@@ -133,8 +133,10 @@ namespace MMAP
         // data used later
         uint16 holes[16][16];
         memset(holes, 0, sizeof(holes));
-        uint8 liquid_type[16][16];
-        memset(liquid_type, 0, sizeof(liquid_type));
+        uint16 liquid_entry[16][16];
+        memset(liquid_entry, 0, sizeof(liquid_entry));
+        uint8 liquid_flags[16][16];
+        memset(liquid_flags, 0, sizeof(liquid_flags));
         G3D::Array<int> ltriangles;
         G3D::Array<int> ttriangles;
 
@@ -291,13 +293,25 @@ namespace MMAP
 
             if (!(lheader.flags & MAP_LIQUID_NO_TYPE))
             {
-                file_read = fread(liquid_type, sizeof(liquid_type), 1, mapFile);
+                file_read = fread(liquid_entry, sizeof(liquid_entry), 1, mapFile);
                 if (file_read <= 0)
                 {
                     fclose(mapFile);
                     printf("Could not read map data from %s.\n", mapFileName);
                     return false;
                 }
+                file_read = fread(liquid_flags, sizeof(liquid_flags), 1, mapFile);
+                if (file_read <= 0)
+                {
+                    fclose(mapFile);
+                    printf("Could not read map data from %s.\n", mapFileName);
+                    return false;
+                }
+            }
+            else
+            {
+                // uniform liquid grid: header liquidType field carries the MAP_LIQUID_TYPE_* flags
+                memset(liquid_flags, (uint8)lheader.liquidType, sizeof(liquid_flags));
             }
 
             if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
@@ -313,65 +327,63 @@ namespace MMAP
                 }
             }
 
-            if (liquid_type && liquid_map)
+            int count = meshData.liquidVerts.size() / 3;
+            float xoffset = (float(tileX) - 32) * GRID_SIZE;
+            float yoffset = (float(tileY) - 32) * GRID_SIZE;
+
+            float coord[3];
+            int row, col;
+
+            // generate coordinates
+            if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
             {
-                int count = meshData.liquidVerts.size() / 3;
-                float xoffset = (float(tileX) - 32) * GRID_SIZE;
-                float yoffset = (float(tileY) - 32) * GRID_SIZE;
-
-                float coord[3];
-                int row, col;
-
-                // generate coordinates
-                if (!(lheader.flags & MAP_LIQUID_NO_HEIGHT))
+                int j = 0;
+                for (int i = 0; i < V9_SIZE_SQ; ++i)
                 {
-                    int j = 0;
-                    for (int i = 0; i < V9_SIZE_SQ; ++i)
+                    row = i / V9_SIZE;
+                    col = i % V9_SIZE;
+
+                    if (row < lheader.offsetY || row >= lheader.offsetY + lheader.height ||
+                        col < lheader.offsetX || col >= lheader.offsetX + lheader.width)
                     {
-                        row = i / V9_SIZE;
-                        col = i % V9_SIZE;
-
-                        if (row < lheader.offsetY || row >= lheader.offsetY + lheader.height ||
-                            col < lheader.offsetX || col >= lheader.offsetX + lheader.width)
-                        {
-                            // dummy vert using invalid height
-                            meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, INVALID_MAP_LIQ_HEIGHT, (yoffset + row * GRID_PART_SIZE) * -1);
-                            continue;
-                        }
-
-                        getLiquidCoord(i, j, xoffset, yoffset, coord, liquid_map);
-                        meshData.liquidVerts.append(coord[0]);
-                        meshData.liquidVerts.append(coord[2]);
-                        meshData.liquidVerts.append(coord[1]);
-                        j++;
+                        // dummy vert using invalid height
+                        meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, INVALID_MAP_LIQ_HEIGHT, (yoffset + row * GRID_PART_SIZE) * -1);
+                        continue;
                     }
+
+                    getLiquidCoord(i, j, xoffset, yoffset, coord, liquid_map);
+                    meshData.liquidVerts.append(coord[0]);
+                    meshData.liquidVerts.append(coord[2]);
+                    meshData.liquidVerts.append(coord[1]);
+                    j++;
                 }
-                else
-                {
-                    for (int i = 0; i < V9_SIZE_SQ; ++i)
-                    {
-                        row = i / V9_SIZE;
-                        col = i % V9_SIZE;
-                        meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, lheader.liquidLevel, (yoffset + row * GRID_PART_SIZE) * -1);
-                    }
-                }
-
-                delete [] liquid_map;
-
-                int indices[3], loopStart, loopEnd, loopInc, triInc;
-                getLoopVars(portion, loopStart, loopEnd, loopInc);
-                triInc = BOTTOM - TOP;
-
-                // generate triangles
-                for (int i = loopStart; i < loopEnd; i += loopInc)
-                    for (int j = TOP; j <= BOTTOM; j += triInc)
-                    {
-                        getHeightTriangle(i, Spot(j), indices, true);
-                        ltriangles.append(indices[2] + count);
-                        ltriangles.append(indices[1] + count);
-                        ltriangles.append(indices[0] + count);
-                    }
             }
+            else
+            {
+                // flat liquid surface at a uniform level
+                for (int i = 0; i < V9_SIZE_SQ; ++i)
+                {
+                    row = i / V9_SIZE;
+                    col = i % V9_SIZE;
+                    meshData.liquidVerts.append((xoffset + col * GRID_PART_SIZE) * -1, lheader.liquidLevel, (yoffset + row * GRID_PART_SIZE) * -1);
+                }
+            }
+
+            delete [] liquid_map;
+
+            int indices[3], loopStart, loopEnd, loopInc, triInc;
+            getLoopVars(portion, loopStart, loopEnd, loopInc);
+            triInc = BOTTOM - TOP;
+
+            // generate triangles
+            for (int i = loopStart; i < loopEnd; i += loopInc)
+                for (int j = TOP; j <= BOTTOM; j += triInc)
+                {
+                    getHeightTriangle(i, Spot(j), indices, true);
+                    ltriangles.append(indices[2] + count);
+                    ltriangles.append(indices[1] + count);
+                    ltriangles.append(indices[0] + count);
+                }
         }
 
         fclose(mapFile);
@@ -412,34 +424,36 @@ namespace MMAP
                 uint8 liquidType = MAP_LIQUID_TYPE_NO_WATER;
 
                 // if there is no liquid, don't use liquid
-                if (!liquid_type || !meshData.liquidVerts.size() || !ltriangles.size())
+                if (!meshData.liquidVerts.size() || !ltriangles.size())
                 {
                     useLiquid = false;
                 }
                 else
                 {
-                    liquidType = getLiquidType(i, liquid_type);
-                    switch (liquidType)
+                    // liquid flags are MAP_LIQUID_TYPE_* bits, test them - dark water first
+                    liquidType = getLiquidType(i, liquid_flags);
+                    if (liquidType & MAP_LIQUID_TYPE_DARK_WATER)
                     {
-                        default:
-                            useLiquid = false;
-                            break;
-                        case MAP_LIQUID_TYPE_WATER:
-                        case MAP_LIQUID_TYPE_OCEAN:
-                            // merge different types of water
-                            liquidType = NAV_WATER;
-                            break;
-                        case MAP_LIQUID_TYPE_MAGMA:
-                            liquidType = NAV_MAGMA;
-                            break;
-                        case MAP_LIQUID_TYPE_SLIME:
-                            liquidType = NAV_SLIME;
-                            break;
-                        case MAP_LIQUID_TYPE_DARK_WATER:
-                            // players should not be here, so logically neither should creatures
-                            useTerrain = false;
-                            useLiquid = false;
-                            break;
+                        // players should not be here, so logically neither should creatures
+                        useTerrain = false;
+                        useLiquid = false;
+                    }
+                    else if (liquidType & (MAP_LIQUID_TYPE_WATER | MAP_LIQUID_TYPE_OCEAN))
+                    {
+                        // merge different types of water
+                        liquidType = NAV_WATER;
+                    }
+                    else if (liquidType & MAP_LIQUID_TYPE_MAGMA)
+                    {
+                        liquidType = NAV_MAGMA;
+                    }
+                    else if (liquidType & MAP_LIQUID_TYPE_SLIME)
+                    {
+                        liquidType = NAV_SLIME;
+                    }
+                    else
+                    {
+                        useLiquid = false;
                     }
                 }
 

--- a/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/TerrainBuilder.cpp
@@ -775,17 +775,26 @@ namespace MMAP
                         uint8 type = NAV_EMPTY;
 
                         // convert liquid type to NavTerrain
+                        // vmap-extractor stores LiquidType.dbc ids (13/14/19/20 for WMO
+                        // water/ocean/magma/slime); basic ids 1-4 can pass through raw
                         switch (liquid->GetType())
                         {
-                            case 0:
-                            case 1:
+                            case 1:  // water
+                            case 2:  // ocean
+                            case 13: // WMO water
+                            case 14: // WMO ocean
                                 type = NAV_WATER;
                                 break;
-                            case 2:
+                            case 3:  // magma
+                            case 19: // WMO magma
                                 type = NAV_MAGMA;
                                 break;
-                            case 3:
+                            case 4:  // slime
+                            case 20: // WMO slime
+                            case 21: // Naxxramas slime
                                 type = NAV_SLIME;
+                                break;
+                            default: // unknown: keep NAV_EMPTY, span is dropped
                                 break;
                         }
 


### PR DESCRIPTION
## Problem

The movemap generator dropped most liquid from the navmesh, on two paths:

**Terrain liquid:** `loadMap` read a single `uint8[16][16]` where the `.map` liquid block (c1.4) stores `liquid_entry` (`uint16[16][16]`) followed by `liquid_flags` (`uint8[16][16]`) — misaligning the heightmap by 512 bytes and classifying cells by DBC-id bytes instead of `MAP_LIQUID_TYPE_*` flags. A dead `liquid_type && liquid_map` gate also meant flat uniform-level liquid (most oceans) never produced any liquid mesh.

**WMO liquid:** the switch matched raw types 0–3, but vmap-extractor normalizes WMO liquid to `LiquidType.dbc` ids (13 water, 14 ocean, 19 magma, 20 slime). Every WMO liquid span fell through to `NAV_EMPTY` and was dropped.

## Fix

Read both terrain arrays, pick the NAV type by flag bit-tests (dark water first), and seed flags from the header `liquidType` for uniform `NO_TYPE` grids — making the `liquidLevel` branch reachable and matching `GridMap` reader behaviour. Map WMO liquid by both DBC-id ranges grouped per `LiquidType.dbc` SoundBank; unknown ids still drop.

Two commits (terrain + WMO).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/238)
<!-- Reviewable:end -->
