### PR TITLE
[Cleanup] Fix MapObjects typo in ADT_file MCNK struct

### DIFF
--- a/dep/loadlib/sl/adt.h
+++ b/dep/loadlib/sl/adt.h
@@ -276,8 +276,8 @@ class adt_MHDR
         uint32 offsTex;            // MTEX
         uint32 offsModels;         // MMDX
         uint32 offsModelsIds;      // MMID
-        uint32 offsMapObejcts;     // MWMO
-        uint32 offsMapObejctsIds;  // MWID
+        uint32 offsMapObjects;     // MWMO
+        uint32 offsMapObjectsIds;  // MWID
         uint32 offsDoodsDef;       // MDDF
         uint32 offsObjectsDef;     // MODF
         uint32 offsMFBO;           // MFBO


### PR DESCRIPTION
Per @Antz's catch — `offsMapObejcts`/`offsMapObejctsIds` → `offsMapObjects`/`offsMapObjectsIds` (MWMO/MWID offsets in the ADT MCNK struct). Declarations only; no other references in the tree, so no call-site churn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/241)
<!-- Reviewable:end -->
