### PR TITLE
[Extractors] Thread vmap-extractor tile extraction

### DIFF
--- a/src/tools/Extractor_projects/vmap-extractor/adtfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/adtfile.cpp
@@ -123,7 +123,13 @@ bool ADTFile::init(uint32 map_num, uint32 tileX, uint32 tileY, StringSet& failed
 
     string AdtMapNumber = xMap + ' ' + yMap + ' ' + GetPlainName((char*)AdtFilename.c_str());
 
-    std::string dirname = std::string(szWorkDirWmo) + "/dir_bin";
+    // Write this tile's placement records to a per-tile temp file rather than
+    // the shared dir_bin. A placement is several fwrites, so concurrent tiles
+    // sharing one handle would interleave (corrupt) records. ParsMapFiles
+    // concatenates these temps into dir_bin in tile order afterwards.
+    char tileSuffix[32];
+    sprintf(tileSuffix, "/dir_bin.%u_%u", tileX, tileY);
+    std::string dirname = std::string(szWorkDirWmo) + tileSuffix;
     FILE* dirfile;
     dirfile = fopen(dirname.c_str(), "ab");
     if (!dirfile)

--- a/src/tools/Extractor_projects/vmap-extractor/gameobject_extract.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/gameobject_extract.cpp
@@ -5,6 +5,20 @@
 
 #include <algorithm>
 #include <stdio.h>
+#include <condition_variable>
+#include <mutex>
+#include <set>
+
+// Dedup model extraction across parallel tile workers. The old
+// FileExists()-then-write check is a TOCTOU race once tiles run concurrently.
+// One worker extracts a given model; the rest must WAIT until its file is on
+// disk, because the placement written straight after (ModelInstance) opens that
+// file and silently drops the spawn if it is missing. A plain "claimed" flag is
+// not enough -- the file has to exist before any referencing worker proceeds.
+static std::mutex s_modelExtractMutex;
+static std::condition_variable s_modelExtractCv;
+static std::set<std::string> s_modelsInProgress;
+static std::set<std::string> s_modelsDone;
 
 bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet& failedPaths)
 {
@@ -26,18 +40,39 @@ bool ExtractSingleModel(std::string& origPath, std::string& fixedName, StringSet
     output += "/";
     output += fixedName;
 
-    if (FileExists(output.c_str()))
     {
-        return true;
+        std::unique_lock<std::mutex> lock(s_modelExtractMutex);
+        if (s_modelsDone.count(fixedName))
+        {
+            return true;
+        }
+        if (s_modelsInProgress.count(fixedName))
+        {
+            // Another worker is extracting this model; block until its file is
+            // written so the placement that follows can read it.
+            s_modelExtractCv.wait(lock, [&] { return s_modelsDone.count(fixedName) != 0; });
+            return true;
+        }
+        if (FileExists(output.c_str()))
+        {
+            s_modelsDone.insert(fixedName);
+            return true;
+        }
+        // Claim it, then extract outside the lock so distinct models convert in
+        // parallel.
+        s_modelsInProgress.insert(fixedName);
     }
 
     Model mdl(origPath);                                    // Possible changed fname
-    if (!mdl.open(failedPaths))
-    {
-        return false;
-    }
+    bool ok = mdl.open(failedPaths) && mdl.ConvertToVMAPModel(output.c_str());
 
-    return mdl.ConvertToVMAPModel(output.c_str());
+    {
+        std::lock_guard<std::mutex> lock(s_modelExtractMutex);
+        s_modelsInProgress.erase(fixedName);
+        s_modelsDone.insert(fixedName);
+    }
+    s_modelExtractCv.notify_all();
+    return ok;
 }
 
 extern HANDLE LocaleMpq;

--- a/src/tools/Extractor_projects/vmap-extractor/mpqfile.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/mpqfile.cpp
@@ -1,7 +1,15 @@
 #include "mpqfile.h"
 #include <deque>
 #include <cstdio>
+#include <mutex>
 #include "StormLib.h"
+
+// StormLib mutates a shared per-archive file position on every read with no
+// internal locking, so concurrent reads from one archive handle race (and
+// return wrong data on Linux). Every MPQ read in this tool flows through this
+// constructor, so one mutex here serialises all archive I/O; the parsing and
+// geometry conversion that follow run fully in parallel.
+std::mutex g_mpqReadMutex;
 
 MPQFile::MPQFile(HANDLE mpq, const char* filename):
     eof(false),
@@ -9,6 +17,7 @@ MPQFile::MPQFile(HANDLE mpq, const char* filename):
     pointer(0),
     size(0)
 {
+    std::lock_guard<std::mutex> mpqLock(g_mpqReadMutex);
     HANDLE file;
     if (!SFileOpenFileEx(mpq, filename, SFILE_OPEN_FROM_MPQ, &file))
     {

--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -27,6 +27,11 @@
 #include <vector>
 #include <list>
 #include <errno.h>
+#include <atomic>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
 
 #if defined WIN32
 #include <Windows.h>
@@ -104,6 +109,7 @@ char output_path[128] = ".";
 char input_path[1024] = ".";
 bool preciseVectorData = true;
 uint32 CONF_max_build = 0;
+uint32 CONF_threads = 0;            ///< Worker threads for tile extraction; 0 = auto-detect cores, 1 = serial.
 
 // Constants
 
@@ -462,6 +468,7 @@ void Usage(char* prg)
     printf("   -l : large size, ~500MB more vmap data. (might contain more details)\n");
     printf("   -d <path>: Path to the vector data source folder.\n");
     printf("   -b : target build (default %u)", CONF_TargetBuild);
+    printf("   -t <#>: worker threads for tile extraction. 0 = auto-detect cores (default), 1 = serial.\n");
     printf("   -? : This message.\n");
 }
 
@@ -483,22 +490,102 @@ void ParsMapFiles()
         WDTFile WDT(fn, map_ids[i].name);
         if (WDT.init(id, map_ids[i].id))
         {
-            printf(" Processing Map %u (%s)\n[", map_ids[i].id, map_ids[i].name);
+            printf(" Processing Map %u (%s)\n", map_ids[i].id, map_ids[i].name);
+
+            // Queue every tile slot; GetMap()/init() fast-fail the absent ones.
+            std::queue<std::pair<int, int> > tileQueue;
             for (int x = 0; x < 64; ++x)
             {
                 for (int y = 0; y < 64; ++y)
                 {
+                    tileQueue.push(std::make_pair(x, y));
+                }
+            }
+
+            uint32 nThreads = CONF_threads ? CONF_threads : std::thread::hardware_concurrency();
+            if (nThreads < 1)
+            {
+                nThreads = 1;
+            }
+
+            uint32 mapId = map_ids[i].id;
+            std::mutex queueMutex;
+            std::mutex failedMutex;
+            auto worker = [&]()
+            {
+                StringSet localFailed;
+                while (true)
+                {
+                    int x, y;
+                    {
+                        std::lock_guard<std::mutex> lock(queueMutex);
+                        if (tileQueue.empty())
+                        {
+                            break;
+                        }
+                        x = tileQueue.front().first;
+                        y = tileQueue.front().second;
+                        tileQueue.pop();
+                    }
                     if (ADTFile* ADT = WDT.GetMap(x, y))
                     {
-                        //sprintf(id_filename,"%02u %02u %03u",x,y,map_ids[i].id);//!!!!!!!!!
-                        ADT->init(map_ids[i].id, x, y, failedPaths);
+                        ADT->init(mapId, x, y, localFailed);
                         delete ADT;
                     }
                 }
-                printf("#");
-                fflush(stdout);
+                std::lock_guard<std::mutex> lock(failedMutex);
+                failedPaths.insert(localFailed.begin(), localFailed.end());
+            };
+
+            if (nThreads <= 1)
+            {
+                // Serial path: one worker on this thread.
+                worker();
             }
-            printf("]\n");
+            else
+            {
+                std::vector<std::thread> workers;
+                workers.reserve(nThreads);
+                for (uint32 t = 0; t < nThreads; ++t)
+                {
+                    workers.emplace_back(worker);
+                }
+                for (std::thread& w : workers)
+                {
+                    w.join();
+                }
+            }
+
+            // Concatenate the per-tile temp files into dir_bin in tile order,
+            // so dir_bin is assembled in the same order no matter which worker
+            // wrote which tile, then remove the temps.
+            std::string dirBin = std::string(szWorkDirWmo) + "/dir_bin";
+            if (FILE* out = fopen(dirBin.c_str(), "ab"))
+            {
+                char copyBuf[8192];
+                for (int x = 0; x < 64; ++x)
+                {
+                    for (int y = 0; y < 64; ++y)
+                    {
+                        char tileSuffix[32];
+                        sprintf(tileSuffix, "/dir_bin.%u_%u", x, y);
+                        std::string tilePath = std::string(szWorkDirWmo) + tileSuffix;
+                        FILE* in = fopen(tilePath.c_str(), "rb");
+                        if (!in)
+                        {
+                            continue;
+                        }
+                        size_t n;
+                        while ((n = fread(copyBuf, 1, sizeof(copyBuf), in)) > 0)
+                        {
+                            fwrite(copyBuf, 1, n, out);
+                        }
+                        fclose(in);
+                        remove(tilePath.c_str());
+                    }
+                }
+                fclose(out);
+            }
         }
     }
 
@@ -730,6 +817,18 @@ bool processArgv(int argc, char** argv)
             if (i + 1 < argc)                            // all ok
             {
                 CONF_TargetBuild = atoi(argv[i++ + 1]);
+            }
+        }
+        else if (strcmp("-t", argv[i]) == 0)
+        {
+            if (i + 1 < argc)                            // all ok
+            {
+                CONF_threads = atoi(argv[i + 1]);
+                ++i;
+            }
+            else
+            {
+                result = false;
             }
         }
         else

