### PR TITLE
[Movemap] Lower default walkable slope to 55 degrees

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/generator.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/generator.cpp
@@ -321,7 +321,7 @@ int finish(const char* message, int returnValue)
 int main(int argc, char** argv)
 {
     int mapnum = -1;
-    float maxAngle = 60.0f;
+    float maxAngle = 55.0f;
     int tileX = -1, tileY = -1;
     bool skipLiquid = false,
          skipContinents = false,


### PR DESCRIPTION
## Problem

The default walkable slope of 60° let creatures path up near-vertical terrain (NPCs climbing cliffs players cannot).

## Fix

Lower the default to 55°, matching the TrinityCore 4.3.4 ground-walkable angle.

The steep 55–70° combat-band (`NAV_AREA_GROUND_STEEP`) is left as a future enhancement.

**NOTE:** takes effect only after mmaps are re-extracted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/240)
<!-- Reviewable:end -->
