### PR TITLE
[World] Restore weekly currency cap reset wiring

### DIFF
--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -822,6 +822,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Calculate random battleground reset time...");
     InitRandomBGResetTime();
 
+    sLog.outString("Calculate next currency reset time...");
+    InitCurrencyResetTime();
+
     sLog.outString("Starting Game Event system...");
     uint32 nextGameEvent = sGameEventMgr.Initialize();
     m_timers[WUPDATE_EVENTS].SetInterval(nextGameEvent);    // depend on next event
@@ -1098,6 +1101,12 @@ void World::Update(uint32 diff)
     if (m_gameTime > m_NextMonthlyQuestReset)
     {
         ResetMonthlyQuests();
+    }
+
+    /// Handle weekly currency cap reset time
+    if (m_gameTime > m_NextCurrencyReset)
+    {
+        ResetCurrencyWeekCounts();
     }
 
     /// <ul><li> Handle auctions when the timer has passed

--- a/src/shared/revision_data.h.in
+++ b/src/shared/revision_data.h.in
@@ -50,8 +50,8 @@
 
     #define CHAR_DB_VERSION_NR          "22"
     #define CHAR_DB_STRUCTURE_NR        "3"
-    #define CHAR_DB_CONTENT_NR          "2"
-    #define CHAR_DB_UPDATE_DESCRIPT     "Add_Quest_Tracker_Table"
+    #define CHAR_DB_CONTENT_NR          "4"
+    #define CHAR_DB_UPDATE_DESCRIPT     "Add_NextCurrenciesResetTime"
 
     #define WORLD_DB_VERSION_NR         "22"
     #define WORLD_DB_STRUCTURE_NR       "5"


### PR DESCRIPTION
Cata's weekly currency-cap reset is dead. `saved_variables` has no `NextCurrenciesResetTime` column, and `World::InitCurrencyResetTime()` / `World::ResetCurrencyWeekCounts()` have no callers — commit `165cfba9c` (2016) removed the wiring (it reverted `8e5d609e1`, which had replaced WotLK arena-point distribution with the currency reset). Result: `character_currencies.weekCount` never resets, so the weekly Conquest cap silently becomes a **permanent lifetime cap** — a player who caps in week 1 can never earn Conquest again. Arena-team weekly stats never reset either.

Restores the wiring: `InitCurrencyResetTime()` in `SetInitialWorldSettings` and the `if (m_gameTime > m_NextCurrencyReset) { ResetCurrencyWeekCounts(); }` trigger in `World::Update` (next to the daily/weekly/monthly resets). The reset function, config keys (`Currency.Reset*`), and per-player `CurrencyMgr::ResetWeekCounts` all already exist.

**Schema coordination:** needs a paired `mangosthree/database` migration **`Rel22_03_004_Add_NextCurrenciesResetTime`** (adds the `bigint` column); this PR bumps `CHAR_DB_CONTENT_NR` to `4`. It **sequences after #296** (the cleaner, `Rel22_03_003` / content `3`) — the two are a schema pair. If you'd rather land this one first/alone, the content number and migration should be renumbered to `3` / `Rel22_03_003`. Migration SQL is ready.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/297)
<!-- Reviewable:end -->
