### PR TITLE
Align src codestyle fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,12 +23,12 @@ add_subdirectory(shared)
 add_subdirectory(genrev)
 
 # Needs to link against mangos_world.lib
-if(BUILD_MANGOSD)
+if (BUILD_MANGOSD)
     # Build the mangos game library
     add_subdirectory(game)
 endif()
 
-if(BUILD_MANGOSD)
+if (BUILD_MANGOSD)
     # Build the mangos world server
     add_subdirectory(mangosd)
 
@@ -37,17 +37,17 @@ if(BUILD_MANGOSD)
 endif()
 
 # Build the mangos realm authentication server
-if(BUILD_REALMD)
+if (BUILD_REALMD)
     add_subdirectory(realmd)
 endif()
 
 # If we want the tools for map/vmap/mmap extraction
-if(BUILD_TOOLS)
+if (BUILD_TOOLS)
     add_subdirectory(tools)
 endif()
 
 if (BUILD_MANGOSD OR BUILD_REALMD)
-    if(WIN32)
+    if (WIN32)
         get_filename_component(MYSQL_LIB_DIR ${MySQL_LIBRARIES} DIRECTORY)
         get_filename_component(MYSQL_LIB_DLL ${MySQL_LIBRARIES} NAME)
         STRING(REPLACE ".lib" ".dll" MYSQL_LIB_DLL ${MYSQL_LIB_DLL})

--- a/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
+++ b/src/tools/Extractor_projects/Movemap-Generator/IntermediateValues.cpp
@@ -61,10 +61,11 @@ namespace MMAP
             {                                                                                   \
                 debugWrite(file, data);                                                         \
             }                                                                                   \
-            if(file) fclose(file);                                                              \
-            {                                                                                   \
-                printf("%sWriting debug output...                       \r", tileString);       \
-            }                                                                                   \
+            if (file)                                                                          \
+            {                                                                                  \
+                fclose(file);                                                                  \
+            }                                                                                  \
+            printf("%sWriting debug output...                       \r", tileString);          \
         }                                                                                       \
         while (false)
 


### PR DESCRIPTION
Fix the flagged src/CMakeLists.txt control-paren spacing and brace the single-line file-close path in IntermediateValues.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/289)
<!-- Reviewable:end -->
