### PR TITLE
[Proto] Restore 4.3.4 login: unbounded opcode, per-packet handling

### DIFF
--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -133,34 +133,64 @@ namespace proto
 
     std::vector<uint8_t> ClientConnection::onData(const uint8_t* data, size_t len)
     {
-        std::vector<WorldPacket> packets;
-
-        if (m_codec.Feed(data, len, packets) == DecodeStatus::Malformed)
-        {
-            sLog.outError("proto: malformed packet framing from %s, dropping",
-                          m_address.c_str());
-            Close();
-            return std::vector<uint8_t>();
-        }
+        // Each packet is handled as it completes, before the next header in this
+        // same buffer is decoded. HandleAuthSession() arms the header cipher, and
+        // the client enciphers everything after CMSG_AUTH_SESSION -- which TCP
+        // routinely delivers in one read with the packets that follow it.
+        size_t decoded = 0;
+        bool   fatal   = false;
 
         // A short read anywhere below unwinds onto a network worker thread, where
         // nothing else would catch it and the process would abort. Dropping the
         // peer has to be the worst a malformed packet can do.
+        DecodeStatus status = DecodeStatus::Ok;
         try
         {
-            for (size_t i = 0; i < packets.size(); ++i)
-            {
-                if (!HandlePacket(std::move(packets[i])))
+            status = m_codec.Feed(data, len,
+                [&](WorldPacket&& packet) -> bool
                 {
-                    Close();
-                    break;
-                }
-            }
+                    ++decoded;
+                    if (!HandlePacket(std::move(packet)))
+                    {
+                        fatal = true;
+                        return false;
+                    }
+                    return true;
+                });
         }
         catch (ByteBufferException&)
         {
             sLog.outError("proto: short read handling packet from %s, dropping",
                           m_address.c_str());
+            Close();
+            return std::vector<uint8_t>();
+        }
+
+        if (status == DecodeStatus::Malformed)
+        {
+            // Print the header that failed, not just the fact that one did: a
+            // desynchronised header cipher and a peer talking a different
+            // protocol produce the same symptom and need opposite fixes.
+            const PacketCodec::Failure& bad = m_codec.LastFailure();
+
+            sLog.outError("proto: malformed packet framing from %s, dropping "
+                          "(header %.2X %.2X %.2X %.2X %.2X %.2X -> size=%u "
+                          "cmd=0x%.4X, header cipher %s, %u byte(s) read, "
+                          "%u packet(s) decoded before it)",
+                          m_address.c_str(),
+                          bad.header[0], bad.header[1], bad.header[2],
+                          bad.header[3], bad.header[4], bad.header[5],
+                          bad.size, bad.cmd,
+                          bad.decrypted ? "armed" : "not armed",
+                          uint32(len), uint32(decoded));
+            Close();
+            return std::vector<uint8_t>();
+        }
+
+        // A handler that refused the packet has already said why; it only
+        // remains to drop the peer.
+        if (fatal)
+        {
             Close();
         }
 

--- a/src/proto/PacketCodec.cpp
+++ b/src/proto/PacketCodec.cpp
@@ -40,10 +40,22 @@ namespace proto
           m_payloadNeeded(0)
     {
         std::memset(m_header, 0, sizeof(m_header));
+        std::memset(&m_failure, 0, sizeof(m_failure));
     }
 
     DecodeStatus PacketCodec::Feed(const uint8* data, size_t len,
                                    std::vector<WorldPacket>& out)
