### PR TITLE
[Tools] Skip antiportal/unreachable WMO groups during vmap extraction

### DIFF
--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -586,6 +586,7 @@ bool ExtractSingleWmo(std::string& fname)
     }
     froot.ConvertToVMAPRootWmo(output);
     int Wmo_nVertices = 0;
+    uint32 groupCount = 0; ///< groups actually written (post-ShouldSkip filter)
     //printf("root has %d groups\n", froot->nGroups);
     if (froot.nGroups != 0)
     {
@@ -607,12 +608,24 @@ bool ExtractSingleWmo(std::string& fname)
                 break;
             }
 
+            // Drop antiportal/unreachable groups before they reach the
+            // collision mesh — invisible renderer occluders must not
+            // block LoS rays or the navmesh.
+            if (fgroup.ShouldSkip(&froot))
+            {
+                continue;
+            }
+
             Wmo_nVertices += fgroup.ConvertToVMAPGroupWmo(output, &froot, preciseVectorData);
+            ++groupCount;
         }
     }
 
     fseek(output, 8, SEEK_SET); // store the correct no of vertices
     fwrite(&Wmo_nVertices, sizeof(int), 1, output);
+    // Overwrite the nGroups placeholder at offset 12 with the post-filter
+    // group count, or the runtime tries to load filtered-out groups.
+    fwrite(&groupCount, sizeof(uint32), 1, output);
     fclose(output);
 
     // Delete the extracted file in the case of an error

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -136,6 +136,14 @@ bool WMORoot::open()
                 f.read(DoodadData.Spawns.data(), size);
             }
         }
+        else if (!strcmp(fourcc, "MOGN")) // packed group-name blob
+        {
+            GroupNames.resize(size);
+            if (size)
+            {
+                f.read(GroupNames.data(), size);
+            }
+        }
         f.seek((int)nextpos);
     }
     f.close();
@@ -161,6 +169,29 @@ WMORoot::~WMORoot()
 WMOGroup::WMOGroup(std::string& filename) : filename(filename),
     MOPY(0), MOVI(0), MoviEx(0), MOVT(0), MOBA(0), MobaEx(0), hlq(0), LiquEx(0), LiquBytes(0)
 {
+}
+
+bool WMOGroup::ShouldSkip(WMORoot const* root) const
+{
+    // Unreachable groups (MOGP 0x80) are level-streaming hints, not walkable areas.
+    if (mogpFlags & 0x80)
+    {
+        return true;
+    }
+    // Antiportal groups (MOGP 0x4000000) are invisible renderer occluders;
+    // they must not contribute collision/LoS mesh. Mirrors TC vmap4_extractor.
+    if (mogpFlags & 0x4000000)
+    {
+        return true;
+    }
+    // Some WMOs flag antiportals by group name instead of the MOGP bit.
+    if (root && groupName >= 0 &&
+        static_cast<std::size_t>(groupName) < root->GroupNames.size() &&
+        !strcmp(&root->GroupNames[groupName], "antiportal"))
+    {
+        return true;
+    }
+    return false;
 }
 
 bool WMOGroup::open()

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.h
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.h
@@ -98,6 +98,7 @@ class WMORoot
         float bbcorn1[3]; /**< TODO */
         float bbcorn2[3]; /**< TODO */
         WMODoodadData DoodadData; ///< Parsed MODS/MODN/MODD interior doodads.
+        std::vector<char> GroupNames; ///< MOGN packed name blob; WMOGroup::ShouldSkip resolves groupName in here.
 
         /**
          * @brief
@@ -160,6 +161,9 @@ struct WMOLiquidVert
 class WMOGroup
 {
     public:
+        /// Skip antiportal (MOGP 0x4000000 or name "antiportal") and unreachable (MOGP 0x80) groups.
+        bool ShouldSkip(WMORoot const* root) const;
+
         // MOGP
         int groupName, descGroupName, mogpFlags; /**< TODO */
         float bbcorn1[3]; /**< TODO */


### PR DESCRIPTION
## Problem

Antiportals are invisible renderer occluders. Baked into vmaps they block spell line-of-sight and fragment the navmesh inside large WMOs (Stormwind Keep / Cathedral) — `.mmap path` fails to build through clear interior space and spells won't cast around pillars.

## Fix

Drop groups with `MOGP 0x80` (unreachable), `MOGP 0x4000000` (antiportal) or group name `antiportal` before they reach the collision mesh, and backfill the post-filter group count at offset 12.

This restores the `ShouldSkip` half of the archived vmap-redesign LoS fix (`0205ed9af`); the MOPY-relabel half already landed separately.

**NOTE:** takes effect only after vmaps (and then mmaps) are re-extracted with this extractor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/239)
<!-- Reviewable:end -->
