### PR TITLE
[Mmap] Fix navmesh tile corruption from double border removal

### DIFF
--- a/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/MapBuilder.cpp
@@ -556,12 +556,14 @@ namespace MMAP
         config.borderSize = config.walkableRadius + 3;
         config.maxEdgeLen = VERTEX_PER_TILE + 1;        //anything bigger than tileSize
         config.walkableHeight = m_bigBaseUnit ? 3 : 6;
-        config.walkableClimb = m_bigBaseUnit ? 2 : 4;   // keep less than walkableHeight
+        // a value >= 3|6 allows npcs to walk over some fences
+        // a value >= 4|8 allows npcs to walk over all fences
+        config.walkableClimb = m_bigBaseUnit ? 3 : 6;   // keep less than walkableHeight
         config.minRegionArea = rcSqr(60);
         config.mergeRegionArea = rcSqr(50);
-        config.maxSimplificationError = 2.0f;       // eliminates most jagged edges (tinny polygons)
-        config.detailSampleDist = config.cs * 64;
-        config.detailSampleMaxError = config.ch * 2;
+        config.maxSimplificationError = 1.8f;       // eliminates most jagged edges (tiny polygons)
+        config.detailSampleDist = config.cs * 16;
+        config.detailSampleMaxError = config.ch * 1;
 
         // this sets the dimensions of the heightfield - should maybe happen before border padding
         rcCalcGridSize(config.bmin, config.bmax, config.cs, &config.width, &config.height);
@@ -627,6 +629,12 @@ namespace MMAP
                 if (!rcErodeWalkableArea(&rcCtx, config.walkableRadius, *tile.chf))
                 {
                     printf("%s Failed eroding area!                    \n", tileString);
+                    continue;
+                }
+
+                if (!rcMedianFilterWalkableArea(&rcCtx, *tile.chf))
+                {
+                    printf("%s Failed filtering area!                  \n", tileString);
                     continue;
                 }
 
@@ -732,15 +740,12 @@ namespace MMAP
 
         delete [] tiles;
 
-#if defined (CATA)
-        // remove padding for extraction
-        for (int i = 0; i < iv.polyMesh->nverts; ++i)
-        {
-            unsigned short* v = &iv.polyMesh->verts[i * 3];
-            v[0] -= (unsigned short)config.borderSize;
-            v[2] -= (unsigned short)config.borderSize;
-        }
-#endif
+        // NOTE: do NOT subtract config.borderSize from the merged vertices here.
+        // rcBuildContours already removes the border offset (chf.borderSize > 0),
+        // so an extra subtraction shifts every polygon by borderSize cells and
+        // wraps tile-edge vertices below zero (unsigned short underflow), which
+        // breaks cross-tile stitching in Detour.
+
         // set polygons as walkable
         // TODO: special flags for DYNAMIC polygons, ie surfaces that can be turned on and off
         for (int i = 0; i < iv.polyMesh->npolys; ++i)


### PR DESCRIPTION
Fixes navmesh tile corruption in Cata builds from **double border removal**. `MapBuilder` manually subtracted `config.borderSize` from every merged polymesh vertex, but the bundled Recast already removes the border offset in `rcBuildContours` — so it was subtracted twice. Edge-tile vertices underflowed `uint16` and landed ~17,000 yd outside the tile; every poly shifted ~1.3 yd. Result: Detour cannot stitch neighbouring tiles (**paths truncate / won't curve**) and polys misalign with terrain (**NPCs path through hills**).

The manual loop was correct for the 2012 Recast import (no `borderSize` handling); the 2021 Recast update made it a double removal. `ea1927454` guarded it with `#if defined(CATA)` — fixing the WotLK fork but leaving it active for mangosthree.

Fix: drop the manual border subtraction (Recast already handles it). Plus quality tuning in the same build path: `detailSampleDist` 64→16 cells (17 yd sampling flattened hillsides into ramps), tighter detail error, `walkableClimb` 4→6, `maxSimplificationError` 2.0→1.8, and a median-filter despeckle pass.

Verified: rebuilt tiles have **zero out-of-bounds verts**, edge verts land exactly on shared tile boundaries, poly counts +5–14%. In-game confirmed on Kalimdor (NPCs path around hills and reach elevated-but-reachable targets; `.mmap path` curves to the destination). Requires re-extraction of mmaps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/250)
<!-- Reviewable:end -->