+    {
+        return Feed(data, len,
+            [&out](WorldPacket&& packet) -> bool
+            {
+                out.push_back(std::move(packet));
+                return true;
+            });
+    }
+
+    DecodeStatus PacketCodec::Feed(const uint8* data, size_t len,
+                                   const PacketSink& sink)
     {
         if (data == NULL || len == 0)
         {
@@ -91,14 +103,30 @@ namespace proto
 
                 // `size` counts the four opcode bytes, so anything below that is
                 // impossible and would underflow the payload length below.
-                // The opcode is bounded too, which WorldSocket.cpp never did. An
-                // opcode past the dispatch table can only ever be rejected further
-                // in, and Rule three is that rejection must be the WORST outcome for
-                // anything off a socket -- so it is rejected here, where the peer
-                // controls neither an allocation nor an index.
-                if (size < 4 || size > MAX_CLIENT_PACKET_SIZE
-                    || cmd > MAX_CLIENT_PACKET_SIZE)
+                //
+                // The opcode is deliberately NOT bounded here, which is the one
+                // thing WorldSocket.cpp appeared to forget and in fact relied on.
+                // The 15595 client opens the world socket with a greeting that is
+                // not a packet at all -- a uint16 size followed by the raw string
+                // "WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER". Read through
+                // the 6-byte header that framing puts the ASCII "WORL" in the cmd
+                // field, so cmd arrives as 0x4C524F57 and only the uint16
+                // truncation below turns it back into MSG_WOW_CONNECTION (0x4F57).
+                // Captured live: header 00 30 57 4F 52 4C, size 48, 50 bytes on
+                // the wire, payload 48-4 = 44. ANY upper bound on cmd -- 0x2800,
+                // 0xFFFF, or the opcode table's own size -- rejects the first
+                // thing every client says and no one can log in.
+                //
+                // Rejecting an opcode that is merely absent from the dispatch
+                // table needs NUM_MSG_TYPES, which is game knowledge proto must
+                // not link; that check lives in WorldGateway::Deliver(), on the
+                // one path proto cannot bypass, safely after the truncation.
+                if (size < 4 || size > MAX_CLIENT_PACKET_SIZE)
                 {
+                    std::memcpy(m_failure.header, m_header, CLIENT_HEADER_SIZE);
+                    m_failure.size      = size;
+                    m_failure.cmd       = cmd;
+                    m_failure.decrypted = bool(m_decryptor);
                     return DecodeStatus::Malformed;
                 }
 
@@ -135,11 +163,18 @@ namespace proto
             {
                 packet.append(m_payload.data(), m_payload.size());
             }
-            out.push_back(std::move(packet));
 
+            // Reset BEFORE handing the packet over. The sink installs the header
+            // decryptor from inside this call, so the codec must already be
+            // sitting cleanly on the next header boundary when it does.
             m_haveHeader = false;
             m_headerFill = 0;
             m_payload.clear();
+
+            if (!sink(std::move(packet)))
+            {
+                return DecodeStatus::Ok;
+            }
         }
 
         return DecodeStatus::Ok;

--- a/src/proto/PacketCodec.h
+++ b/src/proto/PacketCodec.h
@@ -44,6 +44,12 @@ namespace proto
     /// included. Source: WorldSocket.cpp:654 (`header.size > 10240`).
     static const uint32 MAX_CLIENT_PACKET_SIZE = 10240;
 
+    /// There is deliberately no MAX_CLIENT_OPCODE. The 32-bit cmd field is
+    /// truncated to uint16 and NOT range-checked, because the client's opening
+    /// greeting is a raw string whose bytes land in that field ("WORL" ->
+    /// 0x4C524F57) and only the truncation recovers MSG_WOW_CONNECTION. See the
+    /// header check in PacketCodec.cpp; bounding cmd breaks every login.
+
     /**
      * @brief Result of handing a run of received bytes to the codec.
      */
@@ -84,8 +90,40 @@ namespace proto
              */
             explicit PacketCodec(HeaderDecryptor decryptor = HeaderDecryptor());
 
+            /// Receives one completed packet. Returning false stops decoding the
+            /// rest of the buffer, for a peer that must not be listened to any
+            /// further. Called as each packet completes, NOT after the whole
+            /// buffer is decoded -- see the Feed() overload below for why.
+            typedef std::function<bool(WorldPacket&&)> PacketSink;
+
+            /**
+             * @brief Feed received bytes; hand over each packet as it completes.
+             *
+             * @p sink runs BEFORE the next header in the same buffer is read, so
+             * a handler may install the header decryptor (or change any other
+             * decode state) and have it apply to the very next packet. That
+             * ordering is load-bearing: the client enciphers every header after
+             * CMSG_AUTH_SESSION, and TCP will happily deliver that packet and its
+             * successors in a single read. Decoding a whole buffer up front would
+             * read those successors as plaintext. WorldSocket.cpp got this right
+             * by construction, calling ProcessIncoming() inside its read loop.
+             *
+             * @param data Received bytes. Need only stay valid for the call.
+             * @param len  Number of bytes at @p data.
+             * @param sink Invoked once per completed packet, in arrival order.
+             * @return DecodeStatus::Malformed if the peer violated the framing,
+             *         in which case the connection must be closed.
+             */
+            DecodeStatus Feed(const uint8* data, size_t len,
+                              const PacketSink& sink);
+
             /**
              * @brief Feed received bytes; append every packet completed by them.
+             *
+             * Convenience form for tests and callers with no decode state to
+             * change mid-buffer. Everything is decoded before anything is
+             * returned, so it must NOT be used on a connection whose cipher is
+             * armed by one of the packets it might decode.
              *
              * @param data Received bytes. Need only stay valid for the call.
              * @param len  Number of bytes at @p data.
@@ -119,9 +157,33 @@ namespace proto
                 m_decryptor = std::move(decryptor);
             }
 
+            /**
+             * @brief What the header looked like when Feed() last said Malformed.
+             *
+             * A bare "malformed framing" line cannot distinguish a desynchronised
+             * stream cipher from a peer that is genuinely not speaking the
+             * protocol, which is the single most expensive ambiguity there is to
+             * chase from a production log. The codec records rather than logs it,
+             * so it still owns no I/O.
+             */
+            struct Failure
+            {
+                uint8  header[CLIENT_HEADER_SIZE]; ///< the raw header, post-decrypt
+                uint32 size;                       ///< size field as decoded
+                uint32 cmd;                        ///< opcode field as decoded
+                bool   decrypted;                  ///< was a decryptor installed?
+            };
+
+            /// Valid only immediately after Feed() returned Malformed.
+            const Failure& LastFailure() const
+            {
+                return m_failure;
+            }
+
         private:
 
             HeaderDecryptor m_decryptor;
+            Failure         m_failure;
 
             uint8  m_header[CLIENT_HEADER_SIZE]; ///< partially received header
             size_t m_headerFill;                 ///< bytes of m_header filled so far

--- a/src/tests/CodecStressTest.cpp
+++ b/src/tests/CodecStressTest.cpp
@@ -274,15 +274,23 @@ TEST(CodecStress_oversized_size_field_is_rejected)
     }
 }
 
