### PR TITLE
[Movement] Fix far-teleport client hang from stale fall data

### DIFF
--- a/src/game/Object/Object.cpp
+++ b/src/game/Object/Object.cpp
@@ -523,9 +523,10 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint16 updateFlags) const
         {
             if (hasFallDirection)
             {
-                *data << float(unit->m_movementInfo.GetJumpInfo().cosAngle);
+                // 15595 client reads horizontal speed, then jump direction sin/cos
                 *data << float(unit->m_movementInfo.GetJumpInfo().xyspeed);
                 *data << float(unit->m_movementInfo.GetJumpInfo().sinAngle);
+                *data << float(unit->m_movementInfo.GetJumpInfo().cosAngle);
             }
 
             *data << uint32(unit->m_movementInfo.GetFallTime());

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -1741,6 +1741,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
 
     // reset movement flags at teleport, because player will continue move with these flags after teleport
     m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+    m_movementInfo.ClearFallData();
     DisableSpline();
 
     if ((GetMapId() == mapid) && (!m_transport))            // TODO the !m_transport might have unexpected effects when teleporting from transport to other place on same map

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -835,6 +835,14 @@ class MovementInfo
             t_time = 0;
             t_seat = -1;
         }
+        /// Drop stale fall state so object creates built after a teleport carry no fall block.
+        void ClearFallData()
+        {
+            fallTime = 0;
+            jump = JumpInfo();
+            si.hasFallData = false;
+            si.hasFallDirection = false;
+        }
         ObjectGuid const& GetGuid() const { return guid; }
         ObjectGuid const& GetGuid2() const { return guid2; }
         ObjectGuid const& GetTransportGuid() const { return t_guid; }


### PR DESCRIPTION
Teleporting while airborne (jumping or falling into an instance portal, or a `.tele` mid-jump) left the previous client move packet's fall block in `m_movementInfo`. `Player::TeleportTo` reset the movement flags but not the jump data, so the self-create `SMSG_UPDATE_OBJECT` built after `MSG_MOVE_WORLDPORT_ACK` still carried a fall block — and its direction trio was serialized in the wrong order for 15595. The client then never finished its own spawn: the loading bar fills, the player never appears, and ~35s later it gives up with `CMSG_LOG_DISCONNECT`. Relogging clears the in-memory state, which is why a restart "fixed" it.

Captured packet logs: every failed worldport carried the fall block (2900-byte self-create); every successful one did not (2872/2881 bytes). The trigger is being airborne at teleport time — walking through a portal flat-footed always worked, which is why it looked random.

Fix:
- Reset stale fall/jump state in `TeleportTo` via a new `MovementInfo::ClearFallData()`, next to the existing movement-flag reset (covers near and far teleports).
- Write the fall-direction trio as `xyspeed, sin, cos` — the order the 15595 client reads.

In-game verified: jumping into an instance portal no longer hangs; normal walk-through teleports are unaffected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/246)
<!-- Reviewable:end -->
