### PR TITLE
[Movement] Clamp unreachable navmesh paths to last reachable poly

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -476,6 +476,25 @@ void PathFinder::BuildPolyPath(const Vector3& startPos, const Vector3& endPos)
     else
     {
         m_type = PATHFIND_INCOMPLETE;
+
+        // The poly corridor stopped short of the target's polygon: the target
+        // sits on a navmesh island we cannot reach (e.g. a cliff-top plateau
+        // walled off from us by a steeper-than-walkable face). Clamp the path
+        // end to the closest point on the last reachable poly so the straight
+        // path stops at that reachable edge. Otherwise findStraightPath()
+        // appends the raw unreachable target and the spline drives the unit
+        // straight up through the terrain to reach it. Pets keep reaching an
+        // off-mesh master because BuildPointPath() re-forces getEndPosition()
+        // when m_forceDestination is set.
+        if (m_pathPolyRefs[m_polyLength - 1] != endPoly)
+        {
+            float closestPoint[VERTEX_SIZE];
+            if (dtStatusSucceed(m_navMeshQuery->closestPointOnPoly(m_pathPolyRefs[m_polyLength - 1], endPoint, closestPoint, NULL)))
+            {
+                dtVcopy(endPoint, closestPoint);
+                setActualEndPosition(Vector3(endPoint[2], endPoint[0], endPoint[1]));
+            }
+        }
     }
 
     // generate the point-path out of our up-to-date poly-path


### PR DESCRIPTION
### Problem
A following/chasing ground creature whose target stands on a spot the navmesh can't reach — e.g. a cliff-top plateau that is its own navmesh island, walled off by a steeper-than-walkable face — would drive its movement spline **straight up through the terrain** to reach the target.

### Cause
When the poly corridor stops short of the target's polygon, `BuildPolyPath()` correctly marks the path `PATHFIND_INCOMPLETE`, but still passes the **raw, unreachable target** to `findStraightPath()`, which appends it as the final path corner. The spline then interpolates the unit up the cliff to that point.

### Fix
When the corridor's last polygon isn't the target polygon, clamp the path end to the closest point on the **last reachable** polygon. The creature now stops at the reachable edge (the base of the cliff) instead of clipping up through it.

Pets are unaffected — `BuildPointPath()` still re-forces `getEndPosition()` for an off-mesh master when `m_forceDestination` is set.

Verified in-game: a creature `.npc follow`-ing a GM standing atop a Durotar cliff now idles at the base instead of clipping up the face. `+19 / -0`, `PathFinder.cpp` only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/255)
<!-- Reviewable:end -->
