### PR TITLE
[Extractors] Add map conversion diagnostics to map-extractor

### DIFF
--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -600,8 +600,9 @@ bool ConvertADT(char* filename, char* filename2, uint32 build)
 {
     ADT_file adt;
 
-    if (!adt.loadFile(filename, false))
+    if (!adt.loadFile(filename, true))
     {
+        printf("Error: Failed to load ADT file: %s\n", filename);
         return false;
     }
 
@@ -1258,7 +1259,17 @@ void ExtractMapsFromMpq(uint32 build, const int locale)
 
     std::string path = output_path;
     path += "/maps/";
-    CreateDir(path);
+    if (!CreateDir(path))
+    {
+        printf("Warning: Output directory '%s' already exists or could not be created\n", path.c_str());
+    }
+    else
+    {
+        printf("Created output directory: %s\n", path.c_str());
+    }
+
+    uint32 success_count = 0;
+    uint32 failed_count = 0;
 
     printf("\n Converting map files\n");
     for (uint32 z = 0; z < map_count; ++z)
@@ -1269,25 +1280,70 @@ void ExtractMapsFromMpq(uint32 build, const int locale)
         WDT_file wdt;
         if (!wdt.loadFile(mpq_map_name, false))
         {
+            printf("Warning: Failed to load WDT file for map: %s\n", map_ids[z].name);
+            ++failed_count;
             continue;
         }
+
+        if (!wdt.main)
+        {
+            printf("Error: WDT main chunk is NULL for map: %s\n", map_ids[z].name);
+            ++failed_count;
+            continue;
+        }
+
+        uint32 adt_count = 0;
+        uint32 adt_exist_in_wdt = 0;
+        for (uint32 y = 0; y < WDT_MAP_SIZE; ++y)
+        {
+            for (uint32 x = 0; x < WDT_MAP_SIZE; ++x)
+            {
+                // Check bit 0 only: some WDT versions use the full uint32
+                if (wdt.main->adt_list[y][x].exist & 0x1)
+                {
+                    ++adt_exist_in_wdt;
+                }
+            }
+        }
+        printf("  WDT indicates %u ADT files exist for this map\n", adt_exist_in_wdt);
 
         for (uint32 y = 0; y < WDT_MAP_SIZE; ++y)
         {
             for (uint32 x = 0; x < WDT_MAP_SIZE; ++x)
             {
-                if (!wdt.main->adt_list[y][x].exist)
+                // Check bit 0 only: this is the ADT existence flag
+                if (!(wdt.main->adt_list[y][x].exist & 0x1))
                 {
                     continue;
                 }
+                ++adt_count;
                 sprintf(mpq_filename, "World\\Maps\\%s\\%s_%u_%u.adt", map_ids[z].name, map_ids[z].name, x, y);
                 sprintf(output_filename, "%s/maps/%04u%02u%02u.map", output_path, map_ids[z].id, y, x);
-                ConvertADT(mpq_filename, output_filename, build);
+                if (ConvertADT(mpq_filename, output_filename, build))
+                {
+                    ++success_count;
+                }
+                else
+                {
+                    ++failed_count;
+                }
             }
             // draw progress bar
             printf(" Processing........................%d%%\r", (100 * (y + 1)) / WDT_MAP_SIZE);
         }
+
+        if (adt_count > 0)
+        {
+            printf("\n  Found %u ADT files for map %s\n", adt_count, map_ids[z].name);
+        }
+        else
+        {
+            printf("\n  WARNING: No ADT files found for map %s (map ID: %u)\n", map_ids[z].name, map_ids[z].id);
+        }
     }
+    printf("\n\nMap extraction complete!\n");
+    printf("Successfully converted: %u tiles\n", success_count);
+    printf("Failed to convert: %u tiles\n", failed_count);
     delete [] areas;
     delete [] map_ids;
 }


### PR DESCRIPTION
Carries the map-extraction diagnostics from MangosFour's extractor fix into the map-extractor.

**Adds (all `printf`, matching the tool's existing console output):**
- Per-map WDT load-failure and `WDT main == NULL` reporting.
- A count of the ADT tiles the WDT advertises, plus per-map `Found N` / `No ADT files found` warnings.
- Success/failure tile counters and a final summary.
- An explicit message when an individual ADT fails to load.

**One behavioral line:** the per-tile existence check now tests bit 0 of the WDT flags field (`& 0x1`) instead of the whole `uint32`. That is the documented "has-ADT" flag; for 4.3.4 data it is equivalent (upper bits are unused pre-Legion), so extraction output is unchanged — it only hardens the check.

No format magics, opcodes, or DB touched. Builds clean on MSVC — `map-extractor.exe` links; only pre-existing StormLib/loadlib warnings remain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/282)
<!-- Reviewable:end -->
