### PR TITLE
[Movement] Fix truncated point paths and clip-through on partial paths

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -541,8 +541,20 @@ void PathFinder::BuildPointPath(const float* startPoint, const float* endPoint)
         m_pathPoints[i] = Vector3(pathPoints[i * VERTEX_SIZE + 2], pathPoints[i * VERTEX_SIZE], pathPoints[i * VERTEX_SIZE + 1]);
     }
 
+    // clamp each point to the real surface: navmesh detail heights drift
+    // from terrain/vmap geometry on rough slopes, sinking units into hills
+    NormalizePath();
+
     // first point is always our current location - we need the next one
     setActualEndPosition(m_pathPoints[pointCount - 1]);
+
+    // the point path can stop short of the requested end (iteration cap or
+    // steering failure) even when the poly corridor reached the end poly -
+    // never report such a truncated path as complete
+    if ((m_type & PATHFIND_NORMAL) && !inRange(getActualEndPosition(), getEndPosition(), 3.0f, 7.5f))
+    {
+        m_type = PATHFIND_INCOMPLETE;
+    }
 
     // force the given destination, if needed
     if (m_forceDestination &&
@@ -875,16 +887,29 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
     uint32 npolys = polyPathSize;
 
     float iterPos[VERTEX_SIZE], targetPos[VERTEX_SIZE];
-    dtStatus dtResult = m_navMeshQuery->closestPointOnPolyBoundary(polys[0], startPos, iterPos);
-    if (dtStatusFailed(dtResult))
-    {
-        return DT_FAILURE;
-    }
+    dtStatus dtResult = DT_FAILURE;
 
-    dtResult = m_navMeshQuery->closestPointOnPolyBoundary(polys[npolys - 1], endPos, targetPos);
-    if (dtStatusFailed(dtResult))
+    if (polyPathSize > 1)
     {
-        return DT_FAILURE;
+        // pick the closest points on poly border
+        dtResult = m_navMeshQuery->closestPointOnPolyBoundary(polys[0], startPos, iterPos);
+        if (dtStatusFailed(dtResult))
+        {
+            return DT_FAILURE;
+        }
+
+        dtResult = m_navMeshQuery->closestPointOnPolyBoundary(polys[npolys - 1], endPos, targetPos);
+        if (dtStatusFailed(dtResult))
+        {
+            return DT_FAILURE;
+        }
+    }
+    else
+    {
+        // start and end are on the same poly: keep the exact positions,
+        // a boundary clamp would snap both onto the polygon edge
+        dtVcopy(iterPos, startPos);
+        dtVcopy(targetPos, endPos);
     }
 
     dtVcopy(&smoothPath[nsmoothPath * VERTEX_SIZE], iterPos);
@@ -930,7 +955,13 @@ dtStatus PathFinder::findSmoothPath(const float* startPos, const float* endPos,
         dtPolyRef visited[MAX_VISIT_POLY];
 
         uint32 nvisited = 0;
-        m_navMeshQuery->moveAlongSurface(polys[0], iterPos, moveTgt, &m_filter, result, visited, (int*)&nvisited, MAX_VISIT_POLY);
+        dtResult = m_navMeshQuery->moveAlongSurface(polys[0], iterPos, moveTgt, &m_filter, result, visited, (int*)&nvisited, MAX_VISIT_POLY);
+        if (dtStatusFailed(dtResult))
+        {
+            // iterPos would desync from the corridor; abort instead of
+            // emitting garbage points
+            return DT_FAILURE;
+        }
         npolys = fixupCorridor(polys, npolys, MAX_PATH_LENGTH, visited, nvisited);
 
         m_navMeshQuery->getPolyHeight(polys[0], result, &result[1]);
@@ -1048,24 +1079,13 @@ float PathFinder::dist3DSqr(const Vector3& p1, const Vector3& p2) const
     return (p1 - p2).squaredLength();
 }
 
-void PathFinder::NormalizePath(uint32& size)
+/**
+ * @brief Clamps every path point to the allowed height at its location.
+ */
+void PathFinder::NormalizePath()
 {
     for (uint32 i = 0; i < m_pathPoints.size(); ++i)
     {
         m_sourceUnit->UpdateAllowedPositionZ(m_pathPoints[i].x, m_pathPoints[i].y, m_pathPoints[i].z);
     }
-
-    // check if the Z difference between each point is higher than SMOOTH_PATH_HEIGHT.
-    // add another point if that's the case and keep adding new midpoints till the Z difference is low enough
-    for (uint32 i = 1; i < m_pathPoints.size(); ++i)
-    {
-        if ((m_pathPoints[i - 1].z - m_pathPoints[i].z) > SMOOTH_PATH_HEIGHT)
-        {
-            auto midPoint = m_pathPoints[i - 1] + (m_pathPoints[i] - m_pathPoints[i - 1]) / 2.f;
-            m_sourceUnit->UpdateAllowedPositionZ(midPoint.x, midPoint.y, midPoint.z);
-            m_pathPoints.insert(m_pathPoints.begin() + i, midPoint);
-            --i;
-        }
-    }
-    size = m_pathPoints.size();
 }

--- a/src/game/MotionGenerators/PathFinder.h
+++ b/src/game/MotionGenerators/PathFinder.h
@@ -44,7 +44,6 @@ class Unit;
 
 #define SMOOTH_PATH_STEP_SIZE   4.0f
 #define SMOOTH_PATH_SLOP        0.3f
-#define SMOOTH_PATH_HEIGHT      1.0f
 
 #define VERTEX_SIZE       3
 #define INVALID_POLYREF   0
@@ -120,7 +119,6 @@ class PathFinder
          * @return The actual end position of the path.
          */
         Vector3 getActualEndPosition() const { return m_actualEndPosition; }
-        void NormalizePath(uint32& size);
 
         /**
          * @brief Get the path points.
@@ -254,6 +252,11 @@ class PathFinder
          * @brief Build a shortcut path.
          */
         void BuildShortcut();
+
+        /**
+         * @brief Clamp every path point to the allowed height at its location.
+         */
+        void NormalizePath();
 
         /**
          * @brief Build a straight 3D swim path through open water.

--- a/src/game/MotionGenerators/TargetedMovementGenerator.cpp
+++ b/src/game/MotionGenerators/TargetedMovementGenerator.cpp
@@ -109,6 +109,13 @@ void TargetedMovementGeneratorMedium<T, D>::_setTargetLocation(T& owner, bool up
     i_path->calculate(x, y, z, forceDest);
     if (i_path->getPathType() & PATHFIND_NOPATH)
     {
+        // no usable path: halt instead of running on along the stale spline,
+        // which may cut through terrain the new query just rejected
+        D::_clearUnitStateMove(owner);
+        if (!owner.IsStopped())
+        {
+            owner.StopMoving();
+        }
         return;
     }
 


### PR DESCRIPTION
Fixes NPC pathfinding bugs in 4.3.4 — paths that stop short / won't curve around obstacles, and creatures clipping through terrain on partial paths. In-game verified on Kalimdor (chase, follow, `.mmap path` on open ground and around hills).

- **Stop reporting truncated paths as `PATHFIND_NORMAL`.** `findSmoothPath` silently breaks out (steer-target failure or point-cap) and returned success for any short path, so every consumer believed it arrived mid-route. `BuildPointPath` now flags `PATHFIND_INCOMPLETE` when the produced path ends far from the requested end, so chase keeps re-pathing instead of declaring arrival.
- **Clamp generated point-path Z to the surface** (`NormalizePath`) — points were left at navmesh detail height +0.5, so splines crossing a hill ran *inside* the geometry.
- **Stop on `NOPATH` instead of running the stale spline.** `TargetedMovementGenerator` bare-returned on NOPATH and kept executing the previous (already-rejected) spline → tunneling. Now clears move state and stops.
- **`moveAlongSurface` failure → `DT_FAILURE`** instead of emitting a truncated path.
- **Keep exact start/end for single-poly paths** instead of snapping to the polygon boundary (fixes short-range melee micro-teleports).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/249)
<!-- Reviewable:end -->