--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -33,6 +33,7 @@
 #include <cassert>
 #include <map>
 #include <fstream>
+#include <mutex>
 #undef min
 #undef max
 #include "mpqfile.h"
@@ -660,9 +661,15 @@ WMOInstance::WMOInstance(MPQFile& f, const char* WmoInstName, uint32 mapID, uint
 /// uint32 range, so they cannot collide with client MODF/MDDF unique ids.
 static uint32 GenerateDoodadUniqueId(uint32 wmoUniqueId, uint32 doodadIndex)
 {
+    static std::mutex s_doodadIdMutex;
     static std::map<std::pair<uint32, uint32>, uint32> doodadIdMap;
     static uint32 nextId = 0x80000000;
 
+    // Guards the shared map + counter against concurrent tile workers. The id a
+    // given (wmo, doodad) gets still depends on first-seen order, so threaded
+    // runs assign different (but equally valid, unique) ids than serial runs --
+    // the values are opaque spawn tags, so output stays functionally correct.
+    std::lock_guard<std::mutex> lock(s_doodadIdMutex);
     uint32& uid = doodadIdMap[std::make_pair(wmoUniqueId, doodadIndex)];
     if (uid == 0)
     {


### PR DESCRIPTION
Adds `-t/--threads` to **vmap-extractor** and processes each map's ADT tiles across a worker pool (`0` = auto-detect cores, default; `1` = serial). The movemap generator and map-extractor (#285) were threaded; vmap extraction is the slowest stage. Mirrors the mmap `--threads` pattern.

**Concurrency hazards handled**
- **MPQ reads** — StormLib mutates a shared per-archive file position with no internal lock, so all reads flow through one mutex in the `MPQFile` ctor. Parsing + geometry conversion run in parallel. *(This read-lock is the throughput limiter; per-thread archive handles are a follow-up.)*
- **Model dedup** — the old `FileExists()`-then-write is a TOCTOU race. A worker claims a model, extracts it, and any worker referencing the same model **blocks on a condition variable until its file is on disk** — the placement written next (`ModelInstance`) opens that file and silently drops the spawn if it's missing. Without the wait, **156 placements were lost across 55 tiles** (caught in validation).
- **dir_bin** — each tile writes its own temp file (a placement is several `fwrite`s; a shared handle would interleave records), concatenated in tile order afterwards.
- **`GenerateDoodadUniqueId`** — shared map + counter mutex-guarded.
- **`failedPaths`** — per-worker, merged after.
- **`g_WmoDoodads`** — populated by the serial `ExtractWmo` pass that runs first, so it's read-only during the threaded tile pass.

**Verified on the 4.3.4 client (full extract + assemble):** `--threads 1` vs auto produce the same model-file set (11082), same vmap set (14234), and **identical `dir_bin` records (1,504,834; every tile present)** once the non-deterministic doodad-ID *values* are masked. **~1.68× faster on 16 cores (237s → 141s)**, read-bound by the MPQ lock.

> Output is functionally equivalent, **not byte-identical**: doodad IDs are order-dependent, and `.wmo` exports already vary run-to-run from a **pre-existing uninitialised-memory read in the LIQU path** (confirmed by serial-vs-serial — two `-t 1` runs differ identically). Recommend an in-game collision/LoS smoke-test before merge. Generic infra — intended for the shared `mangos/Extractor_projects`; this is the m3 in-tree change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/286)
<!-- Reviewable:end -->
