### PR TITLE
[Extractor] Read the MH2O deep attribute, and ocean objects as depth-only

### DIFF
--- a/src/tests/ClientParserTest.cpp
+++ b/src/tests/ClientParserTest.cpp
@@ -138,6 +138,12 @@ namespace
         uint64_t existsBits = ~uint64_t(0);
         bool withHeights = false;
         float heightBias = 0.f;
+        bool withAttributes = false;
+        uint64_t fishableBits = 0;
+        uint64_t deepBits = 0;
+        /// Non-zero overrides the attributes offset written to the table, for
+        /// exercising the parser's bounds guard against a malformed chunk.
+        uint32_t forceAttributesOfs = 0;
     };
 
     // One MH2O chunk carrying a single layer on chunk (iy,ix).
@@ -161,7 +167,13 @@ namespace
         const uint32_t afterInstance = instOfs + 24;
         uint32_t existsOfs = 0;
         uint32_t vertsOfs = 0;
+        uint32_t attrOfs = 0;
         uint32_t cursor = afterInstance;
+        if (l.withAttributes)
+        {
+            attrOfs = cursor;
+            cursor += 16;
+        }
         if (l.withExists)
         {
             existsOfs = cursor;
@@ -174,6 +186,17 @@ namespace
         tail.U32(existsOfs);
         tail.U32(vertsOfs);
 
+        if (l.withAttributes)
+        {
+            for (int i = 0; i < 8; ++i)
+            {
+                tail.U8(uint8_t((l.fishableBits >> (i * 8)) & 0xFF));
+            }
+            for (int i = 0; i < 8; ++i)
+            {
+                tail.U8(uint8_t((l.deepBits >> (i * 8)) & 0xFF));
+            }
+        }
         if (l.withExists)
         {
             for (int i = 0; i < 8; ++i)
@@ -195,6 +218,8 @@ namespace
         body.Append(tail);
         body.PatchU32(size_t(iy * 16 + ix) * 12 + 0, instOfs);
         body.PatchU32(size_t(iy * 16 + ix) * 12 + 4, 1);
+        body.PatchU32(size_t(iy * 16 + ix) * 12 + 8,
+                      l.forceAttributesOfs ? l.forceAttributesOfs : attrOfs);
         return body;
     }
 
@@ -312,6 +337,92 @@ TEST(AdtMh2oFlatLayerFillsWholeChunk)
     }
     CHECK_EQ(d.liquidHeight[size_t(8) * ADT_V9 + 8], 42.5f);
     CHECK_EQ(d.liquidShow[0], uint8_t(0));
