### PR TITLE
[Fix] Grant quest reward currencies and consume required currencies

### DIFF
--- a/src/game/Object/PlayerQuest.cpp
+++ b/src/game/Object/PlayerQuest.cpp
@@ -960,6 +960,15 @@ void Player::RewardQuest(Quest const* pQuest, uint32 reward, Object* questGiver,
         }
     }
 
+    // take currency
+    for (uint32 i = 0; i < QUEST_REQUIRED_CURRENCY_COUNT; ++i)
+    {
+        if (pQuest->ReqCurrencyId[i])
+        {
+            ModifyCurrencyCount(pQuest->ReqCurrencyId[i], -int32(pQuest->ReqCurrencyCount[i] * GetCurrencyPrecision(pQuest->ReqCurrencyId[i])));
+        }
+    }
+
     RemoveTimedQuest(quest_id);
 
     if (BattleGround* bg = GetBattleGround())
@@ -1040,6 +1049,15 @@ void Player::RewardQuest(Quest const* pQuest, uint32 reward, Object* questGiver,
     if (pQuest->GetRewOrReqMoney() < 0)
     {
         ModifyMoney(pQuest->GetRewOrReqMoney());
+    }
+
+    // reward currency
+    for (uint32 i = 0; i < QUEST_REWARD_CURRENCY_COUNT; ++i)
+    {
+        if (pQuest->RewCurrencyId[i])
+        {
+            ModifyCurrencyCount(pQuest->RewCurrencyId[i], int32(pQuest->RewCurrencyCount[i] * GetCurrencyPrecision(pQuest->RewCurrencyId[i])));
+        }
     }
 
     // honor reward


### PR DESCRIPTION
`Player::RewardQuest` awards only honor. The reward-currency and required-currency loops were deleted by `165cfba9c` (2016) and replaced with a WotLK `RewardHonor()`.

Effect: the client still displays quest reward currencies (Justice/Valor/Conquest points, Chef's/Ironpaw/Darkmoon tokens) via `GossipDef.cpp`, but turn-in grants none; and currency-cost quests still check `ReqCurrencyId` for gating but never deduct it, so they are infinitely repeatable.

Restores both loops at their original positions. All plumbing (`ModifyCurrencyCount`, `GetCurrencyPrecision`, the `quest_template` loader) is intact — code-only, no schema change. mangostwo has no quest-currency fields, so this is m3-only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/293)
<!-- Reviewable:end -->
