### PR TITLE
[Maps] Support 4-digit map IDs under MISTS + MoP TODO markers

### DIFF
--- a/dep/loadlib/sl/adt.h
+++ b/dep/loadlib/sl/adt.h
@@ -116,7 +116,10 @@ class adt_MCNK
         uint32 sizeMCSH;
         uint32 areaid;
         uint32 nMapObjRefs;
-        uint16 holes;           // locations where models pierce the heightmap
+        uint16 holes;           // low-res 16-bit hole map (holes_low_res)
+        // TODO(MoP): client 5.3+ adds a 64-bit high_res_holes map (MCNK flag
+        // 0x10000) that reuses the ofsHeight/ofsNormal bytes; parse it for MoP.
+        // See MOP_READINESS.md (B1).
         uint16 pad;
         uint16 s[2];
         uint32 data1;

--- a/dep/loadlib/sl/adt.h
+++ b/dep/loadlib/sl/adt.h
@@ -117,9 +117,12 @@ class adt_MCNK
         uint32 areaid;
         uint32 nMapObjRefs;
         uint16 holes;           // low-res 16-bit hole map (holes_low_res)
-        // TODO(MoP): client 5.3+ adds a 64-bit high_res_holes map (MCNK flag
-        // 0x10000) that reuses the ofsHeight/ofsNormal bytes; parse it for MoP.
-        // See MOP_READINESS.md (B1).
+        // TODO(MoP): ENTANGLED - do NOT wire in isolation. Client 5.3+ stores a
+        // 64-bit high_res_holes map at MCNK +0x14 (flag 0x10000) - the SAME bytes
+        // this struct reads as offsMCVT/offsMCNR. In 5.3+ ofsHeight/ofsNormal are
+        // gone (MCVT/MCNR found by sub-chunk iteration), so reading holes here
+        // would feed garbage to getMCVT() on flagged chunks. MoP holes require the
+        // whole 5.3+ MCNK header rework, not a holes-only change. MOP_READINESS (B1).
         uint16 pad;
         uint16 s[2];
         uint32 data1;

--- a/src/game/ChatCommands/MMapCommands.cpp
+++ b/src/game/ChatCommands/MMapCommands.cpp
@@ -177,7 +177,11 @@ bool ChatHandler::HandleMmapLocCommand(char* /*args*/)
     int32 gx = 32 - player->GetPositionX() / SIZE_OF_GRIDS;
     int32 gy = 32 - player->GetPositionY() / SIZE_OF_GRIDS;
 
+#if defined(MISTS)
+    PSendSysMessage("%04u%02i%02i.mmtile", player->GetMapId(), gy, gx);
+#else
     PSendSysMessage("%03u%02i%02i.mmtile", player->GetMapId(), gy, gx);
+#endif
     PSendSysMessage("gridloc [%i,%i]", gx, gy);
 
     // calculate navmesh tile location

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -378,8 +378,10 @@ float GridMap::getHeightFromFlat(float /*x*/, float /*y*/) const
  */
 // TODO(MoP): 4.3.4 only has the low-res 16-bit hole map. Client 5.3+ adds a
 // 64-bit high_res_holes map (MCNK flag 0x10000); supporting it needs a 64-bit