+}
+
+// Retail Vashj'ir ships MH2O with no attributes at all, and must not fatigue.
+// Absent is the common case, so it has to read as "not deep", never as a
+// default of set bits.
+TEST(AdtMh2oAbsentAttributesAreNotDeep)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    Mh2oLayer l;
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(1, 1, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(1, 1, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    CHECK_EQ(d.liquidDeepAttr[size_t(8) * ADT_GRID + 8], uint8_t(0));
+}
+
+TEST(AdtMh2oDeepAttributeMarksChunkDeep)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    Mh2oLayer l;
+    l.withAttributes = true;
+    l.deepBits = ~uint64_t(0);
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(1, 1, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(1, 1, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    for (int y = 0; y < 8; ++y)
+    {
+        for (int x = 0; x < 8; ++x)
+        {
+            CHECK_EQ(d.liquidDeepAttr[size_t(8 + y) * ADT_GRID + (8 + x)], uint8_t(1));
+        }
+    }
+    CHECK_EQ(d.liquidDeepAttr[0], uint8_t(0));
+}
+
+// The fishable bitmap sits ahead of the deep one; reading the wrong half would
+// flag shallow fishing water as fatiguing ocean.
+TEST(AdtMh2oFishableAttributeIsNotDeep)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    Mh2oLayer l;
+    l.withAttributes = true;
+    l.fishableBits = ~uint64_t(0);
+    l.deepBits = 0;
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(1, 1, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(1, 1, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    CHECK_EQ(d.liquidDeepAttr[size_t(8) * ADT_GRID + 8], uint8_t(0));
+}
+
+// A truncated or malformed chunk must fall back to "not deep" rather than
+// reading past the body.
+TEST(AdtMh2oOutOfRangeAttributesOffsetIsNotDeep)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    Mh2oLayer l;
+    l.withAttributes = true;
+    l.deepBits = ~uint64_t(0);
+    l.forceAttributesOfs = 0x00FFFFFF;
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(1, 1, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(1, 1, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    CHECK_EQ(d.liquidDeepAttr[size_t(8) * ADT_GRID + 8], uint8_t(0));
 }
 
 TEST(AdtMh2oHonoursSubRectAndExistsBitmap)

--- a/src/tests/ClientParserTest.cpp
+++ b/src/tests/ClientParserTest.cpp
@@ -138,6 +138,8 @@ namespace
         uint64_t existsBits = ~uint64_t(0);
         bool withHeights = false;
         float heightBias = 0.f;
+        bool withDepths = false;      ///< uint8 depth array at offsVerts (LVF 2 / ocean object)
+        uint8_t depthFill = 0xBC;     ///< 0xBCBCBCBC == -0.023f if misread as float32
         bool withAttributes = false;
         uint64_t fishableBits = 0;
         uint64_t deepBits = 0;
@@ -179,7 +181,7 @@ namespace
             existsOfs = cursor;
             cursor += 8;
         }
-        if (l.withHeights)
+        if (l.withHeights || l.withDepths)
         {
             vertsOfs = cursor;
         }
@@ -212,6 +214,23 @@ namespace
                 {
                     tail.F32(l.heightBias + float(y * (l.w + 1) + x));
                 }
+            }
+        }
+        if (l.withDepths)
+        {
+            const int corners = (l.w + 1) * (l.h + 1);
+            for (int i = 0; i < corners; ++i)
+            {
+                tail.U8(l.depthFill);
+            }
+            // Real MH2O bodies carry far more data after a depth array (the
+            // other 255 chunks' instances); the pre-fix bug's float32 read
+            // guard (AdtParser.cpp:214-215) sizes against 4 bytes/corner, so
+            // pad with the same fill byte to reproduce that guard passing
+            // here too, uniformly, without changing the reinterpreted bits.
+            for (int i = corners; i < corners * 4; ++i)
+            {
+                tail.U8(l.depthFill);
             }
         }
 
@@ -496,6 +515,60 @@ TEST(AdtMh2oDepthOnlyLayerUsesMinHeight)
     AdtData d;
     REQUIRE(ParseAdt(adt.b, d));
     CHECK_EQ(d.liquidHeight[0], -7.25f);
+}
+
+TEST(AdtMh2oOceanLiquidObjectIsDepthOnly)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    // Retail coastal ocean: LiquidType 2 through LiquidObject 42, vertex data
+    // is uint8 depths. Misread as float32 the fill byte bakes -0.023f (real
+    // tiles bake anything up to +-1e36).
+    Mh2oLayer l;
+    l.entry = 2;
+    l.lvf = 42;
+    l.minHeight = 0.f;
+    l.withDepths = true;
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(0, 0, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(0, 0, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    REQUIRE(d.hasLiquid);
+    for (int y = 0; y <= 8; ++y)
+    {
+        for (int x = 0; x <= 8; ++x)
+        {
+            CHECK_EQ(d.liquidHeight[size_t(y) * ADT_V9 + x], 0.f);
+        }
+    }
+}
+
+TEST(AdtMh2oNonOceanLiquidObjectKeepsHeights)
+{
+    float mcvt[145];
+    FillRamp(mcvt, 0.f);
+
+    // A river authored as a LiquidObject: LiquidType 5 resolves to a
+    // height-first vertex format, so the float height map must be honoured.
+    Mh2oLayer l;
+    l.entry = 5;
+    l.lvf = 3001;
+    l.w = 2;
+    l.h = 2;
+    l.withHeights = true;
+    l.heightBias = 55.f;
+
+    Blob adt;
+    PutChunk(adt, "MCNK", MakeMcnk(0, 0, 0.f, 0, 0, mcvt));
+    PutChunk(adt, "MH2O", MakeMh2o(0, 0, l));
+
+    AdtData d;
+    REQUIRE(ParseAdt(adt.b, d));
+    CHECK_EQ(d.liquidHeight[size_t(1) * ADT_V9 + 2], 55.f + float(1 * 3 + 2));
 }
 
 TEST(AdtMh2oRejectsOutOfRangeInstance)

--- a/src/tests/ClientParserTest.cpp
+++ b/src/tests/ClientParserTest.cpp
@@ -385,27 +385,6 @@ TEST(AdtMh2oDepthOnlyLayerUsesMinHeight)
     AdtData d;
     REQUIRE(ParseAdt(adt.b, d));
     CHECK_EQ(d.liquidHeight[0], -7.25f);
-    CHECK_EQ(d.liquidNoLight[0], uint8_t(0));
-}
-
-TEST(AdtMh2oMarksTextureCoordLayersAsUnlit)
-{
-    float mcvt[145];
-    FillRamp(mcvt, 0.f);
-
-    Mh2oLayer l;
-    l.lvf = 1;
-    l.w = 1;
-    l.h = 1;
-    l.withHeights = true;
-
-    Blob adt;
-    PutChunk(adt, "MCNK", MakeMcnk(0, 0, 0.f, 0, 0, mcvt));
-    PutChunk(adt, "MH2O", MakeMh2o(0, 0, l));
-
-    AdtData d;
-    REQUIRE(ParseAdt(adt.b, d));
-    CHECK_EQ(d.liquidNoLight[0], uint8_t(1));
 }
 
 TEST(AdtMh2oRejectsOutOfRangeInstance)

