### PR TITLE
[Fix] Drop feign death on NPC and object interaction

### DIFF
--- a/src/game/WorldHandlers/AuctionHouseHandler.cpp
+++ b/src/game/WorldHandlers/AuctionHouseHandler.cpp
@@ -74,6 +74,12 @@ void WorldSession::HandleAuctionHelloOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     SendAuctionHello(unit);
 }
 
@@ -335,6 +341,12 @@ void WorldSession::HandleAuctionSellItem(WorldPacket& recv_data)
             return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     for (uint32 i = 0; i < itemCount; ++i)
     {
         ObjectGuid itemGuid = guids[i];
@@ -454,6 +466,12 @@ void WorldSession::HandleAuctionPlaceBid(WorldPacket& recv_data)
     // always return pointer
     AuctionHouseObject* auctionHouse = sAuctionMgr.GetAuctionsMap(auctionHouseEntry);
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     AuctionEntry* auction = auctionHouse->GetAuction(auctionId);
     Player* pl = GetPlayer();
 
@@ -536,6 +554,12 @@ void WorldSession::HandleAuctionRemoveItem(WorldPacket& recv_data)
 
     // always return pointer
     AuctionHouseObject* auctionHouse = sAuctionMgr.GetAuctionsMap(auctionHouseEntry);
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
 
     AuctionEntry* auction = auctionHouse->GetAuction(auctionId);
     Player* pl = GetPlayer();
@@ -626,6 +650,12 @@ void WorldSession::HandleAuctionListBidderItems(WorldPacket& recv_data)
     // always return pointer
     AuctionHouseObject* auctionHouse = sAuctionMgr.GetAuctionsMap(auctionHouseEntry);
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     WorldPacket data(SMSG_AUCTION_BIDDER_LIST_RESULT, (4 + 4 + 4));
     Player* pl = GetPlayer();
     data << uint32(0);                                      // add 0 as count
@@ -671,6 +701,12 @@ void WorldSession::HandleAuctionListOwnerItems(WorldPacket& recv_data)
 
     // always return pointer
     AuctionHouseObject* auctionHouse = sAuctionMgr.GetAuctionsMap(auctionHouseEntry);
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
 
     WorldPacket data(SMSG_AUCTION_OWNER_LIST_RESULT, (4 + 4 + 4));
     data << (uint32) 0;                                     // amount place holder
@@ -748,6 +784,12 @@ void WorldSession::HandleAuctionListItems(WorldPacket& recv_data)
 
     AuctionSorter sorter(Sort, GetPlayer());
     std::sort(auctions.begin(), auctions.end(), sorter);
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
 
     // DEBUG_LOG("Auctionhouse search %s list from: %u, searchedname: %s, levelmin: %u, levelmax: %u, auctionSlotID: %u, auctionMainCategory: %u, auctionSubCategory: %u, quality: %u, usable: %u",
     //  auctioneerGuid.GetString().c_str(), listfrom, searchedname.c_str(), levelmin, levelmax, auctionSlotID, auctionMainCategory, auctionSubCategory, quality, usable);

--- a/src/game/WorldHandlers/GuildHandler.cpp
+++ b/src/game/WorldHandlers/GuildHandler.cpp
@@ -1146,6 +1146,12 @@ void WorldSession::HandleSaveGuildEmblemOpcode(WorldPacket& recvPacket)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     Guild* guild = sGuildMgr.GetGuildById(GetPlayer()->GetGuildId());
     if (!guild)
     {

--- a/src/game/WorldHandlers/ItemHandlerVendor.cpp
+++ b/src/game/WorldHandlers/ItemHandlerVendor.cpp
@@ -68,6 +68,12 @@ void WorldSession::HandleSellItemOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     Item* pItem = _player->GetItemByGuid(itemGuid);
     if (pItem)
     {
@@ -185,6 +191,12 @@ void WorldSession::HandleBuybackItem(WorldPacket& recv_data)
         DEBUG_LOG("WORLD: HandleBuybackItem - %s not found or you can't interact with him.", vendorGuid.GetString().c_str());
         _player->SendSellError(SELL_ERR_CANT_FIND_VENDOR, NULL, ObjectGuid(), 0);
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     Item* pItem = _player->GetItemFromBuyBackSlot(slot);
@@ -320,6 +332,12 @@ void WorldSession::SendListInventory(ObjectGuid vendorguid)
         DEBUG_LOG("WORLD: SendListInventory - %s not found or you can't interact with him.", vendorguid.GetString().c_str());
         _player->SendSellError(SELL_ERR_CANT_FIND_VENDOR, NULL, ObjectGuid(), 0);
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     // Stop the npc if moving

--- a/src/game/WorldHandlers/NPCHandler.cpp
+++ b/src/game/WorldHandlers/NPCHandler.cpp
@@ -98,6 +98,12 @@ void WorldSession::HandleTabardVendorActivateOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     SendTabardVendorActivate(guid);
 }
 
@@ -129,6 +135,12 @@ void WorldSession::HandleBankerActivateOpcode(WorldPacket& recv_data)
     if (!CheckBanker(guid))
     {
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     SendShowBank(guid);
@@ -222,6 +234,12 @@ void WorldSession::SendTrainerList(ObjectGuid guid, const std::string& strTitle)
     {
         DEBUG_LOG("WORLD: SendTrainerList - %s not found or you can't interact with him.", guid.GetString().c_str());
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     // trainer list loaded at check;
@@ -330,6 +348,12 @@ void WorldSession::HandleTrainerBuySpellOpcode(WorldPacket& recv_data)
     {
         DEBUG_LOG("WORLD: HandleTrainerBuySpellOpcode - %s not found or you can't interact with him.", guid.GetString().c_str());
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     WorldPacket sendData(SMSG_TRAINER_SERVICE, 16);
@@ -444,6 +468,12 @@ void WorldSession::HandleGossipHelloOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     pCreature->StopMoving();
 
     if (pCreature->IsSpiritGuide())
@@ -478,6 +508,12 @@ void WorldSession::HandleGossipSelectOptionOpcode(WorldPacket& recv_data)
     {
         recv_data >> code;
         DEBUG_LOG("Gossip code: %s", code.c_str());
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     uint32 sender = _player->PlayerTalkClass->GossipOptionSender(gossipListId);
@@ -533,6 +569,12 @@ void WorldSession::HandleSpiritHealerActivateOpcode(WorldPacket& recv_data)
     {
         DEBUG_LOG("WORLD: HandleSpiritHealerActivateOpcode - %s not found or you can't interact with him.", guid.GetString().c_str());
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     SendSpiritResurrect();
@@ -622,6 +664,12 @@ void WorldSession::HandleBinderActivateOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     SendBindPoint(unit);
 }
 
@@ -666,6 +714,12 @@ void WorldSession::HandleListStabledPetsOpcode(WorldPacket& recv_data)
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     SendStablePet(npcGUID);
@@ -882,6 +936,12 @@ void WorldSession::HandleStablePet(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     // Slot range goes up to PET_SLOT_LAST_STABLE_SLOT (=20), not just
     // PET_SLOT_LAST_ACTIVE_SLOT (=4). The Cata client uses slots 0..4
     // for the Call Pet 1..5 active roster and 5..20 for stable-only
@@ -1027,6 +1087,12 @@ void WorldSession::HandleUnstablePet(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     uint32 creature_id = 0;
 
     {
@@ -1103,6 +1169,12 @@ void WorldSession::HandleBuyStableSlot(WorldPacket& recv_data)
         SendStableResult(STABLE_ERR_STABLE);
         return;
     }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
 }
 
 /**
@@ -1156,6 +1228,12 @@ void WorldSession::HandleStableSwapPet(WorldPacket& recv_data)
     {
         SendStableResult(STABLE_ERR_STABLE);
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     Pet* pet = _player->GetPet();
@@ -1238,6 +1316,12 @@ void WorldSession::HandleRepairItemOpcode(WorldPacket& recv_data)
     {
         DEBUG_LOG("WORLD: HandleRepairItemOpcode - %s not found or you can't interact with him.", npcGuid.GetString().c_str());
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     // reputation discount

--- a/src/game/WorldHandlers/PetitionsHandler.cpp
+++ b/src/game/WorldHandlers/PetitionsHandler.cpp
@@ -110,6 +110,12 @@ void WorldSession::HandlePetitionBuyOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     if (!pCreature->IsTabardDesigner())
     {
         sLog.outError("WORLD: HandlePetitionBuyOpcode - unsupported npc type, npc: %s", guidNPC.GetString().c_str());
@@ -770,6 +776,12 @@ void WorldSession::SendPetitionShowList(ObjectGuid guid)
     {
         DEBUG_LOG("WORLD: HandlePetitionShowListOpcode - %s not found or you can't interact with him.", guid.GetString().c_str());
         return;
+    }
+
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
     }
 
     WorldPacket data(SMSG_PETITION_SHOWLIST, 8 + 1 + 4 * 6);

--- a/src/game/WorldHandlers/QuestHandler.cpp
+++ b/src/game/WorldHandlers/QuestHandler.cpp
@@ -131,6 +131,12 @@ void WorldSession::HandleQuestgiverHelloOpcode(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     // Stop the npc if moving
     pCreature->StopMoving();
 

--- a/src/game/WorldHandlers/TaxiHandler.cpp
+++ b/src/game/WorldHandlers/TaxiHandler.cpp
@@ -102,6 +102,12 @@ void WorldSession::HandleTaxiQueryAvailableNodes(WorldPacket& recv_data)
         return;
     }
 
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     // unknown taxi node case
     if (SendLearnNewTaxiNode(unit))
     {
@@ -148,6 +154,12 @@ void WorldSession::SendTaxiMenu(Creature* unit)
  */
 void WorldSession::SendDoFlight(uint32 mountDisplayId, uint32 path, uint32 pathNode)
 {
+    // remove fake death
+    if (GetPlayer()->hasUnitState(UNIT_STAT_DIED))
+    {
+        GetPlayer()->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+    }
+
     while (GetPlayer()->GetMotionMaster()->GetCurrentMovementGeneratorType() == FLIGHT_MOTION_TYPE)
         GetPlayer()->GetMotionMaster()->MovementExpired(false);
 


### PR DESCRIPTION
Commit `df3ab5df8` (2016, "13 cmangos commits") removed the `RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH)` calls from every NPC/object interaction handler (30 sites across NPC/AuctionHouse/Vendor/Petitions/Quest/Taxi/Guild). It added `Player::DoInteraction()`, but that only strips `AURA_INTERRUPT_FLAG_TALK`/`USE` (stealth-class) auras — which feign death does not carry — and several paths don't route through it. Net effect: a hunter under Feign Death can bank, vendor, train, take flights, auction, take quests, sign petitions, and do guild actions while mobs still treat them as dead.

Restores the feign-death removal at each of the 30 stripped interaction sites, per-site, matching mangostwo and TrinityCore 4.3.4 (both do this per-handler). `DoInteraction` is left untouched. Code-only, no schema change.

Note: mangostwo has two further feign-death sites (talent wipe, cast start) that were stripped from m3 by different 2016 commits — out of scope here, flagged for a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/295)
<!-- Reviewable:end -->
