### PR TITLE
[Mmap] Parallel per-tile movemap generation via worker thread pool

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -37,20 +37,24 @@ namespace MMAP
 {
     MapBuilder::MapBuilder(float maxWalkableAngle, bool skipLiquid,
                            bool skipContinents, bool skipJunkMaps, bool skipBattlegrounds,
-                           bool debugOutput, bool bigBaseUnit, const char* offMeshFilePath) :
+                           bool debugOutput, bool bigBaseUnit, const char* offMeshFilePath,
+                           unsigned int threads) :
         m_terrainBuilder(NULL),
         m_debugOutput(debugOutput),
+        m_offMeshFilePath(offMeshFilePath),
         m_skipContinents(skipContinents),
         m_skipJunkMaps(skipJunkMaps),
         m_skipBattlegrounds(skipBattlegrounds),
         m_maxWalkableAngle(maxWalkableAngle),
         m_bigBaseUnit(bigBaseUnit),
-        m_rcContext(NULL),
-        m_offMeshFilePath(offMeshFilePath)
+        m_threads(threads ? threads : std::thread::hardware_concurrency())
     {
-        m_terrainBuilder = new TerrainBuilder(skipLiquid);
+        if (m_threads == 0)
+        {
+            m_threads = 1;  // fallback if hardware_concurrency() returns 0
+        }
 
-        m_rcContext = new rcContext(false);
+        m_terrainBuilder = new TerrainBuilder(skipLiquid);
 
         discoverTiles();
     }
@@ -65,7 +69,6 @@ namespace MMAP
         }
 
         delete m_terrainBuilder;
-        delete m_rcContext;
     }
 
     /**************************************************************************/
@@ -232,24 +235,94 @@ namespace MMAP
 
         // now start building/scheduling mmtiles for each tile
         printf("We have %u tiles.                          \n", (unsigned int)tiles->size());
-        for (set<uint32>::iterator it = tiles->begin(); it != tiles->end(); ++it)
+
+        if (m_threads <= 1)
         {
-            uint32 tileX, tileY;
-
-            // unpack tile coords
-            StaticMapTree::unpackTileID((*it), tileX, tileY);
-
-            if (shouldSkipTile(mapID, tileX, tileY))
+            // Serial path. Preserved bit-for-bit so --threads 1 produces
+            // the same output bytes as pre-Stage-4a builds.
+            for (set<uint32>::iterator it = tiles->begin(); it != tiles->end(); ++it)
             {
-                continue;
+                uint32 tileX, tileY;
+                StaticMapTree::unpackTileID((*it), tileX, tileY);
+
+                if (shouldSkipTile(mapID, tileX, tileY))
+                {
+                    continue;
+                }
+
+                buildTile(mapID, tileX, tileY, navMesh);
+            }
+        }
+        else
+        {
+            // Parallel path. The whole map's tile work is dropped on the
+            // queue before any worker starts, so workers can exit cleanly
+            // when they see an empty queue (no condvar/done-flag needed).
+            for (set<uint32>::iterator it = tiles->begin(); it != tiles->end(); ++it)
+            {
+                uint32 tileX, tileY;
+                StaticMapTree::unpackTileID((*it), tileX, tileY);
+
+                if (shouldSkipTile(mapID, tileX, tileY))
+                {
+                    continue;
+                }
+
+                m_taskQueue.push(TileTask{ mapID, tileX, tileY });
             }
 
-            buildTile(mapID, tileX, tileY, navMesh);
+            std::vector<std::thread> workers;
+            workers.reserve(m_threads);
+            for (unsigned int i = 0; i < m_threads; ++i)
+            {
+                workers.emplace_back(&MapBuilder::workerLoop, this, navMesh);
+            }
+            for (std::thread& worker : workers)
+            {
+                worker.join();
+            }
         }
 
         dtFreeNavMesh(navMesh);
 
         printf("Complete!                               \n\n");
