### PR TITLE
[Fix] Restore weekly and monthly quest reset triggers

### DIFF
--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1087,6 +1087,18 @@ void World::Update(uint32 diff)
         ResetDailyQuests();
     }
 
+    /// Handle weekly quests reset time
+    if (m_gameTime > m_NextWeeklyQuestReset)
+    {
+        ResetWeeklyQuests();
+    }
+
+    /// Handle monthly quests reset time
+    if (m_gameTime > m_NextMonthlyQuestReset)
+    {
+        ResetMonthlyQuests();
+    }
+
     /// <ul><li> Handle auctions when the timer has passed
     if (m_timers[WUPDATE_AUCTIONS].Passed())
     {


### PR DESCRIPTION
`World::Update()` fires only the daily-quest reset. The weekly and monthly triggers were removed by `c78d8199d` (2016, "Unused code removed"). `ResetWeeklyQuests()` / `ResetMonthlyQuests()` still exist and their init still runs at startup, but nothing calls them at runtime — so weekly and monthly quests never reset during uptime (only maybe caught at restart). mangostwo fires all four.

Restores the two `Update()` checks next to the daily one. Code-only, no schema change.

Random-BG was intentionally NOT restored: `c78d8199d` correctly removed it because the `character_battleground_random` table and the winner-API don't exist in Cata, so re-adding it would be an inert no-op.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/292)
<!-- Reviewable:end -->
