### PR TITLE
[Movemap] Fix transposed mmtile/vmap tile coordinate order

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -262,7 +262,7 @@ namespace MMAP
         m_terrainBuilder->loadMap(mapID, tileX, tileY, meshData);
 
         // get model data
-        m_terrainBuilder->loadVMap(mapID, tileX, tileY, meshData);
+        m_terrainBuilder->loadVMap(mapID, tileY, tileX, meshData);
 
         // if there is no data, give up now
         if (!meshData.solidVerts.size() && !meshData.liquidVerts.size())
@@ -771,9 +771,9 @@ namespace MMAP
             // file output
             char fileName[255];
 #if defined(MISTS)
-            sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileX, tileY);
+            sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileY, tileX);
 #else
-            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
+            sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
 #endif
             FILE* file = fopen(fileName, "wb");
             if (!file)
@@ -960,9 +960,9 @@ namespace MMAP
     {
         char fileName[255];
 #if defined(MISTS)
-        sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileX, tileY);
+        sprintf(fileName, "mmaps/%04u%02i%02i.mmtile", mapID, tileY, tileX);
 #else
-        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileX, tileY);
+        sprintf(fileName, "mmaps/%03u%02i%02i.mmtile", mapID, tileY, tileX);
 #endif
         FILE* file = fopen(fileName, "rb");
         if (!file)


### PR DESCRIPTION
## Problem

A prior commit (`ea1927454`) swapped the `.mmtile` filename, `shouldSkipTile`, and `loadVMap` to `(tileX, tileY)`. But the runtime opens `.map`, vmaps and `.mmtile` for a grid with the **same** `(x, y)` (`GridMap::LoadMapAndVMap`), so the `.mmtile` name must match the `.map` name — which the generator writes/reads as `(tileY, tileX)` (`TerrainBuilder::loadMap`). The transpose broke every off-diagonal tile (`gx != gy`): unloadable `.mmtile` + vmap collision loaded from the wrong grid.

## Fix

Restore `(tileY, tileX)` for the mmtile filename, `shouldSkipTile`, and `loadVMap`; keep the `MMAP_VERSION` bump.

## Grounding

- wowdev ADT/v18 confirms a single coordinate convention (`tile = floor(32 - axis/533.33)` per axis) — there is no separate "vmap order".
- TrinityCore 4.3.4 and server-two both use `(tileY, tileX)` for `loadVMap`/mmtile while `loadMap` stays `(tileX, tileY)`.
- In-game: off-diagonal tiles (e.g. Stormwind ↔ open-world boundaries) now load collision and navmesh from the correct grid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/243)
<!-- Reviewable:end -->