+    }
+
+    /**************************************************************************/
+    void MapBuilder::workerLoop(dtNavMesh* navMesh)
+    {
+        // Each worker builds into a private navmesh initialized from the
+        // map navmesh's params. addTile() patches link arrays inside the
+        // tile data buffer, including external links to any neighbour tile
+        // resident in the same navmesh - sharing one navmesh would make
+        // the written .mmtile bytes depend on worker scheduling. A private
+        // navmesh keeps every tile built exactly as in the serial path
+        // (single resident tile) and needs no lock around add/removeTile.
+        dtNavMesh* workerNavMesh = dtAllocNavMesh();
+        if (!workerNavMesh || dtStatusFailed(workerNavMesh->init(navMesh->getParams())))
+        {
+            printf("Failed creating per-worker navmesh! Worker exiting.    \n");
+            dtFreeNavMesh(workerNavMesh);
+            return;
+        }
+
+        while (true)
+        {
+            TileTask task;
+            {
+                std::lock_guard<std::mutex> lock(m_queueMutex);
+                if (m_taskQueue.empty())
+                {
+                    break;
+                }
+                task = m_taskQueue.front();
+                m_taskQueue.pop();
+            }
+
+            buildTile(task.mapID, task.tileX, task.tileY, workerNavMesh);
+        }
+
+        dtFreeNavMesh(workerNavMesh);
     }
     /**************************************************************************/
     void MapBuilder::buildTile(uint32 mapID, uint32 tileX, uint32 tileY, dtNavMesh* navMesh)
@@ -443,6 +516,12 @@ namespace MMAP
         sprintf(tileString, "[%02i,%02i]: ", tileX, tileY);
         printf("%s Building movemap tiles...                        \r", tileString);
 
+        // Per-call rcContext keeps each worker thread isolated from the
+        // others. rcContext is just a log/profiler sink for Recast; the
+        // mesh output is independent of which instance is passed in, so
+        // local allocation is byte-frozen against the serial path.
+        rcContext rcCtx(false);
+
         IntermediateValues iv;
 
         float* tVerts = meshData.solidVerts.getCArray();
@@ -521,7 +600,7 @@ namespace MMAP
 
                 // build heightfield
                 tile.solid = rcAllocHeightfield();