-// hole store here, a wider .map holes block, and a .map version bump. Pairs with
-// the map-extractor writer + adt.h parse. See MOP_READINESS.md (B3).
+// hole store here, a wider .map holes block, and a .map version bump. ENTANGLED:
+// the extractor side can't read those holes in isolation - they live at MCNK +0x14
+// where M3 reads the height offset (see dep/loadlib/sl/adt.h B1), so MoP holes are
+// part of the broader 5.3+ MCNK header rework, not a holes-only change. MOP_READINESS (B3).
 bool GridMap::isHole(int row, int col) const
 {
     int cellRow = row / 8;     // 8 squares per cell

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -378,7 +378,8 @@ float GridMap::getHeightFromFlat(float /*x*/, float /*y*/) const
  */
 // TODO(MoP): 4.3.4 only has the low-res 16-bit hole map. Client 5.3+ adds a
 // 64-bit high_res_holes map (MCNK flag 0x10000); supporting it needs a 64-bit
-// hole store here, a wider .map holes block, and a .map version bump.
+// hole store here, a wider .map holes block, and a .map version bump. Pairs with
+// the map-extractor writer + adt.h parse. See MOP_READINESS.md (B3).
 bool GridMap::isHole(int row, int col) const
 {
     int cellRow = row / 8;     // 8 squares per cell

--- a/src/game/WorldHandlers/MoveMap.cpp
+++ b/src/game/WorldHandlers/MoveMap.cpp
@@ -236,12 +236,15 @@ namespace MMAP
         }
 
         // load and init dtNavMesh - read parameters from file
-        // TODO(MoP): mmap/mmtile names use %03i here and in loadMap below; widen to
-        // %04u for map ids >= 1000. Must move with the Movemap-Generator writers.
-        // Filename-only. See MOP_READINESS.md (A6).
+#if defined(MISTS)
+        uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%04u.mmap") + 1;
+        char* fileName = new char[pathLen];
+        snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%04u.mmap").c_str(), mapId);
+#else
         uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%03i.mmap") + 1;
         char* fileName = new char[pathLen];
         snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%03i.mmap").c_str(), mapId);
+#endif
 
         FILE* file = fopen(fileName, "rb");
         if (!file)
@@ -306,9 +309,15 @@ namespace MMAP
         }
 
         // load this tile :: mmaps/MMMXXYY.mmtile
+#if defined(MISTS)
+        uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%04u%02i%02i.mmtile") + 1;
+        char* fileName = new char[pathLen];
+        snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%04u%02i%02i.mmtile").c_str(), mapId, x, y);
+#else
         uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%03i%02i%02i.mmtile") + 1;
         char* fileName = new char[pathLen];
         snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%03i%02i%02i.mmtile").c_str(), mapId, x, y);
+#endif
 
         FILE* file = fopen(fileName, "rb");
         if (!file)

--- a/src/game/WorldHandlers/MoveMap.cpp
+++ b/src/game/WorldHandlers/MoveMap.cpp
@@ -236,6 +236,9 @@ namespace MMAP
         }
 
         // load and init dtNavMesh - read parameters from file
+        // TODO(MoP): mmap/mmtile names use %03i here and in loadMap below; widen to
+        // %04u for map ids >= 1000. Must move with the Movemap-Generator writers.
+        // Filename-only. See MOP_READINESS.md (A6).
         uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%03i.mmap") + 1;
         char* fileName = new char[pathLen];
         snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%03i.mmap").c_str(), mapId);

--- a/src/game/vmap/MapTree.cpp
+++ b/src/game/vmap/MapTree.cpp
@@ -150,7 +150,11 @@ namespace VMAP
     {
         std::stringstream tilefilename;
         tilefilename.fill('0');
+#if defined(MISTS)
+        tilefilename << std::setw(4) << mapID << "_";
+#else
         tilefilename << std::setw(3) << mapID << "_";
+#endif
         tilefilename << std::setw(2) << tileY << "_" << std::setw(2) << tileX << ".vmtile";
         return tilefilename.str();
     }

--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -170,11 +170,12 @@ namespace VMAP
             }
 
             // Write map tree file
-            // TODO(MoP): widen to setw(4) here and at the .vmtile name below for
-            // map ids >= 1000. Filename-only; pairs with VMapManager2::getMapFileName
-            // and MapBuilder::discoverTiles. See MOP_READINESS.md (A1).
             std::stringstream mapfilename;
+#if defined(MISTS)
+            mapfilename << iDestDir << "/" << std::setfill('0') << std::setw(4) << map_iter->first << ".vmtree";
+#else
             mapfilename << iDestDir << "/" << std::setfill('0') << std::setw(3) << map_iter->first << ".vmtree";
+#endif
             FILE* mapfile = fopen(mapfilename.str().c_str(), "wb");
             if (!mapfile)
             {
@@ -251,8 +252,11 @@ namespace VMAP
 
                 std::stringstream tilefilename;
                 tilefilename.fill('0');
-                // TODO(MoP): setw(4) for map ids >= 1000 (see A1 above). MOP_READINESS.md
+#if defined(MISTS)
+                tilefilename << iDestDir << "/" << std::setw(4) << map_iter->first << "_";
+#else
                 tilefilename << iDestDir << "/" << std::setw(3) << map_iter->first << "_";
+#endif
                 uint32 x, y;
                 StaticMapTree::unpackTileID(tileID, x, y);
                 tilefilename << std::setw(2) << x << "_" << std::setw(2) << y << ".vmtile";

--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -170,6 +170,9 @@ namespace VMAP
             }
 
             // Write map tree file