-TEST(CodecStress_absurd_opcode_is_rejected)
+TEST(CodecStress_absurd_opcode_is_truncated_not_rejected)
 {
+    // The framing layer must NOT range-check the opcode. The client's opening
+    // greeting is a raw string that puts the ASCII "WORL" (0x4C524F57) in the
+    // cmd field, and only the uint16 truncation recovers MSG_WOW_CONNECTION --
+    // so a codec that rejects large cmd values rejects every login. An opcode
+    // that survives truncation but names no handler is the game layer's problem:
+    // WorldGateway::Deliver() drops anything >= NUM_MSG_TYPES before it can be
+    // used as a table index, which is the only place that knowledge exists.
     proto::PacketCodec codec;
     std::vector<WorldPacket> out;
 
     const std::vector<uint8> header = RawHeader(8, 0xFFFFFFFFu);
 
     CHECK(codec.Feed(header.data(), header.size(), out)
-          == proto::DecodeStatus::Malformed);
+          == proto::DecodeStatus::Ok);
+    CHECK_EQ(int(out.size()), 0);           // 4-byte payload still outstanding
 }
 
 TEST(CodecStress_truncated_stream_emits_nothing)

--- a/src/tests/PacketCodecTest.cpp
+++ b/src/tests/PacketCodecTest.cpp
@@ -157,6 +157,116 @@ TEST(PacketCodec_rejects_an_oversized_packet)
     CHECK(codec.Feed(wire, sizeof(wire), out) == proto::DecodeStatus::Malformed);
 }
 