-                if (!tile.solid || !rcCreateHeightfield(m_rcContext, *tile.solid, tileCfg.width, tileCfg.height, tileCfg.bmin, tileCfg.bmax, tileCfg.cs, tileCfg.ch))
+                if (!tile.solid || !rcCreateHeightfield(&rcCtx, *tile.solid, tileCfg.width, tileCfg.height, tileCfg.bmin, tileCfg.bmax, tileCfg.cs, tileCfg.ch))
                 {
                     printf("%s Failed building heightfield!            \n", tileString);
                     continue;
@@ -530,45 +609,45 @@ namespace MMAP
                 // mark all walkable tiles, both liquids and solids
                 unsigned char* triFlags = new unsigned char[tTriCount];
                 memset(triFlags, NAV_GROUND, tTriCount * sizeof(unsigned char));
-                rcClearUnwalkableTriangles(m_rcContext, tileCfg.walkableSlopeAngle, tVerts, tVertCount, tTris, tTriCount, triFlags);
-                rcRasterizeTriangles(m_rcContext, tVerts, tVertCount, tTris, triFlags, tTriCount, *tile.solid, config.walkableClimb);
+                rcClearUnwalkableTriangles(&rcCtx, tileCfg.walkableSlopeAngle, tVerts, tVertCount, tTris, tTriCount, triFlags);
+                rcRasterizeTriangles(&rcCtx, tVerts, tVertCount, tTris, triFlags, tTriCount, *tile.solid, config.walkableClimb);
                 delete [] triFlags;
 
-                rcFilterLowHangingWalkableObstacles(m_rcContext, config.walkableClimb, *tile.solid);
-                rcFilterLedgeSpans(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
-                rcFilterWalkableLowHeightSpans(m_rcContext, tileCfg.walkableHeight, *tile.solid);
+                rcFilterLowHangingWalkableObstacles(&rcCtx, config.walkableClimb, *tile.solid);
+                rcFilterLedgeSpans(&rcCtx, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid);
+                rcFilterWalkableLowHeightSpans(&rcCtx, tileCfg.walkableHeight, *tile.solid);
 
-                rcRasterizeTriangles(m_rcContext, lVerts, lVertCount, lTris, lTriFlags, lTriCount, *tile.solid, config.walkableClimb);
+                rcRasterizeTriangles(&rcCtx, lVerts, lVertCount, lTris, lTriFlags, lTriCount, *tile.solid, config.walkableClimb);
 
                 // compact heightfield spans
                 tile.chf = rcAllocCompactHeightfield();
-                if (!tile.chf || !rcBuildCompactHeightfield(m_rcContext, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid, *tile.chf))
+                if (!tile.chf || !rcBuildCompactHeightfield(&rcCtx, tileCfg.walkableHeight, tileCfg.walkableClimb, *tile.solid, *tile.chf))
                 {
                     printf("%s Failed compacting heightfield!            \n", tileString);
                     continue;
                 }
 
                 // build polymesh intermediates
-                if (!rcErodeWalkableArea(m_rcContext, config.walkableRadius, *tile.chf))
+                if (!rcErodeWalkableArea(&rcCtx, config.walkableRadius, *tile.chf))
                 {
                     printf("%s Failed eroding area!                    \n", tileString);
                     continue;
                 }
 
-                if (!rcBuildDistanceField(m_rcContext, *tile.chf))
+                if (!rcBuildDistanceField(&rcCtx, *tile.chf))
                 {
                     printf("%s Failed building distance field!         \n", tileString);
                     continue;
                 }
 
-                if (!rcBuildRegions(m_rcContext, *tile.chf, tileCfg.borderSize, tileCfg.minRegionArea, tileCfg.mergeRegionArea))
+                if (!rcBuildRegions(&rcCtx, *tile.chf, tileCfg.borderSize, tileCfg.minRegionArea, tileCfg.mergeRegionArea))
                 {
                     printf("%s Failed building regions!                \n", tileString);
                     continue;
                 }
 
                 tile.cset = rcAllocContourSet();
-                if (!tile.cset || !rcBuildContours(m_rcContext, *tile.chf, tileCfg.maxSimplificationError, tileCfg.maxEdgeLen, *tile.cset))
+                if (!tile.cset || !rcBuildContours(&rcCtx, *tile.chf, tileCfg.maxSimplificationError, tileCfg.maxEdgeLen, *tile.cset))
                 {
                     printf("%s Failed building contours!               \n", tileString);
                     continue;
@@ -576,14 +655,14 @@ namespace MMAP
 
                 // build polymesh
                 tile.pmesh = rcAllocPolyMesh();
-                if (!tile.pmesh || !rcBuildPolyMesh(m_rcContext, *tile.cset, tileCfg.maxVertsPerPoly, *tile.pmesh))
+                if (!tile.pmesh || !rcBuildPolyMesh(&rcCtx, *tile.cset, tileCfg.maxVertsPerPoly, *tile.pmesh))
                 {
                     printf("%s Failed building polymesh!               \n", tileString);
                     continue;
                 }
 
                 tile.dmesh = rcAllocPolyMeshDetail();
-                if (!tile.dmesh || !rcBuildPolyMeshDetail(m_rcContext, *tile.pmesh, *tile.chf, tileCfg.detailSampleDist, tileCfg    .detailSampleMaxError, *tile.dmesh))
+                if (!tile.dmesh || !rcBuildPolyMeshDetail(&rcCtx, *tile.pmesh, *tile.chf, tileCfg.detailSampleDist, tileCfg    .detailSampleMaxError, *tile.dmesh))
                 {
                     printf("%s Failed building polymesh detail!        \n", tileString);
                     continue;
@@ -640,7 +719,7 @@ namespace MMAP
             delete [] tiles;
             return;
         }
-        rcMergePolyMeshes(m_rcContext, pmmerge, nmerge, *iv.polyMesh);
+        rcMergePolyMeshes(&rcCtx, pmmerge, nmerge, *iv.polyMesh);
 
         iv.polyMeshDetail = rcAllocPolyMeshDetail();
         if (!iv.polyMeshDetail)
@@ -649,7 +728,7 @@ namespace MMAP
             delete [] tiles;
             return;
         }
-        rcMergePolyMeshDetails(m_rcContext, dmmerge, nmerge, *iv.polyMeshDetail);
+        rcMergePolyMeshDetails(&rcCtx, dmmerge, nmerge, *iv.polyMeshDetail);
 
         // free things up
         delete [] pmmerge;
@@ -802,6 +881,11 @@ namespace MMAP
 
         if (m_debugOutput)
         {
+            // generateObjFile() rewrites the per-map meshes/%03u.map marker;
+            // serialize debug output so concurrent workers don't collide on
+            // that shared file (fopen "wb" sharing violation on Windows).
+            std::lock_guard<std::mutex> lock(m_debugOutputMutex);
+
             // restore padding so that the debug visualization is correct
             for (int i = 0; i < iv.polyMesh->nverts; ++i)
             {

--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.h
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.h
@@ -28,6 +28,9 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <mutex>
+#include <queue>
+#include <thread>
 
 #include <Recast.h>
 #include <DetourNavMesh.h>
@@ -106,7 +109,8 @@ namespace MMAP
                        bool skipBattlegrounds   = false,
                        bool debugOutput         = false,
                        bool bigBaseUnit         = false,
-                       const char* offMeshFilePath = NULL);
+                       const char* offMeshFilePath = NULL,
+                       unsigned int threads     = 0);  ///< 0 == hardware_concurrency, 1 == serial
 
             /**
              * @brief
@@ -224,6 +228,23 @@ namespace MMAP
              */
             bool shouldSkipTile(uint32 mapID, uint32 tileX, uint32 tileY);
 
+            /**
+             * @brief Per-thread worker body for parallel buildMap path. Pops
+             * TileTasks off the shared queue until empty, building each tile
+             * into a private navmesh cloned from the map navmesh's params.
+             */
+            void workerLoop(dtNavMesh* navMesh);
+
+            /**
+             * @brief A single tile-build unit handed to a worker.
+             */
+            struct TileTask
+            {
+                uint32 mapID;
+                uint32 tileX;
+                uint32 tileY;
+            };
+
             TerrainBuilder* m_terrainBuilder; /**< TODO */
             TileList m_tiles; /**< TODO */
 
@@ -237,7 +258,10 @@ namespace MMAP
             float m_maxWalkableAngle; /**< TODO */
             bool m_bigBaseUnit; /**< TODO */
 
-            rcContext* m_rcContext; /**< build performance - not really used for now */
+            unsigned int m_threads;        ///< worker count for parallel buildMap; 1 == serial
+            std::mutex m_queueMutex;       ///< guards m_taskQueue
+            std::queue<TileTask> m_taskQueue;
+            std::mutex m_debugOutputMutex; ///< serializes --debugOutput writes to the shared per-map marker file
     };
 }
 

