### PR TITLE
[Terrain] Suppress ADT liquid inside WMO interior groups

### DIFF
--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -82,6 +82,11 @@ namespace
     const uint32 LIQUID_OUTLAND_OCEAN_ROW = 15;
     const uint32 LIQUID_FIRST_OVERRIDABLE_ROW = 21;
 
+    // MOGP group flag: the group is an interior. Outside (ADT) liquid must not
+    // reach a point inside one -- Vashj'ir's L'ghorek air pocket, a dry hold
+    // under the sea -- only liquid the WMO itself carries counts there.
+    const uint32 MOGP_FLAG_INTERIOR = 0x2000;
+
     // LiquidType.dbc SoundBank is the family the client uses (0 water .. 3 slime), and
     // MAP_LIQUID_TYPE_* is one bit per family in that order. The DBC is the authority:
     // the tile carries the row id, never a pre-chewed category.
@@ -352,10 +357,27 @@ GridMapLiquidStatus TerrainInfo::getLiquidStatus(float x, float y, float z,
     const world::terrain::Column column =
         ColumnAt(x, y, z + FLOOR_BURIED_LIFT, z - FLOOR_SEARCH_DOWN);
 
-    const auto liquid = column.HighestLiquid();
+    auto liquid = column.HighestLiquid();
     if (!liquid || !liquid->liquidEntry)
     {
         return LIQUID_MAP_NO_WATER;
+    }
+
+    // Tile liquid is the OUTSIDE water. When the point sits inside a WMO
+    // interior group, drop it and keep only what the model itself carries.
+    if (liquid->fromAdt && column.HasStatic())
+    {
+        uint32 mogpFlags = 0;
+        int32 adtId = 0, rootId = 0, groupId = 0;
+        if (GetAreaInfo(x, y, z, mogpFlags, adtId, rootId, groupId) &&
+            (mogpFlags & MOGP_FLAG_INTERIOR))
+        {
+            liquid = column.HighestLiquid(false);
+            if (!liquid || !liquid->liquidEntry)
+            {
+                return LIQUID_MAP_NO_WATER;
+            }
+        }
     }
     const LiquidInfo info = liquid->AsLiquid();
 

--- a/src/shared/terrain/Column.hpp
+++ b/src/shared/terrain/Column.hpp
@@ -29,6 +29,7 @@ namespace world::terrain
         LiquidKind liquid = LiquidKind::None;
         uint16_t liquidEntry = 0;
         bool deep = false;
+        bool fromAdt = false;  ///< tile (ADT) liquid, not carried by a model
 
         bool Solid() const { return kind != SurfaceKind::Liquid; }
 
@@ -54,7 +55,7 @@ namespace world::terrain
                 m_surfaces.push_back(s);
             }
 
-            void AddLiquid(const LiquidInfo& info)
+            void AddLiquid(const LiquidInfo& info, bool fromAdt = false)
             {
                 Surface s;
                 s.z = info.level;
@@ -62,6 +63,7 @@ namespace world::terrain
                 s.liquid = info.kind;
                 s.liquidEntry = info.entry;
                 s.deep = info.deep;
+                s.fromAdt = fromAdt;
                 m_surfaces.push_back(s);
             }
 
@@ -118,17 +120,32 @@ namespace world::terrain
                 return LowestSolidAbove(z + tolerance);
             }
 
-            std::optional<Surface> HighestLiquid() const
+            std::optional<Surface> HighestLiquid(bool includeAdt = true) const
             {
                 std::optional<Surface> best;
                 for (const Surface& s : m_surfaces)
                 {
-                    if (s.kind == SurfaceKind::Liquid && (!best || s.z > best->z))
+                    if (s.kind == SurfaceKind::Liquid &&
+                        (includeAdt || !s.fromAdt) && (!best || s.z > best->z))
                     {
                         best = s;
                     }
                 }
                 return best;
+            }
+
+            /// Whether any baked model surface lies in the sweep -- the cheap
+            /// pre-test for "could this point be inside a WMO at all".
+            bool HasStatic() const
+            {
+                for (const Surface& s : m_surfaces)
+                {
+                    if (s.kind == SurfaceKind::Static)
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
 
         private:

--- a/src/shared/terrain/FusedTerrain.cpp
+++ b/src/shared/terrain/FusedTerrain.cpp
@@ -345,7 +345,7 @@ namespace world::terrain
         {
             if (auto adt = tile->LiquidAt(x, y))
             {
-                column.AddLiquid(*adt);
+                column.AddLiquid(*adt, true);
             }
         }
 


### PR DESCRIPTION
`getLiquidStatus` takes the highest liquid in the column, and the tile's ADT liquid is added unconditionally. Inside a WMO interior that is the wrong answer: the ocean surface hundreds of yards overhead wins, so a dry air pocket under the sea reports as underwater.

L'ghorek in Vashj'ir is the clearest case — the dome's interior groups carry no `MLIQ` of their own, the tile ships ocean at z = 0.0 across the whole square, and the interior sits near z = -700. Anything inside swims.

This tags tile liquid in the column so it can be told apart from liquid a model carries, and drops it when the point is inside a group flagged `MOGP` interior, keeping only what the WMO itself provides. Open water pays nothing: the check is gated on the column containing a baked model at all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/313)
<!-- Reviewable:end -->
