### PR TITLE
[CI] Fix build workflows and stale CI references

### DIFF
--- a/.github/workflows/core_linux_build.yml
+++ b/.github/workflows/core_linux_build.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build (${{ matrix.name }})
 
     env:
-      BUILD_DIR: ${{ runner.temp }}/build-${{ matrix.name }}
+      BUILD_DIR: ${{ github.workspace }}/../build-${{ matrix.name }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/core_linux_build.yml
+++ b/.github/workflows/core_linux_build.yml
@@ -32,8 +32,7 @@ jobs:
     name: Build (${{ matrix.name }})
 
     env:
-      BUILD_DIR: ${{ github.workspace }}/../build-${{ matrix.name }}
-      CCACHE_DIR: ${{ github.workspace }}/../ccache
+      BUILD_DIR: ${{ runner.temp }}/build-${{ matrix.name }}
 
     steps:
       - name: Checkout repository
@@ -53,6 +52,8 @@ jobs:
           key: linux-${{ matrix.name }}
           max-size: 500M
 
+      # Never the socket tests: they bind real listeners and dominate the
+      # suite's wall-clock. A human asks for them, CI does not.
       - name: Configure
         run: >
           cmake -S . -B "$BUILD_DIR" -G Ninja
@@ -66,8 +67,6 @@ jobs:
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
           -DWITH_TESTS=1
-          # Never the socket tests: they bind real listeners and dominate the
-          # suite's wall-clock. A human asks for them, CI does not.
           -DWITH_NET_TESTS=0
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-2022
 
     env:
-      BUILD_DIR: ${{ runner.temp }}\build-msvc
+      BUILD_DIR: ${{ github.workspace }}\..\build-msvc
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -87,6 +87,9 @@ jobs:
             echo "OPENSSL_INCLUDE_DIR=$root/include" >> "$GITHUB_ENV"
             echo "OPENSSL_CRYPTO_LIBRARY=$root/lib/VC/libcrypto64MT.lib" >> "$GITHUB_ENV"
             echo "OPENSSL_SSL_LIBRARY=$root/lib/VC/libssl64MT.lib" >> "$GITHUB_ENV"
+            # SlProWeb installs provider DLLs beside openssl.exe, while its
+            # compiled MODULESDIR still names the default installation path.
+            echo "OPENSSL_MODULES=$root/bin" >> "$GITHUB_ENV"
             echo "$root/bin" >> "$GITHUB_PATH"
           else
             echo "::error::OpenSSL developer libraries not found"

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,9 +22,7 @@ jobs:
     runs-on: windows-2022
 
     env:
-      BUILD_DIR: ${{ github.workspace }}\..\build-msvc
-      CCACHE_DIR: ${{ github.workspace }}\..\ccache
-      SCCACHE_DIR: ${{ github.workspace }}\..\sccache
+      BUILD_DIR: ${{ runner.temp }}\build-msvc
 
     steps:
       - name: Checkout repository
@@ -109,6 +107,8 @@ jobs:
           key: windows-msvc
           max-size: 500M
 
+      # Never the socket tests: they bind real listeners and dominate the
+      # suite's wall-clock. A human asks for them, CI does not.
       - name: Configure
         shell: bash
         run: >
@@ -122,8 +122,6 @@ jobs:
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
           -DWITH_TESTS=1
-          # Never the socket tests: they bind real listeners and dominate the
-          # suite's wall-clock. A human asks for them, CI does not.
           -DWITH_NET_TESTS=0
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ World of Warcraft, and all related art, images, and lore are copyright [Blizzard
 [7]: http://www.cppreference.com/ "C / C++ reference"
 [8]: https://github.com/mangos/MaNGOS/blob/master/mangosFamily.md "The MaNGOS family of Icons"
 [9]: https://discord.gg/fPxMjHS8xs "Our community hub on Discord"
-[10]: https://github.com/mangosthree/server/actions/workflows/core_build.yml "Github Actions - Linux/MAC build status"
+[10]: https://github.com/mangosthree/server/actions/workflows/core_linux_build.yml "Github Actions - Linux/MAC build status"
 [11]: https://ci.appveyor.com/project/MaNGOS/server-wtbhv/history "AppVeyor Scan - Windows build status"
 [12]: https://app.codacy.com/gh/mangosthree/server/dashboard "Codacy Code Status"
 [13]: https://www.codefactor.io/repository/github/mangosthree/server "Codefactor Code Status"


### PR DESCRIPTION
Three independent defects in the GitHub Actions build workflows. No AppVeyor configuration is touched.

**1. Six configure flags are silently discarded.**
The `Configure` step uses a YAML folded scalar (`run: >`), which joins every line into a single shell command. bash then treats the embedded `#` comment — and everything after it — as a comment, so these never reach cmake:

```
-DWITH_NET_TESTS=0 -DSOAP=1 -DSCRIPT_LIB_ELUNA=1 -DSCRIPT_LIB_SD3=1 -DPLAYERBOTS=… -DPCH=…
```

Confirmed in the job logs: the configure summary prints `Support for SOAP : No (default)` despite `-DSOAP=1` being written. Fixed by moving the comment above the step; the comment's meaning is unchanged and `run: >` is kept.

**2. The compiler cache has never persisted.**
`CCACHE_DIR` / `SCCACHE_DIR` contained `..`, which `actions/cache` rejects at save time:

```
Saving cache failed: Invalid pattern '…/…/../ccache'.
Relative pathing '.' and '..' is not allowed.
```

Every subsequent run reports `No cache found` and rebuilds cold. Measured hit rates: ccache 1.5–1.9%, sccache 0.00%. The overrides are removed so `ccache-action` manages its own directory. `BUILD_DIR` moves to `${{ runner.temp }}` rather than being deleted — it must stay outside the workspace or the "Verify the working tree is clean" step fails.

**3. Stale CI references.**
The README links `core_build.yml`, which does not exist; the workflow is `core_linux_build.yml`.

Verification: each workflow was parsed with PyYAML and the `Configure` step folded exactly as the shell receives it, asserting no `#` survives, all six flags are present, and no `..` remains in the command or in any job-level `env`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/315)
<!-- Reviewable:end -->
