### PR TITLE
[Extractors] Cache model reads and parallelize the vmap assembler

### DIFF
--- a/src/game/vmap/TileAssembler.cpp
+++ b/src/game/vmap/TileAssembler.cpp
@@ -51,6 +51,10 @@
 #include <iomanip>
 #include <sstream>
 #include <iomanip>
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 using G3D::Vector3;
 using G3D::AABox;
@@ -122,7 +126,7 @@ namespace VMAP
         // delete iCoordModelMapping;
     }
 
-    bool TileAssembler::convertWorld2()
+    bool TileAssembler::convertWorld2(unsigned int nThreads)
     {
         bool success = readMapSpawns();
         if (!success)
@@ -130,30 +134,84 @@ namespace VMAP
             return false;
         }
 
-        // Export map data
+        uint32 threadCount = nThreads ? nThreads : std::thread::hardware_concurrency();
+        if (threadCount < 1)
+        {
+            threadCount = 1;
+        }
+
+        // Phase 1: compute the transformed bound for every spawn in ONE global
+        // parallel pass. calculateTransformedBound caches each model's vertices,
+        // so a model placed N times is read+parsed once instead of N times, and
+        // the per-spawn transforms run across all cores (a few giant continent
+        // maps no longer gate a per-map loop).
+        std::vector<ModelSpawn*> boundSpawns;
+        for (MapData::iterator mi = mapData.begin(); mi != mapData.end(); ++mi)
+        {
+            for (UniqueEntryMap::iterator e = mi->second->UniqueEntries.begin(); e != mi->second->UniqueEntries.end(); ++e)
+            {
+                boundSpawns.push_back(&e->second);
+            }
+        }
+
+        std::atomic<size_t> nextSpawn(0);
+        std::atomic<bool> boundFail(false);
+        auto boundWorker = [&]()
+        {
+            while (true)
+            {
+                size_t i = nextSpawn.fetch_add(1);
+                if (i >= boundSpawns.size() || boundFail)
+                {
+                    break;
+                }
+                ModelSpawn* s = boundSpawns[i];
+                if (s->flags & MOD_M2)
+                {
+                    if (!calculateTransformedBound(*s))
+                    {
+                        boundFail = true;
+                    }
+                }
+                else if (s->flags & MOD_WORLDSPAWN)
+                {
+                    s->iBound = s->iBound + Vector3(533.33333f * 32, 533.33333f * 32, 0.f);
+                }
+            }
+        };
+
+        if (threadCount <= 1)
+        {
+            boundWorker();
+        }
+        else
+        {
+            std::vector<std::thread> bworkers;
+            bworkers.reserve(threadCount);
+            for (uint32 t = 0; t < threadCount; ++t)
+            {
+                bworkers.emplace_back(boundWorker);
+            }
+            for (std::thread& w : bworkers)
+            {
+                w.join();
+            }
+        }
+        if (boundFail)
+        {
+            success = false;
+        }
+
+        // Phase 2: build the BIH tree and write each map's files (serial; bounds
+        // are already computed above).
         for (MapData::iterator map_iter = mapData.begin(); map_iter != mapData.end() && success; ++map_iter)
         {
             // Build global map tree
             std::vector<ModelSpawn*> mapSpawns;
             UniqueEntryMap::iterator entry;
 
-            std::cout << "Calculating model bounds for map " << map_iter->first << std::endl;
             for (entry = map_iter->second->UniqueEntries.begin(); entry != map_iter->second->UniqueEntries.end(); ++entry)
             {
-                // M2 models don't have a bound set in WDT/ADT placement data, I still think they're not used for LoS at all on retail
-                if (entry->second.flags & MOD_M2)
-                {
-                    if (!calculateTransformedBound(entry->second))
-                    {
-                        break;
-                    }
-                }
-                else if (entry->second.flags & MOD_WORLDSPAWN) // WMO maps and terrain maps use different origin, so we need to adapt :/
-                {
-                    // TODO: remove extractor hack and uncomment below line:
-                    // entry->second.iPos += Vector3(533.33333f*32, 533.33333f*32, 0.f);
-                    entry->second.iBound = entry->second.iBound + Vector3(533.33333f * 32, 533.33333f * 32, 0.f);
-                }
                 mapSpawns.push_back(&(entry->second));
                 spawnedModelFiles.insert(entry->second.name);
             }
@@ -291,23 +349,55 @@ namespace VMAP
                 }
                 fclose(tilefile);
             }
-            // break; // test, extract only first map; TODO: remove this line
         }
 
         // add an object models, listed in temp_gameobject_models file
         exportGameobjectModels();
 
-        // export objects
+        // export objects -- each model file is independent, so convert them
+        // across the same worker pool. convertRawFile reads one raw model and
+        // writes one .vmo; no shared state.
         std::cout <<  std::endl << "Converting Model Files" << std::endl;