+            // TODO(MoP): widen to setw(4) here and at the .vmtile name below for
+            // map ids >= 1000. Filename-only; pairs with VMapManager2::getMapFileName
+            // and MapBuilder::discoverTiles. See MOP_READINESS.md (A1).
             std::stringstream mapfilename;
             mapfilename << iDestDir << "/" << std::setfill('0') << std::setw(3) << map_iter->first << ".vmtree";
             FILE* mapfile = fopen(mapfilename.str().c_str(), "wb");
@@ -248,6 +251,7 @@ namespace VMAP
 
                 std::stringstream tilefilename;
                 tilefilename.fill('0');
+                // TODO(MoP): setw(4) for map ids >= 1000 (see A1 above). MOP_READINESS.md
                 tilefilename << iDestDir << "/" << std::setw(3) << map_iter->first << "_";
                 uint32 x, y;
                 StaticMapTree::unpackTileID(tileID, x, y);

--- a/src/game/vmap/VMapManager2.cpp
+++ b/src/game/vmap/VMapManager2.cpp
@@ -107,9 +107,11 @@ namespace VMAP
     std::string VMapManager2::getMapFileName(unsigned int pMapId)
     {
         std::stringstream fname;
-        // TODO(MoP): width(4) for map ids >= 1000. Pairs with the TileAssembler
-        // vmtree/vmtile writer and MapBuilder::discoverTiles. See MOP_READINESS.md (A2).
+#if defined(MISTS)
+        fname.width(4);
+#else
         fname.width(3);
+#endif
         fname << std::setfill('0') << pMapId << std::string(MAP_FILENAME_EXTENSION2);
         return fname.str();
     }

