### PR TITLE
[Movement] Only serialize an active spline in the create block

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -7246,7 +7246,7 @@ void Unit::DisableSpline()
 
 bool Unit::IsSplineEnabled() const
 {
-    return movespline->Initialized();
+    return movespline->Initialized() && !movespline->Finalized();
 }
 
 bool Unit::IsInWorgenForm(bool inPermanent) const


### PR DESCRIPTION
### Problem

`Unit::IsSplineEnabled()` returns `movespline->Initialized()`:

```cpp
bool Unit::IsSplineEnabled() const
{
    return movespline->Initialized();   // == !spline.empty()
}
```

`MoveSpline::Initialized()` is `!spline.empty()`, and the point array is **never emptied** — `_Interrupt()` / `Stop()` only set `splineflags.done`. So the moment a unit has *ever* spline-moved, `IsSplineEnabled()` stays true forever, even while stopped or right after a teleport.

Its only consumer is the create-update builder (`Object::BuildMovementUpdate`, `ObjectUpdate.cpp:279`), so a **stopped** unit's create block still serializes its finished spline, and `PacketBuilder::WriteCreateBytes` writes that spline's stale `FinalDestination()`. The 15595 client then spawns the freshly-created object at its **old** position.

### Impact

Any unit created (for a client that didn't previously have it) while stopped after a spline move renders at the wrong spot until something forces a re-create — real players after a charge/knockback, and most visibly server-controlled units that move exclusively by splines.

### Fix

Add the `!Finalized()` guard so only an *active* spline is serialized:

```cpp
return movespline->Initialized() && !movespline->Finalized();
```

This matches the TrinityCore 4.3.4 definition (`Unit::IsSplineEnabled() { return movespline->Initialized() && !movespline->Finalized(); }`). Behaviour is unchanged for actively-moving units (still serialized) and for stopped units the stale spline section is simply omitted, so the create uses the real `GetPositionX/Y/Z`. Sole consumer is the create-block builder; verified in-game (a stopped/teleported unit now spawns at its true position instead of its last spline destination).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/300)
<!-- Reviewable:end -->