-        for (std::set<std::string>::iterator mfile = spawnedModelFiles.begin(); mfile != spawnedModelFiles.end(); ++mfile)
+        std::vector<std::string> modelList(spawnedModelFiles.begin(), spawnedModelFiles.end());
+        std::atomic<size_t> nextModelIdx(0);
+        std::atomic<bool> convFail(false);
+        auto convWorker = [&]()
         {
-            std::cout << "Converting " << *mfile << std::endl;
-            if (!convertRawFile(*mfile))
+            while (true)
             {
-                std::cout << "error converting " << *mfile << std::endl;
-                success = false;
-                break;
+                size_t idx = nextModelIdx.fetch_add(1);
+                if (idx >= modelList.size() || convFail)
+                {
+                    break;
+                }
+                if (!convertRawFile(modelList[idx]))
+                {
+                    std::cout << "error converting " << modelList[idx] << std::endl;
+                    convFail = true;
+                }
             }
+        };
+
+        if (threadCount <= 1)
+        {
+            convWorker();
+        }
+        else
+        {
+            std::vector<std::thread> cworkers;
+            cworkers.reserve(threadCount);
+            for (uint32 t = 0; t < threadCount; ++t)
+            {
+                cworkers.emplace_back(convWorker);
+            }
+            for (std::thread& w : cworkers)
+            {
+                w.join();
+            }
+        }
+        if (convFail)
+        {
+            success = false;
         }
 
         // Cleanup:
