### PR TITLE
[Core] Open mmtiles with the axes the baker named them by

### DIFF
--- a/src/game/WorldHandlers/MoveMap.cpp
+++ b/src/game/WorldHandlers/MoveMap.cpp
@@ -323,8 +323,13 @@ namespace MMAP
             return false;
         }
 
+        /// Recast X is world Y, so the baker names a tile with the axes swapped
+        /// relative to the grid position. See NavMeshBuilder.hpp.
+        const int32 filenameTileX = y;
+        const int32 filenameTileY = x;
+
         // load this tile :: mmaps/MMMMXXYY.mmtile
-        const std::string fileName = MMapTileFileName(mapId, x, y);
+        const std::string fileName = MMapTileFileName(mapId, filenameTileX, filenameTileY);
 
         FILE* file = fopen(fileName.c_str(), "rb");
         if (!file)
@@ -339,7 +344,7 @@ namespace MMAP
 
         if (fileHeader.mmapMagic != MMAP_MAGIC)
         {
-            sLog.outError("MMAP:loadMap: Bad header in mmap %04u%02i%02i.mmtile", mapId, x, y);
+            sLog.outError("MMAP:loadMap: Bad header in mmap %04u%02i%02i.mmtile", mapId, filenameTileX, filenameTileY);
             fclose(file);
             return false;
         }
@@ -347,7 +352,7 @@ namespace MMAP
         if (fileHeader.mmapVersion != MMAP_VERSION)
         {
             sLog.outError("MMAP:loadMap: %04u%02i%02i.mmtile was built with generator v%i, expected v%i",
-                          mapId, x, y, fileHeader.mmapVersion, MMAP_VERSION);
+                          mapId, filenameTileX, filenameTileY, fileHeader.mmapVersion, MMAP_VERSION);
             fclose(file);
             return false;
         }
@@ -358,7 +363,7 @@ namespace MMAP
         size_t result = fread(data, fileHeader.size, 1, file);
         if (!result)
         {
-            sLog.outError("MMAP:loadMap: Bad header or data in mmap %04u%02i%02i.mmtile", mapId, x, y);
+            sLog.outError("MMAP:loadMap: Bad header or data in mmap %04u%02i%02i.mmtile", mapId, filenameTileX, filenameTileY);
             fclose(file);
             return false;
         }
@@ -371,7 +376,7 @@ namespace MMAP
         // memory allocated for data is now managed by detour, and will be deallocated when the tile is removed
         if (mmap->navMesh->addTile(data, fileHeader.size, DT_TILE_FREE_DATA, 0, &tileRef) != DT_SUCCESS)
         {
-            sLog.outError("MMAP:loadMap: Could not load %04u%02i%02i.mmtile into navmesh", mapId, x, y);
+            sLog.outError("MMAP:loadMap: Could not load %04u%02i%02i.mmtile into navmesh", mapId, filenameTileX, filenameTileY);
             dtFree(data);
             return false;
         }


### PR DESCRIPTION
Recast X is world Y, so the navmesh baker writes a tile at grid `(gx, gy)` as `navTileX = gy, navTileY = gx`. `NavMeshBuilder.hpp` states the contract outright: *"the runtime opens `mmaps/%04u%02i%02i.mmtile` with (mapId, y, x); see MMapManager::loadMap"*.

`loadMap` passes `(x, y)` straight through, so every off-diagonal tile is looked up transposed and fails to open — only the `gx == gy` diagonal loads.

Stormwind is ADT `Azeroth_30_48`: the baker emits `00003048.mmtile`, `loadMap` asks for `00004830.mmtile`.

mangoszero, mangosone and mangostwo all carry this swap in `loadMap`; mangosthree is one of the two that do not. This adds it, matching mangostwo's naming and its convention of using the swapped pair only for messages that name the file — the already-loaded warning keeps the grid position, which is what it reports.

The `.mmap` GM command in this tree already prints the swapped order, so the loader was the only place still disagreeing.

Verified against a fresh bake: with the fix, a full world load reports no mmtile errors; without it, off-diagonal tiles never load.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/311)
<!-- Reviewable:end -->