--- a/src/game/vmap/VMapManager2.cpp
+++ b/src/game/vmap/VMapManager2.cpp
@@ -107,6 +107,8 @@ namespace VMAP
     std::string VMapManager2::getMapFileName(unsigned int pMapId)
     {
         std::stringstream fname;
+        // TODO(MoP): width(4) for map ids >= 1000. Pairs with the TileAssembler
+        // vmtree/vmtile writer and MapBuilder::discoverTiles. See MOP_READINESS.md (A2).
         fname.width(3);
         fname << std::setfill('0') << pMapId << std::string(MAP_FILENAME_EXTENSION2);
         return fname.str();

--- a/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
@@ -43,8 +43,6 @@ namespace MMAP
 
         printf("%sWriting debug output...                       \r", tileString);
 
-        // TODO(MoP): debug .obj/.mesh names use %03u; widen to %04u for map ids
-        // >= 1000 (debug output only, not gameplay). See MOP_READINESS.md (A5).
         string name("meshes/%03u%02i%02i.");
 
         // TODO: What the heck are these trailing \/ about in the following lines
@@ -298,8 +296,6 @@ namespace MMAP
         sprintf(tileString, "[%02u,%02u]: ", tileY, tileX);
         printf("%sWriting debug output...                       \r", tileString);
 
-        // TODO(MoP): debug name uses %03u; widen to %04u for map ids >= 1000
-        // (debug output only). See MOP_READINESS.md (A5).
         sprintf(objFileName, "meshes/%03u.map", mapID);
 
         objFile = fopen(objFileName, "wb");

--- a/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
@@ -43,6 +43,8 @@ namespace MMAP
 
         printf("%sWriting debug output...                       \r", tileString);
 
+        // TODO(MoP): debug .obj/.mesh names use %03u; widen to %04u for map ids
+        // >= 1000 (debug output only, not gameplay). See MOP_READINESS.md (A5).
         string name("meshes/%03u%02i%02i.");
 
         // TODO: What the heck are these trailing \/ about in the following lines
@@ -296,6 +298,8 @@ namespace MMAP
         sprintf(tileString, "[%02u,%02u]: ", tileY, tileX);
         printf("%sWriting debug output...                       \r", tileString);
 
+        // TODO(MoP): debug name uses %03u; widen to %04u for map ids >= 1000
+        // (debug output only). See MOP_READINESS.md (A5).
         sprintf(objFileName, "meshes/%03u.map", mapID);
 
         objFile = fopen(objFileName, "wb");

--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -73,6 +73,11 @@ namespace MMAP
     {
         vector<string> files;
         uint32 mapID, tileX, tileY, tileID, count = 0;
+        // TODO(MoP): vmaps/mmaps here are still 3-digit. For map ids >= 1000:
+        // grow filter to [32]; vmtree parse substr(0,3)->substr(0,4); vmtile filter
+        // %03u->%04u and offsets +1 (substr 4->5, 7->8); and the mmap writers below
+        // (%03u->%04u). The .map parse is ALREADY 4-digit - leave it. Pairs with
+        // TileAssembler + VMapManager2 + MoveMap. See MOP_READINESS.md (A3/A4).
         char filter[12];
 
         printf(" Discovering maps...  ");
@@ -399,6 +404,7 @@ namespace MMAP
         }
 
         char fileName[25];
+        // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
         sprintf(fileName, "mmaps/%03u.mmap", mapID);
 
         FILE* file = fopen(fileName, "wb");
@@ -753,6 +759,7 @@ namespace MMAP
 
             // file output
             char fileName[255];
+            // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
             sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
             FILE* file = fopen(fileName, "wb");
             if (!file)
@@ -938,6 +945,7 @@ namespace MMAP
     bool MapBuilder::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
+        // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
         sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
         FILE* file = fopen(fileName, "rb");
         if (!file)

--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -73,18 +73,13 @@ namespace MMAP
     {
         vector<string> files;
         uint32 mapID, tileX, tileY, tileID, count = 0;
-        // TODO(MoP): vmaps/mmaps here are still 3-digit. For map ids >= 1000:
-        // grow filter to [32]; vmtree parse substr(0,3)->substr(0,4); vmtile filter
-        // %03u->%04u and offsets +1 (substr 4->5, 7->8); and the mmap writers below
-        // (%03u->%04u). The .map parse is ALREADY 4-digit - leave it. Pairs with
-        // TileAssembler + VMapManager2 + MoveMap. See MOP_READINESS.md (A3/A4).
-        char filter[12];
+        char filter[32];
 
         printf(" Discovering maps...  ");
         getDirContents(files, "maps");
         for (uint32 i = 0; i < files.size(); ++i)
         {
-            // .map files use a 4-digit map id (vmaps still use 3)
+            // .map files always use a 4-digit map id
             mapID = uint32(atoi(files[i].substr(0, 4).c_str()));
             if (m_tiles.find(mapID) == m_tiles.end())
             {
@@ -97,7 +92,11 @@ namespace MMAP
         getDirContents(files, "vmaps", "*.vmtree");
         for (uint32 i = 0; i < files.size(); ++i)
         {
+#if defined(MISTS)
+            mapID = uint32(atoi(files[i].substr(0, 4).c_str()));
+#else
             mapID = uint32(atoi(files[i].substr(0, 3).c_str()));
+#endif
             m_tiles.insert(pair<uint32, set<uint32>*>(mapID, new set<uint32>));
             count++;
         }
@@ -110,13 +109,22 @@ namespace MMAP
             set<uint32>* tiles = (*itr).second;
             mapID = (*itr).first;
 
+#if defined(MISTS)
+            sprintf(filter, "%04u*.vmtile", mapID);
+#else
             sprintf(filter, "%03u*.vmtile", mapID);
+#endif
             files.clear();
             getDirContents(files, "vmaps", filter);
             for (uint32 i = 0; i < files.size(); ++i)
             {
+#if defined(MISTS)
+                tileX = uint32(atoi(files[i].substr(8, 2).c_str()));
+                tileY = uint32(atoi(files[i].substr(5, 2).c_str()));
+#else
                 tileX = uint32(atoi(files[i].substr(7, 2).c_str()));
                 tileY = uint32(atoi(files[i].substr(4, 2).c_str()));
+#endif
                 tileID = StaticMapTree::packTileID(tileY, tileX);
 
                 tiles->insert(tileID);
@@ -404,8 +412,11 @@ namespace MMAP
         }
 
         char fileName[25];
-        // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
+#if defined(MISTS)
+        sprintf(fileName, "mmaps/%04u.mmap", mapID);
+#else
         sprintf(fileName, "mmaps/%03u.mmap", mapID);
+#endif
 
         FILE* file = fopen(fileName, "wb");
         if (!file)
@@ -759,8 +770,11 @@ namespace MMAP
 
             // file output
             char fileName[255];
-            // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
+#if defined(MISTS)
+            sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileX, tileY);
+#else
             sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
+#endif
             FILE* file = fopen(fileName, "wb");
             if (!file)
             {
@@ -945,8 +959,11 @@ namespace MMAP
     bool MapBuilder::shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY)
     {
         char fileName[255];
-        // TODO(MoP): %03u->%04u for map ids >= 1000 (pairs with MoveMap reader). MOP_READINESS.md (A4)
+#if defined(MISTS)
+        sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileX, tileY);
+#else
         sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
+#endif
         FILE* file = fopen(fileName, "rb");
         if (!file)
         {

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -1145,6 +1145,10 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
     }
 
     // map hole info
+    // TODO(MoP): only the low-res 16-bit holes_low_res is written here. Client 5.3+
+    // adds 64-bit high_res_holes (MCNK flag 0x10000); emitting it needs a wider .map
+    // holes block + a .map version-magic bump. Pairs with the GridMap reader + adt.h
+    // parse. See MOP_READINESS.md (B2).
     uint16 holes[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
 
     if (map.liquidMapOffset)

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -1147,8 +1147,9 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
     // map hole info
     // TODO(MoP): only the low-res 16-bit holes_low_res is written here. Client 5.3+
     // adds 64-bit high_res_holes (MCNK flag 0x10000); emitting it needs a wider .map
-    // holes block + a .map version-magic bump. Pairs with the GridMap reader + adt.h
-    // parse. See MOP_READINESS.md (B2).
+    // holes block + a .map version-magic bump AND the GridMap reader. ENTANGLED with
+    // the 5.3+ MCNK header rework - the 64-bit holes sit at MCNK +0x14 where M3 reads
+    // the height offset (see adt.h B1); cannot be done holes-only. MOP_READINESS (B2).
     uint16 holes[ADT_CELLS_PER_GRID][ADT_CELLS_PER_GRID];
 
     if (map.liquidMapOffset)

--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -471,7 +471,11 @@ void ParsMapFiles()
     printf("\n");
     for (unsigned int i = 0; i < map_count; ++i)
     {
+#if defined(MISTS)
+        sprintf(id, "%04u", map_ids[i].id);
+#else
         sprintf(id, "%03u", map_ids[i].id);
+#endif
         sprintf(fn, "World\\Maps\\%s\\%s.wdt", map_ids[i].name, map_ids[i].name);
         WDTFile WDT(fn, map_ids[i].name);
         if (WDT.init(id, map_ids[i].id))


### PR DESCRIPTION
## Summary

Prep work for MoP map IDs, **fully guarded behind `#if defined(MISTS)`** — a CATA build is byte-for-byte unchanged (still 3-digit filenames, no re-extract needed). Purely additive; M3 stays Cataclysm.

## Commits

- **4-digit map IDs under MISTS** — map IDs ≥ 1000 (MoP) need a 4-digit filename field; tiles stay 2-digit (the world is a fixed 64×64 ADT grid). A MISTS build emits/reads 4-digit `vmtree`/`vmtile`/`mmap`/`mmtile` names. Covers the `TileAssembler`/`MapBuilder` writers, the `VMapManager2`/`MapTree`/`MoveMap` readers, the `MapBuilder` discovery parse, the vmap-extractor id, and the `.mmap` GM command. `.map` terrain is already 4-digit.
- **`TODO(MoP)` markers** at the MoP-readiness sites.
- **64-bit holes entanglement note** — the 64-bit `high_res_holes` (client 5.3+, MCNK flag `0x10000`) occupy MCNK `+0x14`, the same bytes M3 reads as `offsMCVT`/`offsMCNR`. MoP holes can't be wired in isolation; they need the full 5.3+ MCNK header rework. Documented in the holes markers so future MoP work doesn't trip on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/242)
<!-- Reviewable:end -->
