### PR TITLE
[Fix] Initialize BattleGround::m_RandomTypeID and wire its setter

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -245,6 +245,7 @@ void BattleGround::BroadcastWorker(Do& _do)
 BattleGround::BattleGround(): m_BuffChange(false), m_ArenaBuffSpawned(false), m_StartDelayTime(0), m_startMaxDist(0)
 {
     m_TypeID            = BattleGroundTypeId(0);
+    m_RandomTypeID      = BattleGroundTypeId(0);
     m_Status            = STATUS_NONE;
     m_ClientInstanceID  = 0;
     m_EndTime           = 0;

--- a/src/game/BattleGround/BattleGround.h
+++ b/src/game/BattleGround/BattleGround.h
@@ -574,6 +574,12 @@ class BattleGround
          * @param TypeID
          */
         void SetTypeID(BattleGroundTypeId TypeID) { m_TypeID = TypeID; }
+        /**
+         * @brief Sets the concrete battleground type a random battleground resolved to.
+         *
+         * @param TypeID
+         */
+        void SetRandomTypeID(BattleGroundTypeId TypeID) { m_RandomTypeID = TypeID; }
         // here we can count minlevel and maxlevel for players
         void SetBracket(PvPDifficultyEntry const* bracketEntry);
         /**

--- a/src/game/BattleGround/BattleGroundMgr.cpp
+++ b/src/game/BattleGround/BattleGroundMgr.cpp
@@ -944,6 +944,7 @@ BattleGround* BattleGroundMgr::CreateNewBattleGround(BattleGroundTypeId bgTypeId
     bg->SetStatus(STATUS_WAIT_JOIN);
     bg->SetArenaType(arenaType);
     bg->SetRated(isRated);
+    bg->SetRandomTypeID(bgTypeId);
 
     return bg;
 }


### PR DESCRIPTION
`BattleGround::m_RandomTypeID` is declared and read via `GetTypeID(true)` (the AV quest-credit branch in `PlayerQuest.cpp`) but never assigned — `165cfba9c` (2016) added the member and getter but not the setter or ctor init, so the read is undefined behavior (a non-AV BG can be misidentified as AV and `HandleQuestComplete` called on it).

Adds the ctor initialization, a `SetRandomTypeID` setter, and a call in `CreateNewBattleGround`, mirroring mangostwo. Code-only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/294)
<!-- Reviewable:end -->