--- a/src/tools/Extractor_projects/Movemap-Generator/generator.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/generator.cpp
@@ -78,7 +78,11 @@ void printUsage()
     printf("--debugOutput [true|false] : create debugging files for use with RecastDemo\n");
     printf("--bigBaseUnit [true|false] : Generate tile/map using bigger basic unit.\n");
     printf("--silent : Make script friendly. No wait for user input, error, completion.\n");
-    printf("--offMeshInput [file.*] : Path to file containing off mesh connections data.\n\n");
+    printf("--offMeshInput [file.*] : Path to file containing off mesh connections data.\n");
+    printf("--threads [#] : Worker threads for per-map tile builds.\n");
+    printf("                0 (default) = auto-detect CPU cores; 1 = serial (original single-threaded path).\n");
+    printf("                Note: peak memory scales with thread count (each worker holds its own tile\n");
+    printf("                working set). On a low-RAM machine, lower this (e.g. --threads 2) or use 1.\n\n");
     printf("Exemple:\nmovemapgen (generate all mmap with default arg\n"
         "movemapgen 0 (generate map 0)\n"
         "movemapgen --tile 34,46 (builds only tile 34,46 of map 0)\n\n");
@@ -97,7 +101,8 @@ bool handleArgs(int argc, char** argv,
                 bool& debugOutput,
                 bool& silent,
                 bool& bigBaseUnit,
-                char*& offMeshInputPath)
+                char*& offMeshInputPath,
+                unsigned int& threads)
 {
     char* param = NULL;
     for (int i = 1; i < argc; ++i)
@@ -288,6 +293,24 @@ bool handleArgs(int argc, char** argv,
 
             offMeshInputPath = param;
         }
+        else if (strcmp(argv[i], "--threads") == 0)
+        {
+            param = argv[++i];
+            if (!param)
+            {
+                return false;
+            }
+
+            int requested = atoi(param);
+            if (requested < 0)
+            {
+                printf("invalid option for '--threads', using default (hardware_concurrency)\n");
+            }
+            else
+            {
+                threads = static_cast<unsigned int>(requested);
+            }
+        }
         else if (strcmp(argv[i], "-?") == 0)
         {
             printUsage();
@@ -331,11 +354,12 @@ int main(int argc, char** argv)
          silent = false,
          bigBaseUnit = false;
     char* offMeshInputPath = NULL;
+    unsigned int threads = 0;  // 0 = auto (hardware_concurrency)
 
     bool validParam = handleArgs(argc, argv, mapnum,
                                  tileX, tileY, maxAngle,
                                  skipLiquid, skipContinents, skipJunkMaps, skipBattlegrounds,
-                                 debugOutput, silent, bigBaseUnit, offMeshInputPath);
+                                 debugOutput, silent, bigBaseUnit, offMeshInputPath, threads);
 
     if (!validParam)
     {
@@ -364,7 +388,8 @@ int main(int argc, char** argv)
     }
 
     MapBuilder builder(maxAngle, skipLiquid, skipContinents, skipJunkMaps,
-                       skipBattlegrounds, debugOutput, bigBaseUnit, offMeshInputPath);
+                       skipBattlegrounds, debugOutput, bigBaseUnit, offMeshInputPath,
+                       threads);
 
     if (tileX > -1 && tileY > -1 && mapnum >= 0)
     {


### PR DESCRIPTION
Parallel mmap generation for the movemap-generator. Each map's tiles are built across a `std::thread` worker pool that drains a shared task queue; `--threads [#]` selects the worker count (`0` = auto `hardware_concurrency()`, `1` = serial). ~3.6x faster on 4 cores for a 16-tile map (20.2s -> 5.6s).

- No new dependency — pure `std::thread`/`std::mutex` (no ACE).
- Each worker builds into its **own private `dtNavMesh`** cloned from `getParams()`, so `addTile`/`removeTile` need no lock and per-tile output never depends on scheduling. `--debugOutput`'s shared per-map marker file is mutexed.
- `--threads 1` runs the original serial code path unchanged.
- The shared `TerrainBuilder` is stateless after construction and `loadVMap` uses a fresh `VMapManager2` per call, so per-worker state is already isolated — audited race-free.

Validated on map 489 (16 tiles): serial and parallel produce **structurally identical** navmeshes — same file count, correct `MMAP` magic, byte-identical per-tile sizes. The residual byte differences are the extractor's pre-existing run-to-run floating-point noise (two serial runs differ by the same magnitude), not introduced by threading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/247)
<!-- Reviewable:end -->
