### PR TITLE
[LFG] Fix static-analysis findings in proposal/queue flow

### DIFF
--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -305,6 +305,7 @@ bool LFGMgr::IsProposalSameGroup(LFGProposal const& proposal)
             if (firstLoop)
             {
                 priorGroupGuid = grpGuid;
+                firstLoop = false;
             }
             else
             {
@@ -417,8 +418,6 @@ void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted
         proposalPlrStatus.updateType = LFG_UPDATE_LEAVE;
         SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, false);
         SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, true);
-
-        proposalPlrStatus.state = LFG_STATE_IN_DUNGEON;
     }
 
     CreateDungeonGroup(proposal);
@@ -687,9 +686,14 @@ void LFGMgr::TeleportPlayer(Player* pPlayer, bool out)
 {
     // Fetch necessary data first
     Group* pGroup = pPlayer->GetGroup();
-    LFGGroupStatus* status = GetGroupStatus(pGroup->GetObjectGuid());
+    if (!pGroup)
+    {
+        pPlayer->GetSession()->SendLfgTeleportError((uint8)LFG_TELEPORTERROR_INVALID_LOCATION);
+        return;
+    }
 
-    if (!pGroup || !status)
+    LFGGroupStatus* status = GetGroupStatus(pGroup->GetObjectGuid());
+    if (!status)
     {
         pPlayer->GetSession()->SendLfgTeleportError((uint8)LFG_TELEPORTERROR_INVALID_LOCATION);
         return;
@@ -858,11 +862,14 @@ void LFGMgr::UpdateWaitMap(LFGRoles role, uint32 dungeonID, time_t waitTime)
 void LFGMgr::HandleBossKilled(Player* pPlayer)
 {
     Group* pGroup = pPlayer->GetGroup();
+    if (!pGroup)
+    {
+        return;
+    }
 
     ObjectGuid groupGuid = pGroup->GetObjectGuid();
     LFGGroupStatus* status = GetGroupStatus(groupGuid);
-
-    if (!pGroup || !status)
+    if (!status)
     {
         return;
     }

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -80,12 +80,13 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
 
     // used for upcoming checks
     bool isRandom  = false;
-    bool isRaid    = false;
-    bool isDungeon = false;
 
     LfgJoinResult result = GetJoinResult(plr);
     if (result == ERR_LFG_OK)
     {
+        bool isRaid    = false;
+        bool isDungeon = false;
+
         // additional checks on dungeon selection
         for (std::set<uint32>::iterator it = dungeons.begin(); it != dungeons.end(); ++it)
         {


### PR DESCRIPTION
Fixes pre-existing static-analysis findings in the LFG proposal/queue flow (paired with the same fix on mangostwo).

- **TeleportPlayer / HandleBossKilled** — `pGroup` was dereferenced (`GetObjectGuid()`) before the `!pGroup` null check. Reordered so the null check guards the dereference: behaviour-preserving on the non-null path, avoids a crash when the player has no group.
- **ProposalUpdate** — removed a dead store (`proposalPlrStatus.state` was reassigned but never read before the local is rebuilt next iteration).
- **JoinLFG** — narrowed `isRaid`/`isDungeon` to the `ERR_LFG_OK` block (`isRandom` stays at function scope, used later).
- **IsProposalSameGroup** — `firstLoop` was never reset, so the function always returned `true` and *every* proposal was treated as a premade group. Reset the flag after the first grouped member. **Behaviour correction** (not a pure cleanup): changes premade-group detection for proposals spanning more than one existing party.

Built green (MSVC 2022 Release, `game` target).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/283)
<!-- Reviewable:end -->