@@ -388,60 +478,63 @@ namespace VMAP
 
     bool TileAssembler::calculateTransformedBound(ModelSpawn& spawn)
     {
-        // Construct full path to the model file
-        std::string modelFilename = iSrcDir + "/" + spawn.name;
-
-        // Initialize ModelPosition with rotation and scale
         ModelPosition modelPosition;
         modelPosition.iDir = spawn.iRot;
         modelPosition.iScale = spawn.iScale;
         modelPosition.init();
 
-        // Load the raw model data from disk
-        WorldModel_Raw raw_model;
-        if (!raw_model.Read(modelFilename.c_str()))
+        // Fetch the model's raw vertices (all groups concatenated -- the bound
+        // merges across them) from the cache so each unique model is read and
+        // parsed only once, not once per spawn. std::map keeps element
+        // references stable across inserts, so the pointer stays valid while
+        // other worker threads add new entries.
+        const std::vector<Vector3>* verts = NULL;
         {
-            return false;
+            std::lock_guard<std::mutex> lk(iModelCacheMutex);
+            std::map<std::string, std::vector<Vector3> >::iterator it = iModelVertexCache.find(spawn.name);
+            if (it != iModelVertexCache.end())
+            {
+                verts = &it->second;
+            }
+        }
+        if (!verts)
+        {
+            std::string modelFilename = iSrcDir + "/" + spawn.name;
+            WorldModel_Raw raw_model;
+            if (!raw_model.Read(modelFilename.c_str()))
+            {
+                return false;
+            }
+            std::vector<Vector3> collected;
+            for (uint32 g = 0; g < raw_model.groupsArray.size(); ++g)
+            {
+                std::vector<Vector3>& gv = raw_model.groupsArray[g].vertexArray;
+                collected.insert(collected.end(), gv.begin(), gv.end());
+            }
+            // Insert the complete vector atomically (re-check under the lock in
+            // case another worker read the same model concurrently).
+            std::lock_guard<std::mutex> lk(iModelCacheMutex);
+            std::map<std::string, std::vector<Vector3> >::iterator it = iModelVertexCache.find(spawn.name);
+            if (it == iModelVertexCache.end())
+            {
+                it = iModelVertexCache.insert(std::make_pair(spawn.name, std::move(collected))).first;
+            }
+            verts = &it->second;
         }
 
-        // If the model has multiple groups, it might indicate it's not an M2
-        uint32 groups = raw_model.groupsArray.size();
-        if (groups != 1)
-        {
-            std::cout << "Warning: '" << modelFilename << "' does not seem to be a M2 model!" << std::endl;
-        }
-
-        // We'll track the bounding box of the entire model
         AABox modelBound;
         bool boundEmpty = true;
-
-        // Iterate over each group to accumulate vertex data
-        // Should be only one for M2 files...
-        for (uint32 g = 0; g < groups; ++g)
+        for (size_t i = 0; i < verts->size(); ++i)
         {
-            std::vector<Vector3>& vertices = raw_model.groupsArray[g].vertexArray;
-
-            // If no vertices, log an error about missing geometry
-            if (vertices.empty())
+            Vector3 v = modelPosition.transform((*verts)[i]);
+            if (boundEmpty)
             {
-                std::cout << "error: model '" << spawn.name << "' has no geometry!" << std::endl;
-                continue;
+                modelBound = AABox(v, v);
+                boundEmpty = false;
             }
-
-            // Transform all vertices by rotation and scale, then update bounding box
-            uint32 nvectors = vertices.size();
-            for (uint32 i = 0; i < nvectors; ++i)
+            else
             {
-                Vector3 v = modelPosition.transform(vertices[i]);
-                if (boundEmpty)
-                {
-                    modelBound = AABox(v, v);
-                    boundEmpty = false;
-                }
-                else
-                {
-                    modelBound.merge(v);
-                }
+                modelBound.merge(v);
             }
         }
 

--- a/src/game/vmap/TileAssembler.h
+++ b/src/game/vmap/TileAssembler.h
@@ -29,6 +29,8 @@
 #include <G3D/Matrix3.h>
 #include <map>
 #include <set>
+#include <vector>
+#include <mutex>
 
 #include "ModelInstance.h"
 #include "WorldModel.h"
@@ -170,6 +172,11 @@ namespace VMAP
         MapData mapData; /**< Map data */
         std::set<std::string> spawnedModelFiles; /**< Set of spawned model files */
 
+        /// Per-model vertex cache for calculateTransformedBound: each unique
+        /// model is read+parsed once, then reused across all its spawns.
+        std::map<std::string, std::vector<G3D::Vector3> > iModelVertexCache;
+        std::mutex iModelCacheMutex; /**< Guards iModelVertexCache */
+
     public:
         /**
          * @brief Constructor to initialize the TileAssembler
@@ -186,9 +193,12 @@ namespace VMAP
             /**
              * @brief Converts the world data to a different format
              *
+             * \arg \c nThreads
+             *   Worker threads for the per-map and model passes; 0 = auto-detect
+             *   cores, 1 = serial.
              * @return bool True if successful, false otherwise
              */
-            bool convertWorld2();
+            bool convertWorld2(unsigned int nThreads = 0);
             /**
              * @brief Reads the map spawns from a file
              *

--- a/src/tools/Extractor_projects/vmap-extractor/assembler.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/assembler.cpp
@@ -35,12 +35,12 @@
 * \return
 *   true on success; false if TileAssembler reported errors.
 */
-bool AssembleVMAP(std::string src, std::string dest)
+bool AssembleVMAP(std::string src, std::string dest, unsigned int nThreads)
 {
     bool success = true;
     VMAP::TileAssembler* ta = new VMAP::TileAssembler(src, dest);
 
-    if (!ta->convertWorld2())
+    if (!ta->convertWorld2(nThreads))
     {
         success = false;
     }

--- a/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/vmapexport.cpp
@@ -121,7 +121,7 @@ const char* szRawVMAPMagic = "VMAPc06";
 std::map<std::string, WMODoodadData> g_WmoDoodads;
 
 /// Assemble the extracted raw tile data into the final vmaps (assembler.cpp).
-bool AssembleVMAP(std::string src, std::string dest);
+bool AssembleVMAP(std::string src, std::string dest, unsigned int nThreads = 0);
 
 // Local testing functions
 
@@ -984,7 +984,7 @@ int main(int argc, char** argv)
     // Assemble the raw tiles into the final vmaps in the same run (the former
     // standalone vmap-assembler is now folded into vmap-extractor).
     printf("Assembling vmaps from %s into %s ...\n", szWorkDirWmo, outDir.c_str());
-    if (!AssembleVMAP(std::string(szWorkDirWmo), outDir))
+    if (!AssembleVMAP(std::string(szWorkDirWmo), outDir, CONF_threads))
     {
         printf("ERROR: VMAP assembling for %s NOT completed.\n", szRawVMAPMagic);
         delete [] LiqType;


### PR DESCRIPTION
Builds on the merged `--threads` work (#286): parallelizes the vmap **assembler** (`TileAssembler::convertWorld2`), which was the last fully-serial phase.

**Algorithmic win (helps serial too):** `calculateTransformedBound` re-read and re-parsed each model file *once per spawn* — millions of redundant reads. A per-model vertex cache (`iModelVertexCache`) reads each unique model once and reuses it across all its spawns.

**Parallelism:** `convertWorld2` is restructured into three phases —
1. one global parallel pass computing every spawn's transformed bound (replaces the per-map bound loop, removing the giant-continent-map thread imbalance),
2. a serial per-map pass building/writing the BIH `.vmtree`/`.vmtile`,
3. a parallel convert-model-files pass.

Thread count comes from the existing `-t/--threads` option (`0` = auto-detect cores, `1` = serial).

**Correctness:** output is unchanged — a byte-for-byte compare of the assembled vmaps (cached+parallel vs. the original serial assembler, same `dir_bin`) is **identical** (`dir_bin` and vmaps hashes both match).

**Numbers (full 4.3.4 extraction):** assemble phase ~81s → ~17s threaded; the cache alone cuts the *serial* assemble ~81s → ~24s. Overall vmap extraction with all threading is ~3× the original serial.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/288)
<!-- Reviewable:end -->
