### PR TITLE
[Core] Use FindMap() where GetMap() is a nullability check

### DIFF
--- a/src/game/ChatCommands/DebugCommands.cpp
+++ b/src/game/ChatCommands/DebugCommands.cpp
@@ -1852,7 +1852,7 @@ bool ChatHandler::HandleDebugMinionCommand(char* /*args*/)
     {
         if (Transport* vessel = deck->Vessel())
         {
-            if (Map* sailed = vessel->GetMap())
+            if (Map* sailed = vessel->FindMap())
             {
                 DumpPetsOn(sailed, "ashore");
             }

--- a/src/game/Object/CinematicFlyover.cpp
+++ b/src/game/Object/CinematicFlyover.cpp
@@ -191,7 +191,7 @@ void CinematicFlyover::Begin()
     // which already covers the dense citadel before Map::Add.
     if (!(m_route->sequenceId == 165 && m_route->mapId == 609))
     {
-        if (Map* map = m_player->GetMap())
+        if (Map* map = m_player->FindMap())
         {
             for (uint32 i = 0; i < m_route->keyframeCount; ++i)
             {
@@ -313,7 +313,7 @@ void CinematicFlyover::Update(uint32 updateDiff)
 
     // Relocate body using Map::CreatureRelocation to trigger OnRelocated
     // and visibility updates
-    if (body->GetMap())
+    if (body->FindMap())
     {
         body->GetMap()->CreatureRelocation(body, x, y, z, o);
 
@@ -447,7 +447,7 @@ Creature* CinematicFlyover::ResolveBody() const
     }
 
     // Resolve body from map by GUID (safe against async removal)
-    if (!m_player || !m_player->GetMap())
+    if (!m_player || !m_player->FindMap())
     {
         return nullptr;
     }

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -2380,7 +2380,7 @@ bool PlayerCondition::CheckParamRequirements(Player const* pPlayer, Map const* m
                     // Case 2 (Instance map only)
                     if (!map && (pPlayer || source))
                     {
-                        map = source ? source->GetMap() : pPlayer->GetMap();
+                        map = source ? source->FindMap() : pPlayer->FindMap();
                     }
                     if (!map || !map->Instanceable())
                     {

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4606,7 +4606,7 @@ void Player::GetWorldAnchor(uint32& mapId, float& x, float& y, float& z) const
 {
     if (Transport* vessel = Transport::VesselOf(*this))
     {
-        if (Map* sailing = vessel->GetMap())
+        if (Map* sailing = vessel->FindMap())
         {
             mapId = sailing->GetId();
             x = vessel->Where().X();
@@ -4643,7 +4643,7 @@ TerrainInfo const* Player::AnchorTerrain() const
 {
     if (Transport* vessel = Transport::VesselOf(*this))
     {
-        if (Map* sailing = vessel->GetMap())
+        if (Map* sailing = vessel->FindMap())
         {
             return sailing->GetTerrain();
         }
@@ -4656,7 +4656,7 @@ void Player::GetZoneAndAreaAboardOrHere(uint32& zone, uint32& area) const
 {
     if (Transport* vessel = Transport::VesselOf(*this))
     {
-        if (Map* sailing = vessel->GetMap())
+        if (Map* sailing = vessel->FindMap())
         {
             sailing->GetTerrain()->GetZoneAndAreaId(zone, area, vessel->Where().X(),
                                                     vessel->Where().Y(), vessel->Where().Z());

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -956,7 +956,7 @@ void Unit::WriteMovementInfo(ByteBuffer& out, uint16 opcode) const
     // map's, and the client has never heard of it -- no WDT, no terrain, no id it would
     // accept -- so it gets no world position at all. It gets the vessel's guid and those
     // same coordinates as an offset, which is the only thing it can compose a position from.
-    Map* on = GetMap();
+    Map* on = FindMap();
     TransportMap* hull = on ? on->AsTransport() : NULL;
     Transport* vessel = hull ? hull->Vessel() : NULL;
 
@@ -3737,7 +3737,7 @@ Pet* Unit::GetPet() const
         if (TransportMap* hull = on->AsTransport())
         {
             Transport* vessel = hull->Vessel();
-            if (Map* sailed = vessel ? vessel->GetMap() : NULL)
+            if (Map* sailed = vessel ? vessel->FindMap() : NULL)
             {
                 if (Pet* pet = sailed->GetPet(pet_guid))
                 {

--- a/src/game/Object/WorldObjectChat.cpp
+++ b/src/game/Object/WorldObjectChat.cpp
@@ -342,7 +342,7 @@ void WorldObject::SendMessageToSet(WorldPacket* data, bool /*bToSelf*/) const
     for (Transport* vessel : vessels->second)
     {
         TransportMap* hull = vessel->AsMap();
-        if (!hull || vessel->GetMap() != GetMap())
+        if (!hull || vessel->FindMap() != FindMap())
         {
             continue;
         }

--- a/src/game/Object/WorldObjectSummon.cpp
+++ b/src/game/Object/WorldObjectSummon.cpp
@@ -234,7 +234,7 @@ GameObject* WorldObject::SummonGameObject(uint32 id, float x, float y, float z, 
 {
     GameObject* pGameObj = new GameObject;
 
-    Map *map = GetMap();
+    Map *map = FindMap();
 
     if (!map)
     {

--- a/src/game/WorldHandlers/MiscHandlerInstance.cpp
+++ b/src/game/WorldHandlers/MiscHandlerInstance.cpp
@@ -100,7 +100,7 @@ void WorldSession::HandleSetDungeonDifficultyOpcode(WorldPacket& recv_data)
     }
 
     // cannot reset while in an instance
-    Map* map = _player->GetMap();
+    Map* map = _player->FindMap();
     if (map && map->IsDungeon())
     {
         sLog.outError("WorldSession::HandleSetDungeonDifficultyOpcode: player %d tried to reset the instance while inside!", _player->GetGUIDLow());
@@ -149,7 +149,7 @@ void WorldSession::HandleSetRaidDifficultyOpcode(WorldPacket& recv_data)
     }
 
     // cannot reset while in an instance
-    Map* map = _player->GetMap();
+    Map* map = _player->FindMap();
     if (map && map->IsDungeon())
     {
         sLog.outError("WorldSession::HandleSetRaidDifficultyOpcode: player %d tried to reset the instance while inside!", _player->GetGUIDLow());

--- a/src/game/WorldHandlers/TransportMap.cpp
+++ b/src/game/WorldHandlers/TransportMap.cpp
@@ -443,7 +443,7 @@ bool TransportMap::Add(Player* passenger)
     //
     // Never while she is between two maps: she would name the one she is leaving, and he
     // would be handed a continent's worth of ships that are not on the water he can see.
-    if (Map* sailed = m_vessel->IsCrossing() ? NULL : m_vessel->GetMap())
+    if (Map* sailed = m_vessel->IsCrossing() ? NULL : m_vessel->FindMap())
     {
         MapManager::TransportsByMapType::const_iterator vessels =
             sMapMgr.m_TransportsByMap.find(sailed->GetId());
@@ -496,7 +496,7 @@ void TransportMap::Disembark(Player* passenger, float x, float y, float z, float
         return;
     }
 
-    Map* sailed = m_vessel ? m_vessel->GetMap() : NULL;
+    Map* sailed = m_vessel ? m_vessel->FindMap() : NULL;
     if (!sailed)
     {
         return;
@@ -707,7 +707,7 @@ void TransportMap::AppendCrewDestroyBlocks(UpdateData& data)
 
 void TransportMap::SendCrewMemberCreate(Creature* crew)
 {
-    if (!crew || !crew->IsInWorld() || !m_vessel || !m_vessel->GetMap())
+    if (!crew || !crew->IsInWorld() || !m_vessel || !m_vessel->FindMap())
     {
         return;
     }
@@ -779,7 +779,7 @@ void TransportMap::RetractVessel(Transport* vessel, Player* observer)
 void TransportMap::CollectRelaySources(WorldObject const* viewer, float visibility,
                                        std::vector<RelaySource>& out)
 {
-    if (!viewer || !viewer->GetMap())
+    if (!viewer || !viewer->FindMap())
     {
         return;
     }
@@ -789,7 +789,7 @@ void TransportMap::CollectRelaySources(WorldObject const* viewer, float visibili
     if (TransportMap const* hull = viewer->GetMap()->AsTransport())
     {
         Transport* vessel = hull->Vessel();
-        if (Map* sailed = vessel ? vessel->GetMap() : NULL)
+        if (Map* sailed = vessel ? vessel->FindMap() : NULL)
         {
             out.push_back({sailed, vessel->Where().X(), vessel->Where().Y(),
                            visibility + hull->HullRadius() + vessel->NodeSlack()});
@@ -807,7 +807,7 @@ void TransportMap::CollectRelaySources(WorldObject const* viewer, float visibili
     for (Transport* vessel : vessels->second)
     {
         TransportMap* hull = vessel->AsMap();
-        if (!hull || vessel->GetMap() != viewer->GetMap())
+        if (!hull || vessel->FindMap() != viewer->GetMap())
         {
             continue;
         }
@@ -826,7 +826,7 @@ void TransportMap::CollectRelaySources(WorldObject const* viewer, float visibili
 
 void TransportMap::GatherObservers()
 {
-    Map* world = m_vessel ? m_vessel->GetMap() : NULL;
+    Map* world = m_vessel ? m_vessel->FindMap() : NULL;
     if (!world)
     {
         return;

--- a/src/game/WorldHandlers/Transports.cpp
+++ b/src/game/WorldHandlers/Transports.cpp
@@ -448,7 +448,7 @@ Transport* Transport::VesselOf(WorldObject const& obj)
     //
     // A lift passenger and a vehicle rider are NOT here: their map is the world's, and the
     // seat transform is the vehicle system's business, not this one's.
-    Map* map = obj.GetMap();
+    Map* map = obj.FindMap();
     TransportMap* hull = map ? map->AsTransport() : NULL;
     return hull ? hull->Vessel() : NULL;
 }
@@ -472,7 +472,7 @@ void Transport::WithdrawFromWorld()
         m_map->ReleaseCrew();
     }
 
-    if (Map* sailed = GetMap())
+    if (Map* sailed = FindMap())
     {
         sailed->RemoveFromActive(this);
     }
@@ -792,7 +792,7 @@ void Transport::MoveToNextWayPoint()
  */
 void Transport::TeleportTransport(uint32 newMapid, float x, float y, float z)
 {
-    Map* oldMap = GetMap();
+    Map* oldMap = FindMap();
 
     // The route decided WHEN; what crossing means for anyone standing on her is not this
     // object's business and never was. Her own map is told and owns every consequence.
@@ -832,7 +832,7 @@ void Transport::CompleteCrossing()
     const uint32 newMapid = m_crossingTo;
     m_crossingTo = 0;
 
-    Map* oldMap = GetMap();
+    Map* oldMap = FindMap();
     Map* newMap = sMapMgr.CreateMap(newMapid, this);
     if (!oldMap || !newMap || oldMap == newMap)
     {

--- a/src/game/movement/MoveSplineInit.cpp
+++ b/src/game/movement/MoveSplineInit.cpp
@@ -40,7 +40,7 @@ namespace
     /// crew, pet or totem alike -- without anyone having registered it as anything.
     ObjectGuid DeckVesselGuidOf(Unit const& unit)
     {
-        if (Map* on = unit.GetMap())
+        if (Map* on = unit.FindMap())
         {
             if (TransportMap* hull = on->AsTransport())
             {


### PR DESCRIPTION
`WorldObject::GetMap()` asserts on a null `m_currMap`, so the surviving `if (Map* m = GetMap())` and `x ? x->GetMap() : NULL` sites are not guards — in a Debug build they abort exactly when the object they are guarding against is unmapped.

This switches those 26 sites to `FindMap()`, which is the accessor added for the purpose and already used in `MotionFrame`, `Pet`, `PlayerSave` and parts of `TransportMap`. Release behaviour is unchanged; this removes the Debug abort and makes the intent explicit.

Untouched: calls that were never guarded to begin with, which assume an always-mapped object rather than testing for one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/314)
<!-- Reviewable:end -->