--- a/src/tools/extractor/client/AdtParser.cpp
+++ b/src/tools/extractor/client/AdtParser.cpp
@@ -38,7 +38,7 @@ namespace world::terrain
             out.liquidShow.assign(size_t(ADT_GRID) * ADT_GRID, 0);
             out.liquidEntry.assign(size_t(ADT_GRID) * ADT_GRID, 0);
             out.liquidDark.assign(size_t(ADT_GRID) * ADT_GRID, 0);
-            out.liquidNoLight.assign(size_t(ADT_GRID) * ADT_GRID, 0);
+            out.liquidDeepAttr.assign(size_t(ADT_GRID) * ADT_GRID, 0);
         }
 
         void ReadMcnk(const uint8_t* mcnk, uint32_t mcnkSize, AdtData& out)
@@ -177,6 +177,18 @@ namespace world::terrain
                         continue;
                     }
 
+                    // The 12-byte header's third field points at the Cataclysm
+                    // attributes pair { uint64 fishable; uint64 deep; }. Absent
+                    // means NOT deep: retail Vashj'ir ships no attributes and
+                    // must not fatigue, while real deep ocean carries set bits.
+                    const uint32_t offsAttributes = RdU32(ch + 8);
+                    uint64_t deepBits = 0;
+                    if (offsAttributes &&
+                        uint64_t(offsAttributes) + 16 <= bodySize)
+                    {
+                        deepBits = RdU64(body + offsAttributes + 8);
+                    }
+
                     for (uint32_t l = 0; l < layers; ++l)
                     {
                         const uint8_t* inst = body + offsInstances + l * INSTANCE;
@@ -195,11 +207,8 @@ namespace world::terrain
                             continue;
                         }
 
-                        // Vertex format 2 is depth-only and carries no heights; 1 and 3
-                        // replace the depth map with texture coordinates, which is the
-                        // "no light map" the reference reads dark water from.
+                        // Vertex format 2 is depth-only and carries no heights.
                         const bool hasHeights = (lvf != 2);
-                        const bool noLight = (lvf == 1 || lvf == 3 || !offsVerts);
                         const uint32_t corners = uint32_t(w + 1) * uint32_t(hgt + 1);
                         const uint8_t* heights = nullptr;
                         if (hasHeights && offsVerts &&
@@ -234,7 +243,7 @@ namespace world::terrain
                                 out.liquidShow[idx] = 1;
                                 out.liquidEntry[idx] = entry;
                                 out.liquidDark[idx] = 0;
-                                out.liquidNoLight[idx] = noLight ? 1 : 0;
+                                out.liquidDeepAttr[idx] = (deepBits != 0) ? 1 : 0;
                             }
                         }
 

--- a/src/tools/extractor/client/AdtParser.cpp
+++ b/src/tools/extractor/client/AdtParser.cpp
@@ -28,6 +28,11 @@ namespace world::terrain
         constexpr uint8_t MCLQ_NO_LIQUID = 0x0F;
         constexpr uint8_t MCLQ_DARK = 0x80;
 
+        // MH2O instance field 2 is a vertex format below this value and a
+        // LiquidObject.dbc id from it upward (Cataclysm+).
+        constexpr uint16_t MH2O_FIRST_LIQUID_OBJECT = 42;
+        constexpr uint16_t LIQUID_TYPE_OCEAN_ID = 2;
+
         void EnsureLiquid(AdtData& out)
         {
             if (!out.liquidHeight.empty())
@@ -208,7 +213,16 @@ namespace world::terrain
                         }
 
                         // Vertex format 2 is depth-only and carries no heights.
