### PR TITLE
[Movement] Drop zero-length segments from smoothed waypoint splines

### DIFF
--- a/src/game/MotionGenerators/WaypointMovementGenerator.cpp
+++ b/src/game/MotionGenerators/WaypointMovementGenerator.cpp
@@ -50,7 +50,7 @@ namespace
      * @param startZ Leg start Z-coordinate.
      * @param endNode Waypoint the leg ends at.
      * @param pathPoints Path being built; the leg start point is added only when empty.
-     * @return True if a real navmesh leg of at least two points was appended.
+     * @return True if the leg was pathfound; near-duplicate points are dropped, so a degenerate leg may append nothing.
      */
     bool AppendWaypointPathSegment(Creature& creature, float startX, float startY, float startZ, WaypointNode const& endNode, PointsArray& pathPoints)
     {
@@ -78,6 +78,12 @@ namespace
 
         for (PointsArray::const_iterator itr = segment.begin() + 1; itr != segment.end(); ++itr)
         {
+            // Drop zero-length segments: the client cannot interpolate across them
+            if ((*itr - pathPoints.back()).length() < WAYPOINT_SMOOTHING_MIN_SEGMENT_LENGTH)
+            {
+                continue;
+            }
+
             pathPoints.push_back(*itr);
         }
 
@@ -447,7 +453,9 @@ void WaypointMovementGenerator<Creature>::BuildSmoothPath(Creature& creature, Wa
         currPoint = nextPoint;
     }
 
-    if (m_activeSegmentWaypoints.size() <= 1)
+    // A merged path can collapse below a usable spline when every leg was
+    // degenerate; fall back to per-waypoint movement in that case too.
+    if (m_activeSegmentWaypoints.size() <= 1 || pathPoints.size() < 2)
     {
         ClearActiveSegment();
         pathPoints.clear();

--- a/src/game/MotionGenerators/WaypointSmoothing.h
+++ b/src/game/MotionGenerators/WaypointSmoothing.h
@@ -29,6 +29,16 @@ constexpr float WAYPOINT_SMOOTHING_MAX_XY_SPAN = 200.0f;
 constexpr float WAYPOINT_SMOOTHING_MAX_Z_SPAN = 100.0f;
 
 /**
+ * @brief Minimum length (in yards) of a segment in a smoothed multi-point spline.
+ *
+ * The 4.3.4 client cannot interpolate across a zero-length segment inside a
+ * multi-point spline; a mover carrying one becomes selectable from anywhere.
+ * Waypoint paths commonly duplicate their final node, so candidate points
+ * closer than this to the previous path point are dropped during the merge.
+ */
+constexpr float WAYPOINT_SMOOTHING_MIN_SEGMENT_LENGTH = 0.1f;
+
+/**
  * @brief Per-node properties that decide whether smoothing may pass through a waypoint.
  */
 struct WaypointSmoothingNode


### PR DESCRIPTION
Waypoint smoothing (#208) merges consecutive waypoint legs into one multi-point spline. World-DB waypoint loops commonly duplicate their final node (23,153 `creature_movement` guids carry consecutive identical points), and the pathfinder returns a valid two-point degenerate path for a `start == end` leg — so a merged spline can carry zero-length segments.

The 4.3.4 client cannot interpolate across a zero-length segment inside a multi-point spline: the mover's client-side state is corrupted and the creature becomes click-selectable from anywhere. Symptom in the wild: ambient pond wildlife grabbing ground-clicks from the Orgrimmar Drag ledge 40–160 yd away, regardless of where you click, changing target each click. Per-leg movement never hit this because a degenerate leg is a trivial two-point spline.

**Fix:** while building the smoothed path, drop candidate points closer than `0.1` yd to the previous path point, and fall back to per-waypoint movement if a merged path collapses below two points. Smoothing stays enabled for every creature — only redundant zero-length points are removed; the encoder and merge budget are untouched.

Bisected: absent before #208, present after; confirmed by an A/B against a smoothing-disabled probe build (grab present on stock master, gone with smoothing off, gone with this fix while patrols still glide). In-game verified on 4.3.4, client build 15595.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/298)
<!-- Reviewable:end -->
