### PR TITLE
[Decomp][Achievement] Fix gcc/clang build: include ObjectMgr.h in AchievementCriteriaRequirement.cpp

### DIFF
--- a/src/game/WorldHandlers/AchievementCriteriaRequirement.cpp
+++ b/src/game/WorldHandlers/AchievementCriteriaRequirement.cpp
@@ -34,6 +34,7 @@
 #include "AchievementMgr.h"
 #include "Log.h"
 #include "DBCStores.h"
+#include "ObjectMgr.h"
 #include "Player.h"
 #include "SpellMgr.h"
 #include "GameEventMgr.h"


### PR DESCRIPTION
﻿Hotfix for master — #259 was merged before its CI completed, and the gcc/clang builds were failing.

`AchievementCriteriaRequirement::IsValid` calls `ObjectMgr::GetCreatureTemplate(...)`, a static-scope call that needs the **complete** `ObjectMgr` type. The TU did not include `ObjectMgr.h`; MSVC resolved it transitively via the PCH, but gcc/clang error:

```
AchievementCriteriaRequirement.cpp:81: error: incomplete type 'ObjectMgr' used in nested name specifier
```

One-line fix: include `ObjectMgr.h` explicitly. Local build clean; this restores the gcc/clang builds on master.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/260)
<!-- Reviewable:end -->