-                        const bool hasHeights = (lvf != 2);
+                        // A field of 42+ is a LiquidObject.dbc id instead of a
+                        // format: ocean instances are depth-only there (uint8
+                        // depths -- read as floats they bake ~1e11 surfaces),
+                        // while every other 4.3.4 liquid resolves through
+                        // LiquidType->LiquidMaterial to a height-first format.
+                        const bool depthOnly =
+                            (lvf >= MH2O_FIRST_LIQUID_OBJECT)
+                                ? (entry == LIQUID_TYPE_OCEAN_ID)
+                                : (lvf == 2);
+                        const bool hasHeights = !depthOnly;
                         const uint32_t corners = uint32_t(w + 1) * uint32_t(hgt + 1);
                         const uint8_t* heights = nullptr;
                         if (hasHeights && offsVerts &&

--- a/src/tools/extractor/client/AdtParser.hpp
+++ b/src/tools/extractor/client/AdtParser.hpp
@@ -36,7 +36,7 @@ namespace world::terrain
         std::vector<uint8_t> liquidShow;
         std::vector<uint16_t> liquidEntry;
         std::vector<uint8_t> liquidDark;     ///< MCLQ per-cell dark-water bit
-        std::vector<uint8_t> liquidNoLight;  ///< MH2O layer shipped no light map
+        std::vector<uint8_t> liquidDeepAttr; ///< MH2O chunk deep attribute, cell-broadcast
 
         std::vector<std::string> wmoNames;
         std::vector<std::string> m2Names;

--- a/src/tools/extractor/client/MpqTileSource.cpp
+++ b/src/tools/extractor/client/MpqTileSource.cpp
@@ -246,11 +246,13 @@ namespace world::terrain
                 const LiquidKind kind =
                     world::ClassifyLiquid(tile->liquidEntry[i], m_liquidTypes);
                 tile->liquidKind[i] = uint8_t(kind);
-                // Dark water is the MCLQ per-cell bit, or an ocean layer that shipped no
-                // light map -- the rule the reference extractor has always used.
+                // Dark water is the MCLQ per-cell bit (pre-WotLK tiles), or an
+                // ocean cell whose MH2O chunk carries the "deep" attribute --
+                // the rule the pre-rewrite extractor used. The former
+                // ocean-without-light-map guess misflagged all of Vashj'ir.
                 tile->liquidDeep[i] =
                     (adt.liquidDark[i] ||
-                     (kind == LiquidKind::Ocean && adt.liquidNoLight[i]))
+                     (kind == LiquidKind::Ocean && adt.liquidDeepAttr[i]))
                         ? 1
                         : 0;
             }


### PR DESCRIPTION
Two field misreads in the MH2O parser, both of which bake wrong liquid.

**1. The deep-water attribute is never read.** Dark water was inferred from `MCLQ`'s per-cell bit or, failing that, "an ocean layer that shipped no light map". `MCLQ` does not exist on a Cataclysm ADT, so the guess was the only live rule — and retail Vashj'ir, whose ocean instances carry no vertex data, matched it on every cell. The whole zone baked as dark water, which is a fatigue timer on a player who is meant to breathe there. The real source is the MH2O attributes pair `{ uint64 fishable; uint64 deep; }` at the chunk header's third field, which the parse skipped entirely. Absent attributes mean *not* deep: control tiles ship them nearly everywhere with `deep` set only on true fatigue ocean.

**2. An ocean liquid object is read as if it had heights.** The instance field at +2 is dual-purpose: below 42 it is a liquid vertex format, from 42 up it is a `LiquidObject.dbc` id. Only the format meaning was handled, so an ocean object instance — which the client authors as `LiquidType 2` with that field at 42 — took the "has heights" path and read its `uint8` depth array as `float32`. Those bytes bake liquid surfaces around 1e11: 101,390 instances across 1,142 tiles on 20 maps. Anything swimming there snaps to the bogus surface. The navmesh inherits it too, since the swim mesh is built from the same heights.

Every `LiquidMaterial` in 15595 uses a height-first vertex format, so for this build "object instance is depth-only" is exactly "its liquid type is ocean", and the check needs no DBC plumbing.

No clamp on either value — the garbage was loud enough to be found, and a clamp would only hide the next reader bug.

Tests cover both, including that a *non-ocean* object instance still keeps its heights (~24k of those parsed correctly by accident and would regress under a blanket rule). Verified on a full world bake: a map-0 sweep goes from 31 tiles with absurd liquid surfaces to none, and Vashj'ir bakes zero deep cells.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/312)
<!-- Reviewable:end -->