+TEST(PacketCodec_accepts_opcodes_above_the_packet_size_limit)
+{
+    // The opcode space and the packet-size limit are unrelated quantities. Most
+    // of the 4.3.4 opcode set sits above MAX_CLIENT_PACKET_SIZE (0x2800) --
+    // CMSG_PING alone is 0x444D -- so bounding the opcode by the size limit
+    // drops the connection on the client's first keepalive.
+    proto::PacketCodec codec;
+    std::vector<WorldPacket> out;
+
+    const std::vector<uint8> wire = Frame(0x444D, { 0x01, 0x02, 0x03, 0x04 });
+
+    CHECK(codec.Feed(wire.data(), wire.size(), out) == proto::DecodeStatus::Ok);
+    REQUIRE(out.size() == 1);
+    CHECK_EQ(int(out[0].GetOpcode()), 0x444D);
+}
+
+TEST(PacketCodec_decodes_the_client_opening_greeting)
+{
+    // Captured off the wire from a 4.3.4.15595 client, byte for byte. This is
+    // the FIRST thing any client says, and it is not a packet: it is a uint16
+    // big-endian size followed by the raw ASCII string
+    // "WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER".
+    //
+    // Read through the 6-byte client header, "WORL" lands in the 32-bit cmd
+    // field (0x4C524F57) and only the uint16 truncation recovers the real
+    // opcode, MSG_WOW_CONNECTION = 0x4F57. Bounding cmd by anything at all --
+    // the packet size limit, 0xFFFF, or the opcode table size -- rejects this
+    // and nobody can log in. Live symptom:
+    //   "malformed packet framing ... header 00 30 57 4F 52 4C -> size=48
+    //    cmd=0x4C524F57 ... 50 byte(s) read, 0 packet(s) decoded before it"
+    proto::PacketCodec codec;
+    std::vector<WorldPacket> out;
+
+    const char greeting[] = "WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER";
+
+    std::vector<uint8> wire;
+    wire.push_back(0x00);                       // size, big-endian: 48
+    wire.push_back(0x30);
+    // 47 characters plus the terminator the client sends with them.
+    wire.insert(wire.end(), greeting, greeting + sizeof(greeting));
+
+    REQUIRE(wire.size() == 50);
+
+    CHECK(codec.Feed(wire.data(), wire.size(), out) == proto::DecodeStatus::Ok);
+    REQUIRE(out.size() == 1);
+    CHECK_EQ(int(out[0].GetOpcode()), 0x4F57);  // MSG_WOW_CONNECTION
+    CHECK_EQ(int(out[0].size()), 44);           // 48 - the 4 cmd bytes
+}
+
+TEST(PacketCodec_arms_the_decryptor_between_coalesced_packets)
+{
+    // The login sequence in miniature. Two packets arrive in ONE read: the
+    // first is plaintext and, when HANDLED, arms the header cipher; the second
+    // is already enciphered by the client. WorldSocket.cpp ran ProcessIncoming()
+    // inside its read loop (:743-801), so the cipher was always armed before the
+    // next header was decrypted. A codec that decodes the whole buffer before
+    // anything is handled reads header two as plaintext, sees garbage, and drops
+    // the connection -- taking the unprocessed CMSG_AUTH_SESSION with it.
+    proto::PacketCodec codec;
+
+    // "Encryption" that is exactly invertible and obviously not identity.
+    const uint8 key = 0x5A;
+
+    std::vector<uint8> wire = Frame(0x0111, { 0xAA });
+    std::vector<uint8> second = Frame(0x0222, { 0xBB });
+    for (size_t i = 0; i < proto::CLIENT_HEADER_SIZE; ++i)
+    {
+        second[i] = uint8(second[i] ^ key);
+    }
+    wire.insert(wire.end(), second.begin(), second.end());
+
+    std::vector<uint16> handled;
+
+    const proto::DecodeStatus status = codec.Feed(wire.data(), wire.size(),
+        [&](WorldPacket&& packet) -> bool
+        {
+            handled.push_back(uint16(packet.GetOpcode()));
+
+            // Handling packet one is what installs the cipher, exactly as
+            // HandleAuthSession() does.
+            if (handled.size() == 1)
+            {
+                codec.SetHeaderDecryptor(
+                    [key](uint8* header, size_t len)
+                    {
+                        for (size_t i = 0; i < len; ++i)
+                        {
+                            header[i] = uint8(header[i] ^ key);
+                        }
+                    });
+            }
+            return true;
+        });
+
+    CHECK(status == proto::DecodeStatus::Ok);
+    REQUIRE(handled.size() == 2);
+    CHECK_EQ(int(handled[0]), 0x0111);
+    CHECK_EQ(int(handled[1]), 0x0222);
+
+    // The control, and the regression this test exists for: decoding the same
+    // buffer to completion BEFORE handling any of it cannot arm the cipher in
+    // time, so header two is read as plaintext and the whole read is condemned
+    // -- including the still-unhandled packet one.
+    proto::PacketCodec batched;
+    std::vector<WorldPacket> out;
+    CHECK(batched.Feed(wire.data(), wire.size(), out)
+          == proto::DecodeStatus::Malformed);
+    CHECK_EQ(int(out.size()), 1);
+}
+
 TEST(PacketCodec_header_decryptor_runs_once_per_header)
 {
     // The header cipher is a stream cipher: decrypting a header in two pieces as


### PR DESCRIPTION
The proto framing layer added in the united-cores work rejects every client at the world socket. No 4.3.4 client can log in on current `master`. Two independent defects, both fatal on their own.

## 1. The opcode must not be bounded

The header check bounded the opcode by `MAX_CLIENT_PACKET_SIZE`:

```cpp
if (size < 4 || size > MAX_CLIENT_PACKET_SIZE
    || cmd > MAX_CLIENT_PACKET_SIZE)
```

That constant is a packet-size limit and is unrelated to the opcode space, which runs to `0x7DB4`. 256 of 684 CMSGs sit above it — `CMSG_PING` (`0x444D`) and `CMSG_REALM_SPLIT` (`0x2906`) among them.

Raising the ceiling is not the fix either. The opcode must not be bounded **at all**, which is what `WorldSocket.cpp` did and only looked like an oversight.

The client opens the world socket with a greeting that is not a packet: a `uint16` big-endian size followed by the raw ASCII `"WORLD OF WARCRAFT CONNECTION - CLIENT TO SERVER"`. Read through the 6-byte client header, `"WORL"` lands in the 32-bit `cmd` field — so `cmd` arrives as `0x4C524F57`, and only the `uint16` truncation recovers `MSG_WOW_CONNECTION` (`0x4F57`).

Captured live from a 4.3.4.15595 client:

```
header 00 30 57 4F 52 4C -> size=48, cmd=0x4C524F57, 50 bytes read
```

The arithmetic corroborates it: payload = 48 − 4 = 44, and 6 + 44 = the 50 bytes on the wire. Any ceiling on `cmd` — `0x2800`, `0xFFFF`, or `NUM_MSG_TYPES` — rejects the first thing every client says.

Dispatch-table safety is unaffected. `WorldGateway::Deliver()` already drops anything `>= NUM_MSG_TYPES`, after the truncation and before the value is used as an index — the one path `proto` cannot bypass, and the only layer where that knowledge exists.

## 2. Packets must be handled as they decode

`Feed()` decoded and decrypted every header in a read before `onData()` handled any of them. `HandleAuthSession()` arms the header cipher, and the client enciphers everything after `CMSG_AUTH_SESSION` — which TCP routinely delivers coalesced with the packets behind it.

Header two was therefore read as plaintext, `Feed()` returned `Malformed`, and the peer was dropped **with `CMSG_AUTH_SESSION` never handled** — so the failure left no auth trace in the log at all, which makes it very hard to read from a production log.

`WorldSocket::handle_input_missing_data()` called `ProcessIncoming()` inside its read loop and could not desync. `Feed()` gains a `PacketSink` overload that hands each packet over as it completes; the vector overload remains for tests and is documented as unsafe on a connection whose cipher is armed mid-buffer.

## Diagnostics

The malformed-framing line now reports the offending header bytes, decoded `size`/`cmd`, whether the cipher was armed, and how many packets decoded before it. The last field alone separates a cipher desync (`>= 1`) from a bad first packet (`0`).

## Tests

166 pass. Notable:

- `PacketCodec_decodes_the_client_opening_greeting` — built from the captured 50 bytes, asserts `MSG_WOW_CONNECTION` and a 44-byte payload.
- `PacketCodec_arms_the_decryptor_between_coalesced_packets` — carries a control that reproduces the old failure exactly: batched decoding of the same buffer returns `Malformed` having decoded only one packet.
- `CodecStress_absurd_opcode_is_rejected` asserted the behaviour that breaks login and is replaced by `_is_truncated_not_rejected`; leaving it would have re-introduced defect 1.

## Verification

Built RelWithDebInfo x64 (MSVC), deployed, and confirmed by the reporter that a 4.3.4 client now logs in. Both defects were found from server logs plus the pre-refactor `WorldSocket.cpp`; the greeting fix is backed by captured wire bytes rather than inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/309)
<!-- Reviewable:end -->
