### PR TITLE
[Bots] Port Bo Zimmerman's engine-layer playerbot fixes from m0

### DIFF
--- a/src/game/Object/PlayerGroup.cpp
+++ b/src/game/Object/PlayerGroup.cpp
@@ -54,6 +54,10 @@
 #include "Guild.h"
 #include "GuildMgr.h"
 #include "Pet.h"
+#ifdef ENABLE_PLAYERBOTS
+#include "playerbot.h"
+#include "PlayerbotMgr.h"
+#endif
 #include "Util.h"
 #include "Transports.h"
 #include "Weather.h"
@@ -179,6 +183,13 @@ void Player::SetGroup(Group* group, int8 subgroup)
         m_group.link(group, this);
         m_group.setSubGroup((uint8)subgroup);
     }
+
+#ifdef ENABLE_PLAYERBOTS
+    if (GetPlayerbotAI())
+    {
+        GetPlayerbotAI()->ResetStrategies();
+    }
+#endif
 }
 
 /**

--- a/src/game/Object/PlayerZone.cpp
+++ b/src/game/Object/PlayerZone.cpp
@@ -52,6 +52,10 @@
 #include "Guild.h"
 #include "GuildMgr.h"
 #include "Pet.h"
+#ifdef ENABLE_PLAYERBOTS
+#include "playerbot.h"
+#include "PlayerbotMgr.h"
+#endif
 #include "Util.h"
 #include "Transports.h"
 #include "Weather.h"
@@ -268,6 +272,10 @@ void Player::UpdateZone(uint32 newZone, uint32 newArea)
         // handle outdoor pvp zones
         sOutdoorPvPMgr.HandlePlayerLeaveZone(this, m_zoneUpdateId);
         sOutdoorPvPMgr.HandlePlayerEnterZone(this, newZone);
+
+#ifdef ENABLE_PLAYERBOTS
+        sRandomPlayerbotMgr.OnPlayerZoneChange(this, newZone);
+#endif
 
         SendInitWorldStates(newZone, newArea);              // only if really enters to new zone, not just area change, works strange...
 

--- a/src/modules/Bots/playerbot/AiFactory.cpp
+++ b/src/modules/Bots/playerbot/AiFactory.cpp
@@ -150,11 +150,6 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
 
     engine->addStrategies("racials", "chat", "default", "aoe", "potions", "cast time", "conserve mana", "duel", "pvp", NULL);
 
-    if (sPlayerbotAIConfig.cautiousDefault)
-    {
-        engine->addStrategy("cautious");
-    }
-
     switch (player->getClass())
     {
         case CLASS_PRIEST:
@@ -287,15 +282,27 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             break;
     }
 
-    if (sRandomPlayerbotMgr.IsRandomBot(player))
+    if (player->GetGroup())
     {
-        if (!player->GetGroup())
+        if (engine->ContainsStrategy(STRATEGY_TYPE_TANK))
         {
-            engine->ChangeStrategy(sPlayerbotAIConfig.randomBotCombatStrategies);
-            if (player->getClass() == CLASS_DRUID && player->getLevel() < 20)
-            {
-                engine->addStrategies("bear", NULL);
-            }
+            engine->ChangeStrategy(sPlayerbotAIConfig.botTankStrategies);
+        }
+        else if (engine->ContainsStrategy(STRATEGY_TYPE_HEAL))
+        {
+            engine->ChangeStrategy(sPlayerbotAIConfig.botHealStrategies);
+        }
+        else
+        {
+            engine->ChangeStrategy(sPlayerbotAIConfig.botDpsStrategies);
+        }
+    }
+    else if (sRandomPlayerbotMgr.IsRandomBot(player))
+    {
+        engine->ChangeStrategy(sPlayerbotAIConfig.randomBotCombatStrategies);
+        if (player->getClass() == CLASS_DRUID && player->getLevel() < 20)
+        {
+            engine->addStrategies("bear", NULL);
         }
     }
     else
@@ -313,11 +320,6 @@ Engine* AiFactory::createCombatEngine(Player* player, PlayerbotAI* const facade,
 void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const facade, Engine* nonCombatEngine)
 {
     int tab = GetPlayerSpecTab(player);
-
-    if (sPlayerbotAIConfig.cautiousDefault)
-    {
-        nonCombatEngine->addStrategy("cautious");
-    }
 
     switch (player->getClass()){
         case CLASS_PRIEST:
@@ -414,12 +416,13 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
         nonCombatEngine->removeStrategy("stay");
     }
 
-    if (sRandomPlayerbotMgr.IsRandomBot(player))
+    if (player->GetGroup())
     {
-        if (!player->GetGroup())
-        {
-            nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.randomBotNonCombatStrategies);
-        }
+        nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.botGroupNonCombatStrategies);
+    }
+    else if (sRandomPlayerbotMgr.IsRandomBot(player))
+    {
+        nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.randomBotNonCombatStrategies);
     }
     else
     {

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -179,6 +179,15 @@ PlayerbotAI::~PlayerbotAI()
  */
 void PlayerbotAI::UpdateAI(uint32 elapsed)
 {
+    if (sPlayerbotAIConfig.randomBotActiveZoneOnly &&
+        !bot->GetGroup() && sRandomPlayerbotMgr.IsRandomBot(bot) &&
+        botOutgoingPacketHandlers.IsEmpty() &&
+        !sRandomPlayerbotMgr.HasRealPlayerInZone(bot->GetZoneId()))
+    {
+        SetNextCheckDelay(5000);
+        return;
+    }
+
     if (m_eatingUntil || m_drinkingUntil)
     {
         bool finished = !IsEating() && !IsDrinking();

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -1507,6 +1507,12 @@ void PlayerbotAI::WaitForSpellCast(Spell *spell)
  */
 void PlayerbotAI::InterruptSpell()
 {
+    Spell* autoRepeat = bot->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+    if (autoRepeat)
+    {
+        bot->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+    }
+
     for (int type = CURRENT_MELEE_SPELL; type < CURRENT_CHANNELED_SPELL; type++)
     {
         Spell* spell = bot->GetCurrentSpell((CurrentSpellTypes)type);

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -796,7 +796,7 @@ bool PlayerbotAI::ContainsStrategy(StrategyType type)
  * @param type The type of the engine.
  * @return True if the strategy is present, false otherwise.
  */
-bool PlayerbotAI::HasStrategy(string name, BotState type)
+bool PlayerbotAI::HasStrategy(const string& name, BotState type)
 {
     return engines[type]->HasStrategy(name);
 }
@@ -867,6 +867,36 @@ bool PlayerbotAI::IsTank(Player* player)
 }
 
 /**
+ * Returns the tank player in a given player's group.
+ * @param except The player to check.
+ * @return the tank in the group, or null
+ */
+Player* PlayerbotAI::GetGroupTank(Player* except)
+{
+    Group* group = except->GetGroup();
+    if (!group)
+    {
+        return nullptr;
+    }
+
+    Group::MemberSlotList const& slots = group->GetMemberSlots();
+    if (slots.size() < 5)
+    {
+        return nullptr;
+    }
+
+    for (Group::member_citerator itr = slots.begin(); itr != slots.end(); ++itr)
+    {
+        Player* member = sObjectMgr.GetPlayer(itr->guid);
+        if (member && member != except && IsTank(member))
+        {
+            return member;
+        }
+    }
+    return nullptr;
+}
+
+/**
  * Checks if the player is a healer class.
  * @param player The player to check.
  * @return True if the player is a healer class, false otherwise.
@@ -885,6 +915,96 @@ bool PlayerbotAI::IsHeal(Player* player)
         return true;
     case CLASS_DRUID:
         return HasAnyAuraOf(player, "tree of life form", NULL);
+    }
+    return false;
+}
+
+bool PlayerbotAI::HasBreakableCrowdControl(Unit* unit)
+{
+    if (!unit || !unit->IsAlive())
+    {
+        return false;
+    }
+
+    if (unit->HasAuraType(SPELL_AURA_MOD_CHARM) ||
+        unit->HasAuraType(SPELL_AURA_TRANSFORM) ||
+        unit->HasAuraType(SPELL_AURA_MOD_PACIFY))
+    {
+        return true;
+    }
+
+    if (unit->isFeared() || unit->IsInRoots() || unit->IsPolymorphed())
+    {
+        return true;
+    }
+
+    static const uint32 breakableCcMechanicMask =
+        (1 << (MECHANIC_SAPPED - 1)) |
+        (1 << (MECHANIC_FREEZE - 1)) |
+        (1 << (MECHANIC_BANISH - 1)) |
+        (1 << (MECHANIC_SHACKLE - 1)) |
+        (1 << (MECHANIC_HORROR - 1)) |
+        (1 << (MECHANIC_SLEEP - 1)) |
+        (1 << (MECHANIC_TURN - 1)) |
+        (1 << (MECHANIC_DAZE - 1)) |
+        (1 << (MECHANIC_POLYMORPH - 1));
+
+    Unit::SpellAuraHolderMap const& auras = unit->GetSpellAuraHolderMap();
+    for (Unit::SpellAuraHolderMap::const_iterator itr = auras.begin();
+         itr != auras.end(); ++itr)
+    {
+        if (itr->second->HasMechanicMask(breakableCcMechanicMask))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/*
+ * Uses the bots in-range unfriendlys as a pool to determine if
+ * the given center point (or the bots position) has any unfriendlys
+ * within the given range of that point. Such npcs would have to be
+ * non-combatants, and non-cced.
+ */
+bool PlayerbotAI::HasNonCombatantInRange(float range,
+    float centerX, float centerY, float centerZ)
+{
+    // Find nearby unfriendly units using grid search
+    list<Unit*> targets;
+    MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(bot, range);
+    MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    Cell::VisitAllObjects(bot, searcher, range);
+
+    for (list<Unit*>::iterator i = targets.begin(); i != targets.end(); ++i)
+    {
+        Unit* unit = *i;
+        if (!unit || !unit->IsAlive())
+        {
+            continue;
+        }
+        // Check distance from center point (bot position by default, or explicit coords)
+        float dist;
+        if (centerX != 0 || centerY != 0 || centerZ != 0)
+        {
+            float dx = unit->GetPositionX() - centerX;
+            float dy = unit->GetPositionY() - centerY;
+            float dz = unit->GetPositionZ() - centerZ;
+            dist = sqrt(dx * dx + dy * dy + dz * dz);
+        }
+        else
+        {
+            dist = bot->GetDistance(unit);
+        }
+        if (dist > range || unit->hasUnitState(UNIT_STAT_STUNNED))
+        {
+            continue;
+        }
+        if (HasBreakableCrowdControl(unit) || !unit->getVictim()) // do not aggro, or break cc
+        {
+            return true;
+        }
     }
     return false;
 }

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -131,6 +131,7 @@ PlayerbotAI::PlayerbotAI(Player* bot) :
     masterIncomingPacketHandlers.AddHandler(CMSG_SPIRIT_HEALER_ACTIVATE, "master spirit healer");
 
     botOutgoingPacketHandlers.AddHandler(SMSG_GUILD_INVITE, "guild invite");
+    botOutgoingPacketHandlers.AddHandler(SMSG_PETITION_SHOW_SIGNATURES, "petition sign");
     botOutgoingPacketHandlers.AddHandler(SMSG_GROUP_INVITE, "group invite");
     botOutgoingPacketHandlers.AddHandler(BUY_ERR_NOT_ENOUGHT_MONEY, "not enough money");
     botOutgoingPacketHandlers.AddHandler(BUY_ERR_REPUTATION_REQUIRE, "not enough reputation");

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -85,6 +85,10 @@ public:
     void AddHandler(uint16 opcode, string handler);
     void Handle(ExternalEventHelper &helper);
     void AddPacket(const WorldPacket& packet);
+    bool IsEmpty()
+    {
+        return queue.size() == 0;
+    }
 
 private:
     map<uint16, string> handlers;

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -146,13 +146,16 @@ public:
     void ClearStrategies(BotState type) const;
     list<string> GetStrategies(BotState type) const;
     bool ContainsStrategy(StrategyType type);
-    bool HasStrategy(string name, BotState type);
-    bool HasStrategy(string name) { return HasStrategy(name, currentState); }
+    bool HasStrategy(const string& name, BotState type);
+    bool HasStrategy(const string& name) { return HasStrategy(name, currentState); }
     BotState GetState() const { return currentState; }
     void ResetStrategies();
     void ReInitCurrentEngine();
     void Reset();
     bool IsTank(Player* player);
+    Player* GetGroupTank(Player* except);
+    bool HasNonCombatantInRange(float range, float centerX = 0, float centerY = 0, float centerZ = 0);
+    bool HasBreakableCrowdControl(Unit* unit);
     bool IsHeal(Player* player);
     bool IsRanged(Player* player);
     Creature* GetCreature(ObjectGuid guid);

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -148,6 +148,7 @@ public:
     bool ContainsStrategy(StrategyType type);
     bool HasStrategy(string name, BotState type);
     bool HasStrategy(string name) { return HasStrategy(name, currentState); }
+    BotState GetState() const { return currentState; }
     void ResetStrategies();
     void ReInitCurrentEngine();
     void Reset();

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -70,6 +70,7 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       maxRandomBotsPriceChangeInterval(0),
       randomBotJoinLfg(false),
       randomBotLoginAtStartup(false),
+      randomBotKeepGroups(false),
       randomBotActiveZoneOnly(false),
       randomBotTeleLevel(0),
       feralBearTankChance(0),
@@ -225,6 +226,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMinLevel = config.GetIntDefault("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
     randomBotLoginAtStartup = config.GetBoolDefault("AiPlayerbot.RandomBotLoginAtStartup", true);
+    randomBotKeepGroups = config.GetBoolDefault("AiPlayerbot.RandomBotKeepGroups", false);
     randomBotActiveZoneOnly = config.GetBoolDefault("AiPlayerbot.RandomBotActiveZoneOnly", false);
     randomBotTeleLevel = config.GetIntDefault("AiPlayerbot.RandomBotTeleLevel", 3);
     openGoSpell = config.GetIntDefault("AiPlayerbot.OpenGoSpell", 6477);

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -34,6 +34,7 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       whisperDistance(0.0f),
       contactDistance(0.0f),
       aoeRadius(0.0f),
+      whisperToZoneOnly(false),
       criticalHealth(0),
       lowHealth(0),
       mediumHealth(0),
@@ -170,6 +171,7 @@ bool PlayerbotAIConfig::Initialize()
     whisperDistance = config.GetFloatDefault("AiPlayerbot.WhisperDistance", 6000.0f);
     contactDistance = config.GetFloatDefault("AiPlayerbot.ContactDistance", 0.5f);
     aoeRadius = config.GetFloatDefault("AiPlayerbot.AoeRadius", 10.0f);
+    whisperToZoneOnly = config.GetBoolDefault("AiPlayerbot.WhisperToZoneOnly", false);
 
     criticalHealth = config.GetIntDefault("AiPlayerbot.CriticalHealth", 20);
     lowHealth = config.GetIntDefault("AiPlayerbot.LowHealth", 50);

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -100,7 +100,9 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       minGuildTaskRewardTime(0),
       maxGuildTaskRewardTime(0),
       guildTaskAdvertCleanupTime(0),
-      iterationsPerTick(0)
+      iterationsPerTick(0),
+      tankDelaySeconds(0),
+      tankThreatPct(0.0f)
 {
 }
 
@@ -187,6 +189,8 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMaxLevelChance = config.GetFloatDefault("AiPlayerbot.RandomBotMaxLevelChance", 0.15);
 
     iterationsPerTick = config.GetIntDefault("AiPlayerbot.IterationsPerTick", 100);
+    tankDelaySeconds = config.GetIntDefault("AiPlayerbot.TankDelaySeconds", 3);
+    tankThreatPct = config.GetFloatDefault("AiPlayerbot.TankThreatPct", 2.0f);
 
     allowGuildBots = config.GetBoolDefault("AiPlayerbot.AllowGuildBots", true);
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -70,6 +70,7 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       maxRandomBotsPriceChangeInterval(0),
       randomBotJoinLfg(false),
       randomBotLoginAtStartup(false),
+      randomBotActiveZoneOnly(false),
       randomBotTeleLevel(0),
       feralBearTankChance(0),
       logInGroupOnly(false),
@@ -224,6 +225,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMinLevel = config.GetIntDefault("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
     randomBotLoginAtStartup = config.GetBoolDefault("AiPlayerbot.RandomBotLoginAtStartup", true);
+    randomBotActiveZoneOnly = config.GetBoolDefault("AiPlayerbot.RandomBotActiveZoneOnly", false);
     randomBotTeleLevel = config.GetIntDefault("AiPlayerbot.RandomBotTeleLevel", 3);
     openGoSpell = config.GetIntDefault("AiPlayerbot.OpenGoSpell", 6477);
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -243,6 +243,11 @@ bool PlayerbotAIConfig::Initialize()
 
     commandPrefix = config.GetStringDefault("AiPlayerbot.CommandPrefix", "");
 
+    {
+        std::string name = "RandomMovementTargets";
+        SetValue(name, config.GetStringDefault("AiPlayerbot.RandomMovementTargets", "anynpcs,anyitems,random"));
+    }
+
     commandServerPort = config.GetIntDefault("AiPlayerbot.CommandServerPort", 0);
 
     // Load class spec probabilities from the configuration file
@@ -384,6 +389,11 @@ string PlayerbotAIConfig::GetValue(string name) const
         out << iterationsPerTick;
     }
 
+    else if (name == "RandomMovementTargets")
+    {
+        out << randomMovementTargetsAsString;
+    }
+
     return out.str();
 }
 
@@ -462,5 +472,33 @@ void PlayerbotAIConfig::SetValue(string &name, string value)
     else if (name == "IterationsPerTick")
     {
         out >> iterationsPerTick;
+    }
+
+    else if (name == "RandomMovementTargets")
+    {
+        randomMovementTargetsAsString = value;
+        randomMovementTargets.clear();
+        std::vector<std::string> tokens = split(value, ',');
+        std::set<std::string> validTargets = { "usefulnpcs", "anynpcs", "players", "tradeskillitems", "interactableitems", "anyitems", "random" };
+        for (std::vector<std::string>::iterator i = tokens.begin(); i != tokens.end(); ++i)
+        {
+            std::string token = *i;
+            size_t start = token.find_first_not_of(" \t");
+            size_t end = token.find_last_not_of(" \t");
+            if (start == std::string::npos)
+            {
+                continue;
+            }
+            token = token.substr(start, end - start + 1);
+            std::string lowerToken = token;
+            for (size_t j = 0; j < lowerToken.size(); ++j)
+            {
+                lowerToken[j] = static_cast<char>(tolower(static_cast<unsigned char>(lowerToken[j])));
+            }
+            if (validTargets.find(lowerToken) != validTargets.end())
+            {
+                randomMovementTargets.push_back(lowerToken);
+            }
+        }
     }
 }

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -77,7 +77,6 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       logInGroupOnly(false),
       logValuesPerTick(false),
       fleeingEnabled(false),
-      cautiousDefault(false),
       spawnZoneStats(false),
       randomBotMinLevel(0),
       randomBotMaxLevel(0),
@@ -221,7 +220,6 @@ bool PlayerbotAIConfig::Initialize()
     logInGroupOnly = config.GetBoolDefault("AiPlayerbot.LogInGroupOnly", true);
     logValuesPerTick = config.GetBoolDefault("AiPlayerbot.LogValuesPerTick", false);
     fleeingEnabled = config.GetBoolDefault("AiPlayerbot.FleeingEnabled", true);
-    cautiousDefault = config.GetBoolDefault("AiPlayerbot.Cautious", false);
     spawnZoneStats = config.GetBoolDefault("AiPlayerbot.SpawnZoneStats", false);
     randomBotMinLevel = config.GetIntDefault("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
@@ -237,6 +235,11 @@ bool PlayerbotAIConfig::Initialize()
     randomBotNonCombatStrategies = config.GetStringDefault("AiPlayerbot.RandomBotNonCombatStrategies", "+grind,+move random,+loot");
     combatStrategies = config.GetStringDefault("AiPlayerbot.CombatStrategies", "+custom::say");
     nonCombatStrategies = config.GetStringDefault("AiPlayerbot.NonCombatStrategies", "+custom::say");
+    botTankStrategies = config.GetStringDefault("AiPlayerbot.BotTankStrategies", "+tank aoe");
+    botDpsStrategies = config.GetStringDefault("AiPlayerbot.BotDpsStrategies", "+dps assist");
+    botHealStrategies = config.GetStringDefault("AiPlayerbot.BotHealStrategies", "");
+    // m3 registers the follow strategy as "follow" (m0: "follow master") -- align the default.
+    botGroupNonCombatStrategies = config.GetStringDefault("AiPlayerbot.BotGroupNonCombatStrategies", "+follow,+loot");
 
     commandPrefix = config.GetStringDefault("AiPlayerbot.CommandPrefix", "");
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -83,6 +83,7 @@ public:
     uint32 minRandomBotsPriceChangeInterval, maxRandomBotsPriceChangeInterval;
     bool randomBotJoinLfg; ///< Indicates if random bots should join Looking For Group.
     bool randomBotLoginAtStartup; ///< Indicates if random bots should login at startup.
+    bool randomBotActiveZoneOnly; ///< If true, ungrouped random bots only tick when a real player is in their zone.
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;
     bool fleeingEnabled; ///< Indicates if fleeing is enabled for bots.

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -88,9 +88,9 @@ public:
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;
     bool fleeingEnabled; ///< Indicates if fleeing is enabled for bots.
-    bool cautiousDefault; ///< If true, all bots get the "cautious" strategy (avoid pulling aggro while moving) by default.
     bool spawnZoneStats;  ///< If true, scan all creatures once to level-band bot spawn zones. Expensive (multi-second world-thread scan); off by default.
     std::string combatStrategies, nonCombatStrategies;
+    std::string botTankStrategies, botDpsStrategies, botHealStrategies, botGroupNonCombatStrategies; ///< Role-based strategy strings applied to grouped bots.
     std::string randomBotCombatStrategies, randomBotNonCombatStrategies;
     uint32 randomBotMinLevel, randomBotMaxLevel;
     float randomChangeMultiplier;

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -125,6 +125,9 @@ public:
 
     int commandServerPort; ///< Port for the command server.
 
+    uint32 tankDelaySeconds; ///< Grouped cautious DPS wait this long after the tank engages before attacking (0 = disabled).
+    float tankThreatPct; ///< Grouped cautious DPS wait until the tank has this % of target max HP in threat (0 = disabled).
+
     /**
      * @brief Gets the value of a configuration parameter by name.
      * @param name The name of the configuration parameter.

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -56,6 +56,7 @@ public:
     float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, shootDistance,
         fleeDistance, tooCloseDistance, meleeDistance, followDistance, whisperDistance, contactDistance,
         aoeRadius;
+    bool whisperToZoneOnly; ///< Restricts suggestion whispers to players in the bot's zone.
     uint32 criticalHealth, lowHealth, mediumHealth, almostFullHealth, hungryHealth;
     uint32 lowMana, mediumMana, thirstyMana;
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -120,6 +120,9 @@ public:
 
     uint32 iterationsPerTick; ///< Number of iterations per tick.
 
+    std::string randomMovementTargetsAsString; ///< Comma-separated string of random movement targets.
+    std::vector<std::string> randomMovementTargets; ///< List of validated random movement targets, priority order.
+
     int commandServerPort; ///< Port for the command server.
 
     /**

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -83,6 +83,7 @@ public:
     uint32 minRandomBotsPriceChangeInterval, maxRandomBotsPriceChangeInterval;
     bool randomBotJoinLfg; ///< Indicates if random bots should join Looking For Group.
     bool randomBotLoginAtStartup; ///< Indicates if random bots should login at startup.
+    bool randomBotKeepGroups; ///< Indicates if random bots should preserve groups across restarts.
     bool randomBotActiveZoneOnly; ///< If true, ungrouped random bots only tick when a real player is in their zone.
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -55,6 +55,15 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed)
         return;
     }
 
+    if (sPlayerbotAIConfig.randomBotKeepGroups)
+    {
+        if (!processTicks)
+        {
+            EnsureGroupedBotsOnline();
+        }
+        LoadGroupedBots();
+    }
+
     sLog.outBasic("Processing random bots...");
 
     uint32 cachedMin = GetEventValue(0, "config_min");
@@ -260,8 +269,15 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         Player* player = GetPlayerBot(bot);
         if (!player || !player->GetGroup())
         {
-            sLog.outString("Bot %d expired", bot);
-            SetEventValue(bot, "add", 0, 0);
+            if (sPlayerbotAIConfig.randomBotKeepGroups && m_groupedBots.count(bot))
+            {
+                SetEventValue(bot, "add", 1, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+            }
+            else
+            {
+                sLog.outString("Bot %d expired", bot);
+                SetEventValue(bot, "add", 0, 0);
+            }
         }
         return true;
     }
@@ -1007,6 +1023,77 @@ bool RandomPlayerbotMgr::IsZoneSafeForBot(Player* bot, uint32 mapId, float x, fl
             return false;
     }
     return true;
+}
+
+QueryResult* RandomPlayerbotMgr::QueryGroupedBots()
+{
+    if (sPlayerbotAIConfig.randomBotAccounts.empty())
+    {
+        return nullptr;
+    }
+
+    ostringstream os;
+    bool first = true;
+    for (list<uint32>::iterator i = sPlayerbotAIConfig.randomBotAccounts.begin(); i != sPlayerbotAIConfig.randomBotAccounts.end(); ++i)
+    {
+        if (!first)
+        {
+            os << ",";
+        }
+        os << *i;
+        first = false;
+    }
+
+    return CharacterDatabase.PQuery(
+        "SELECT gm.`memberGuid` FROM `group_member` gm "
+        "INNER JOIN `characters` c ON gm.`memberGuid` = c.`guid` "
+        "INNER JOIN `groups` g ON gm.`groupId` = g.`groupId` "
+        "WHERE c.`account` IN (%s)",
+        os.str().c_str());
+}
+
+void RandomPlayerbotMgr::LoadGroupedBots()
+{
+    m_groupedBots.clear();
+    QueryResult* result = QueryGroupedBots();
+    if (!result)
+    {
+        return;
+    }
+
+    do
+    {
+        Field* fields = result->Fetch();
+        m_groupedBots.insert(fields[0].GetUInt32());
+    } while (result->NextRow());
+    delete result;
+}
+
+void RandomPlayerbotMgr::EnsureGroupedBotsOnline()
+{
+    QueryResult* result = QueryGroupedBots();
+    if (!result)
+    {
+        return;
+    }
+
+    uint32 count = 0;
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 botGuid = fields[0].GetUInt32();
+        if (!GetEventValue(botGuid, "add"))
+        {
+            SetEventValue(botGuid, "add", 1, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+            count++;
+        }
+    } while (result->NextRow());
+    delete result;
+
+    if (count > 0)
+    {
+        sLog.outString("Queued %u grouped bot(s) for login at startup", count);
+    }
 }
 
 uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -1013,6 +1013,16 @@ uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)
 {
     uint32 value = 0;
 
+    std::pair<uint32, std::string> key(bot, event);
+    std::map<std::pair<uint32, std::string>, EventValueEntry>::iterator cacheIt = m_eventValueCache.find(key);
+    if (cacheIt != m_eventValueCache.end())
+    {
+        if (((uint32)time(0) - cacheIt->second.lastChangeTime) < cacheIt->second.validIn)
+        {
+            return cacheIt->second.value;
+        }
+    }
+
     // Query the database to get the event value for the specified bot
     QueryResult* results = CharacterDatabase.PQuery(
             "SELECT `value`, `time`, `validIn` FROM `ai_playerbot_random_bots` WHERE `owner` = 0 AND `bot` = '%u' AND `event` = '%s'",
@@ -1028,6 +1038,7 @@ uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)
         {
             value = 0;
         }
+        m_eventValueCache[key] = { value, lastChangeTime, validIn };
         delete results;
     }
 
@@ -1051,6 +1062,8 @@ uint32 RandomPlayerbotMgr::SetEventValue(uint32 bot, string event, uint32 value,
     {
         m_randomBotCache[bot] = (value != 0);
     }
+
+    m_eventValueCache[std::make_pair(bot, event)] = { value, (uint32)time(0), validIn };
 
     return value;
 }
@@ -1312,6 +1325,20 @@ void RandomPlayerbotMgr::OnPlayerLogout(Player* player)
         {
             players.erase(i);
         }
+
+        uint32 zone = player->GetZoneId();
+        std::unordered_map<uint32, uint32>::iterator zi = m_playerZoneCounts.find(zone);
+        if (zi != m_playerZoneCounts.end())
+        {
+            if (zi->second <= 1)
+            {
+                m_playerZoneCounts.erase(zi);
+            }
+            else
+            {
+                zi->second--;
+            }
+        }
     }
 }
 
@@ -1351,6 +1378,43 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
         players.push_back(player);
         sLog.outDebug("Including non-random bot player %s into random bot update", player->GetName());
     }
+}
+
+void RandomPlayerbotMgr::OnPlayerZoneChange(Player* player, uint32 newZone)
+{
+    // PlayerbotAI is not set yet when this is called on bot login, so also
+    // check IsRandomBot directly -- a null-socket bot session never matches
+    // a "bot" remote address the way m0's guard assumed.
+    if (player->GetPlayerbotAI() || sRandomPlayerbotMgr.IsRandomBot(player))
+    {
+        return;
+    }
+
+    uint32 oldZone = player->GetCachedZoneId();
+    if (oldZone == newZone)
+    {
+        return;
+    }
+
+    std::unordered_map<uint32, uint32>::iterator zi = m_playerZoneCounts.find(oldZone);
+    if (zi != m_playerZoneCounts.end())
+    {
+        if (zi->second <= 1)
+        {
+            m_playerZoneCounts.erase(zi);
+        }
+        else
+        {
+            zi->second--;
+        }
+    }
+    m_playerZoneCounts[newZone]++;
+}
+
+bool RandomPlayerbotMgr::HasRealPlayerInZone(uint32 zoneId) const
+{
+    std::unordered_map<uint32, uint32>::const_iterator zi = m_playerZoneCounts.find(zoneId);
+    return zi != m_playerZoneCounts.end() && zi->second > 0;
 }
 
 Player* RandomPlayerbotMgr::GetRandomPlayer()

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -11,6 +11,7 @@ class Player;
 class Unit;
 class Object;
 class Item;
+class QueryResult;
 
 using namespace std;
 /**
@@ -197,6 +198,13 @@ class RandomPlayerbotMgr : public PlayerbotHolder
          */
         void RandomTeleportForLevel(Player* bot);
 
+        /// Queues every bot in a persisted group for login (used when AiPlayerbot.RandomBotKeepGroups is set).
+        void EnsureGroupedBotsOnline();
+        /// Refreshes m_groupedBots from the character DB.
+        void LoadGroupedBots();
+        /// Underlying query shared by EnsureGroupedBotsOnline/LoadGroupedBots.
+        QueryResult* QueryGroupedBots();
+
         /**
          * @brief Teleports the given player bot to a random location.
          * @param bot Pointer to the player bot.
@@ -309,6 +317,7 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         bool m_areaCreatureStatsComputed = false; ///< Guards the one-time area-stats scan so an empty result is not recomputed every call.
         std::unordered_map<uint32, bool> m_randomBotCache; ///< Caches IsRandomBot("add") lookups to avoid a DB query per call; kept coherent in SetEventValue.
         std::unordered_map<uint32, uint32> m_playerZoneCounts; ///< zone_id -> real player count, for O(1) bot tick gating.
+        std::set<uint32> m_groupedBots; ///< Cached set of bot GUIDs currently in a group, refreshed each update cycle.
 
         /// Cached mirror of one `ai_playerbot_random_bots` row.
         struct EventValueEntry

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -4,6 +4,7 @@
 #include "Common.h"
 #include "PlayerbotAIBase.h"
 #include "PlayerbotMgr.h"
+#include <unordered_map>
 
 class WorldPacket;
 class Player;
@@ -127,6 +128,16 @@ class RandomPlayerbotMgr : public PlayerbotHolder
          * @param player Pointer to the player.
          */
         void OnPlayerLogin(Player* player);
+
+        /**
+         * @brief Updates zone-population bookkeeping when a player changes zone.
+         * @param player Pointer to the player.
+         * @param newZone The zone the player is entering.
+         */
+        void OnPlayerZoneChange(Player* player, uint32 newZone);
+
+        /// True if at least one real (non-bot) player is currently in the given zone.
+        bool HasRealPlayerInZone(uint32 zoneId) const;
 
         /**
          * @brief Gets a random player.
@@ -297,6 +308,16 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         std::map<std::pair<uint32, uint32>, uint32> m_cellToAreaCache;
         bool m_areaCreatureStatsComputed = false; ///< Guards the one-time area-stats scan so an empty result is not recomputed every call.
         std::unordered_map<uint32, bool> m_randomBotCache; ///< Caches IsRandomBot("add") lookups to avoid a DB query per call; kept coherent in SetEventValue.
+        std::unordered_map<uint32, uint32> m_playerZoneCounts; ///< zone_id -> real player count, for O(1) bot tick gating.
+
+        /// Cached mirror of one `ai_playerbot_random_bots` row.
+        struct EventValueEntry
+        {
+            uint32 value;
+            uint32 lastChangeTime;
+            uint32 validIn;
+        };
+        std::map<std::pair<uint32, std::string>, EventValueEntry> m_eventValueCache; ///< (bot, event) -> cached value, avoids a DB query per GetEventValue call.
         std::set<uint32> m_allianceGuardAreas; ///< Contested areas whose guards are hostile to Horde; Horde bots are kept out.
         std::set<uint32> m_hordeGuardAreas;    ///< Contested areas whose guards are hostile to Alliance; Alliance bots are kept out.
 };

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -91,9 +91,6 @@ AiPlayerbot.CommandPrefix = ~
 # Bot can flee for enemy
 #AiPlayerbot.FleeingEnabled = 1
 
-# Bot avoids pulling aggro during movement by default
-#AiPlayerbot.Cautious = 0
-
 # Restrict random-bot spawns to zones whose creature level band fits the bot.
 # WARNING: this scans every creature in the world once (tens of seconds of
 # world-thread work on a full DB) the first time a bot picks a spawn, which
@@ -117,6 +114,12 @@ AiPlayerbot.CommandPrefix = ~
 # Random bot default strategies (applied after defaults)
 #AiPlayerbot.RandomBotCombatStrategies = +dps,+attack weak
 #AiPlayerbot.RandomBotNonCombatStrategies = +grind,+move random,+loot
+
+# Group strategies (applied by role to all bots when in a group, replacing solo strategies)
+#AiPlayerbot.BotTankStrategies = +tank aoe
+#AiPlayerbot.BotDpsStrategies = +dps assist
+#AiPlayerbot.BotHealStrategies =
+#AiPlayerbot.BotGroupNonCombatStrategies = +follow,+loot
 
 # Create random bot characters automatically
 #AiPlayerbot.RandomBotAutoCreate = 1

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -186,6 +186,10 @@ AiPlayerbot.CommandPrefix = ~
 # Enable LFG for random bots
 #AiPlayerbot.RandomBotJoinLfg = 1
 
+# Only tick ungrouped random bots when a real player is in their zone.
+# Reduces CPU load on empty zones at the cost of bots being frozen there.
+#AiPlayerbot.RandomBotActiveZoneOnly = 0
+
 # Level diff between random bots and nearby creatures for random teleports
 AiPlayerbot.RandomBotTeleLevel = 3
 

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -88,6 +88,19 @@ AiPlayerbot.CommandPrefix = ~
 #AiPlayerbot.WhisperToZoneOnly = false
 #AiPlayerbot.ContactDistance = 0.5
 
+# Random movement target priority (comma-separated, earlier = higher weight)
+# Valid types: usefulnpcs, anynpcs, players, tradeskillitems, interactableitems, anyitems, random
+#   usefulnpcs       = NPCs with service flags (bankers, vendors, quest givers, trainers, ...)
+#   anynpcs          = any friendly NPC including non-interactable critters
+#   players          = other player characters (including bots)
+#   tradeskillitems  = game objects matching bot's tradeskills (mining, herbalism, etc.)
+#   interactableitems= chests, quest items, usable objects (type-based filter)
+#   anyitems         = any game object including decorative
+#   random           = random position in the area
+# Omitting a type from the list excludes it as a possible target entirely
+# Example: AiPlayerbot.RandomMovementTargets = anynpcs,anyitems,random
+#AiPlayerbot.RandomMovementTargets = anynpcs,anyitems,random
+
 # Bot can flee for enemy
 #AiPlayerbot.FleeingEnabled = 1
 

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -186,6 +186,9 @@ AiPlayerbot.CommandPrefix = ~
 # Enable LFG for random bots
 #AiPlayerbot.RandomBotJoinLfg = 1
 
+# Preserve bot group assignments across server restarts
+#AiPlayerbot.RandomBotKeepGroups = 0
+
 # Only tick ungrouped random bots when a real player is in their zone.
 # Reduces CPU load on empty zones at the cost of bots being frozen there.
 #AiPlayerbot.RandomBotActiveZoneOnly = 0

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -209,6 +209,16 @@ AiPlayerbot.CommandPrefix = ~
 # Reduces CPU load on empty zones at the cost of bots being frozen there.
 #AiPlayerbot.RandomBotActiveZoneOnly = 0
 
+# DPS bots in a group with a tank will wait before engaging.
+# Only applies when the "cautious" strategy is active on the bot.
+# TankDelaySeconds: wait N seconds after tank first hits the target
+# (0 = disabled)
+# TankThreatPct: wait until tank has threat >= N% of target max HP
+# (0 = disabled)
+# Both conditions must be met if both are nonzero.
+#AiPlayerbot.TankDelaySeconds = 3
+#AiPlayerbot.TankThreatPct = 2.0
+
 # Level diff between random bots and nearby creatures for random teleports
 AiPlayerbot.RandomBotTeleLevel = 3
 

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -84,6 +84,8 @@ AiPlayerbot.CommandPrefix = ~
 #AiPlayerbot.MeleeDistance = 1.0
 #AiPlayerbot.FollowDistance = 1.5
 #AiPlayerbot.WhisperDistance = 6000.0
+# If enabled, bot suggestion whispers will only target players in the same zone
+#AiPlayerbot.WhisperToZoneOnly = false
 #AiPlayerbot.ContactDistance = 0.5
 
 # Bot can flee for enemy

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -413,7 +413,7 @@ void Engine::toggleStrategy(string name)
 }
 
 // Checks if the engine has a specific strategy
-bool Engine::HasStrategy(string name)
+bool Engine::HasStrategy(const string& name)
 {
     return strategies.find(name) != strategies.end();
 }

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -608,6 +608,8 @@ void Engine::ChangeStrategy(string &names)
     vector<string> splitted = split(names, ',');
     for (vector<string>::iterator i = splitted.begin(); i != splitted.end(); i++)
     {
+        i->erase(0, i->find_first_not_of(" \t"));
+        i->erase(i->find_last_not_of(" \t") + 1);
         const char* name = i->c_str();
         switch (name[0])
         {

--- a/src/modules/Bots/playerbot/strategy/Engine.h
+++ b/src/modules/Bots/playerbot/strategy/Engine.h
@@ -90,7 +90,7 @@ namespace ai
         void addStrategy(string name);
         void addStrategies(string first, ...);
         bool removeStrategy(string name);
-        bool HasStrategy(string name);
+        bool HasStrategy(const string& name);
         void removeAllStrategies();
         void toggleStrategy(string name);
         std::string ListStrategies();

--- a/src/modules/Bots/playerbot/strategy/ItemVisitors.h
+++ b/src/modules/Bots/playerbot/strategy/ItemVisitors.h
@@ -296,6 +296,7 @@ namespace ai
         virtual bool Accept(const ItemPrototype* proto)
         {
             return proto->Class == ITEM_CLASS_CONSUMABLE &&
+                   proto->SubClass != ITEM_SUBCLASS_BANDAGE &&
                    proto->Spells[0].SpellCategory == spellCategory;
         }
     private:

--- a/src/modules/Bots/playerbot/strategy/StrategyContext.h
+++ b/src/modules/Bots/playerbot/strategy/StrategyContext.h
@@ -29,6 +29,7 @@
 #include "generic/AttackEnemyPlayersStrategy.h"
 #include "generic/MoveRandomStrategy.h"
 #include "generic/CautiousStrategy.h"
+#include "generic/DpsTanksTargetStrategy.h"
 
 namespace ai
 {
@@ -116,6 +117,7 @@ namespace ai
         AssistStrategyContext() : NamedObjectContext<Strategy>(false, true)
         {
             creators["dps assist"] = &AssistStrategyContext::dps_assist;
+            creators["dps tanks"] = &AssistStrategyContext::dps_tanks_target;
             creators["tank aoe"] = &AssistStrategyContext::tank_aoe;
             creators["grind"] = &AssistStrategyContext::grind;
         }
@@ -124,6 +126,7 @@ namespace ai
         static Strategy* dps_assist(PlayerbotAI* ai) { return new DpsAssistStrategy(ai); }
         static Strategy* tank_aoe(PlayerbotAI* ai) { return new TankAoeStrategy(ai); }
         static Strategy* grind(PlayerbotAI* ai) { return new GrindingStrategy(ai); }
+        static Strategy* dps_tanks_target(PlayerbotAI* ai) { return new DpsTanksTargetStrategy(ai); }
     };
 
     class QuestStrategyContext : public NamedObjectContext<Strategy>

--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -69,6 +69,7 @@ namespace ai
             creators["move to loot"] = &ActionContext::move_to_loot;
             creators["open loot"] = &ActionContext::open_loot;
             creators["guard"] = &ActionContext::guard;
+            creators["goto"] = &ActionContext::goto_action;
             creators["move out of enemy contact"] = &ActionContext::move_out_of_enemy_contact;
             creators["set facing"] = &ActionContext::set_facing;
             creators["swim to surface"] = &ActionContext::swim_to_surface;
@@ -89,6 +90,7 @@ namespace ai
         static Action* drop_target(PlayerbotAI* ai) { return new DropTargetAction(ai); }
         static Action* attack_duel_opponent(PlayerbotAI* ai) { return new AttackDuelOpponentAction(ai); }
         static Action* guard(PlayerbotAI* ai) { return new GuardAction(ai); }
+        static Action* goto_action(PlayerbotAI* ai) { return new GotoAction(ai); }
         static Action* open_loot(PlayerbotAI* ai) { return new OpenLootAction(ai); }
         static Action* move_to_loot(PlayerbotAI* ai) { return new MoveToLootAction(ai); }
         static Action* move_random(PlayerbotAI* ai) { return new MoveRandomAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -61,6 +61,7 @@ namespace ai
             creators["stay"] = &ActionContext::stay;
             creators["attack anything"] = &ActionContext::attack_anything;
             creators["attack least hp target"] = &ActionContext::attack_least_hp_target;
+            creators["attack tanks target"] = &ActionContext::attack_tanks_target;
             creators["attack enemy player"] = &ActionContext::enemy_player_target;
             creators["emote"] = &ActionContext::emote;
             creators["suggest what to do"] = &ActionContext::suggest_what_to_do;
@@ -110,6 +111,7 @@ namespace ai
         static Action* suggest_trade(PlayerbotAI* ai) { return new SuggestTradeAction(ai); }
         static Action* attack_anything(PlayerbotAI* ai) { return new AttackAnythingAction(ai); }
         static Action* attack_least_hp_target(PlayerbotAI* ai) { return new AttackLeastHpTargetAction(ai); }
+        static Action* attack_tanks_target(PlayerbotAI* ai) { return new AttackTanksTargetAction(ai); }
         static Action* enemy_player_target(PlayerbotAI* ai) { return new AttackEnemyPlayerAction(ai); }
         static Action* stay(PlayerbotAI* ai) { return new StayAction(ai); }
         static Action* runaway(PlayerbotAI* ai) { return new RunAwayAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/actions/AttackAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/AttackAction.cpp
@@ -4,6 +4,7 @@
 #include "MovementGenerator.h"
 #include "CreatureAI.h"
 #include "../../LootObjectStack.h"
+#include "ThreatManager.h"
 
 using namespace ai;
 
@@ -17,6 +18,54 @@ bool AttackAction::Execute(Event event)
     }
 
     return Attack(target);
+}
+
+bool AttackAction::isUseful()
+{
+    if (!bot->GetGroup() || !ai->HasStrategy("cautious") ||
+       (sPlayerbotAIConfig.tankDelaySeconds == 0 && sPlayerbotAIConfig.tankThreatPct == 0.0f) ||
+       ai->IsTank(bot))
+    {
+        return true;
+    }
+
+    Player* tank = ai->GetGroupTank(bot);
+    Unit* target = GetTarget();
+    if (!tank || !tank->getVictim() || !target || tank->getVictim() != target)
+    {
+        return true;
+    }
+
+    float tankThreat = target->GetThreatManager().getThreat(tank);
+    if (sPlayerbotAIConfig.tankDelaySeconds > 0)
+    {
+        if (tankThreat == 0.0f)
+        {
+            return false;
+        }
+
+        if (m_tankEngageTarget != target->GetObjectGuid())
+        {
+            m_tankEngageTarget = target->GetObjectGuid();
+            m_tankEngageTime = getMSTime();
+        }
+
+        if (getMSTimeDiff(m_tankEngageTime, getMSTime()) < sPlayerbotAIConfig.tankDelaySeconds * 1000)
+        {
+            return false;
+        }
+    }
+
+    if (sPlayerbotAIConfig.tankThreatPct > 0.0f)
+    {
+        float threshold = target->GetMaxHealth() * sPlayerbotAIConfig.tankThreatPct / 100.0f;
+        if (tankThreat < threshold)
+        {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool AttackMyTargetAction::Execute(Event event)

--- a/src/modules/Bots/playerbot/strategy/actions/AttackAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/AttackAction.h
@@ -8,13 +8,18 @@ namespace ai
     class AttackAction : public MovementAction
     {
     public:
-        AttackAction(PlayerbotAI* ai, string name) : MovementAction(ai, name) {}
+        AttackAction(PlayerbotAI* ai, string name) :
+            MovementAction(ai, name), m_tankEngageTarget(),
+            m_tankEngageTime(0) {}
 
     public:
         virtual bool Execute(Event event);
+        virtual bool isUseful();
 
     protected:
         bool Attack(Unit* target);
+        ObjectGuid m_tankEngageTarget;
+        uint32 m_tankEngageTime;
     };
 
     class AttackMyTargetAction : public AttackAction

--- a/src/modules/Bots/playerbot/strategy/actions/ChooseTargetActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ChooseTargetActions.h
@@ -31,7 +31,7 @@ namespace ai
         }
         virtual bool isUseful() {
             /// No real-player proximity gate (m0 behavior): random bots grind on their own
-            return (GetTarget() &&
+            return AttackAction::isUseful() && (GetTarget() &&
                     AI_VALUE2(uint8, "health", "self target") > sPlayerbotAIConfig.mediumHealth &&
                     (!AI_VALUE2(uint8, "mana", "self target") || AI_VALUE2(uint8, "mana", "self target") > sPlayerbotAIConfig.mediumMana)
                 ) || AI_VALUE2(bool, "combat", "self target")
@@ -48,6 +48,22 @@ namespace ai
     public:
         AttackLeastHpTargetAction(PlayerbotAI* ai) : AttackAction(ai, "attack least hp target") {}
         virtual string GetTargetName() { return "least hp target"; }
+    };
+
+    class AttackTanksTargetAction : public AttackAction
+    {
+    public:
+        AttackTanksTargetAction(PlayerbotAI* ai) : AttackAction(ai, "attack tanks target") {}
+
+        virtual string GetTargetName()
+        {
+            Player* tank = ai->GetGroupTank(bot);
+            if (!tank || !tank->IsAlive())
+            {
+                return "least hp target";
+            }
+            return "dps tanks target";
+        }
     };
 
     class AttackEnemyPlayerAction : public AttackAction

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -488,43 +488,163 @@ bool RunAwayAction::Execute(Event event)
     return Flee(AI_VALUE(Unit*, "master target"));
 }
 
+template<typename F>
+static std::vector<WorldObject*> CollectValidUnits(PlayerbotAI* ai, Player* bot, const std::list<ObjectGuid>& guids, F filter)
+{
+    std::vector<WorldObject*> results;
+    for (std::list<ObjectGuid>::const_iterator i = guids.begin(); i != guids.end(); ++i)
+    {
+        Unit* unit = ai->GetUnit(*i);
+        if (unit && filter(unit) && bot->GetDistance(unit) > sPlayerbotAIConfig.tooCloseDistance)
+        {
+            results.push_back(unit);
+        }
+    }
+    return results;
+}
+
+template<typename F>
+static std::vector<WorldObject*> CollectValidGameObjects(PlayerbotAI* ai, Player* bot, const std::list<ObjectGuid>& guids, F filter)
+{
+    std::vector<WorldObject*> results;
+    for (std::list<ObjectGuid>::const_iterator i = guids.begin(); i != guids.end(); ++i)
+    {
+        GameObject* go = ai->GetGameObject(*i);
+        if (go && filter(go) && bot->GetDistance(go) > sPlayerbotAIConfig.tooCloseDistance)
+        {
+            results.push_back(go);
+        }
+    }
+    return results;
+}
+
 bool MoveRandomAction::Execute(Event event)
 {
+    if (m_hasFaceTarget)
+    {
+        if (bot->IsStopped())
+        {
+            m_hasFaceTarget = false;
+            bot->SetFacingTo(bot->GetAngle(m_faceX, m_faceY));
+        }
+        return true;
+    }
+
+    WorldObject* target = NULL;
+
+    // If no configured targets, fall through to the random-position fallback.
+    if (!sPlayerbotAIConfig.randomMovementTargets.empty())
+    {
+        // Cache all value queries ONCE per Execute()
+        std::list<ObjectGuid> npcs = AI_VALUE(std::list<ObjectGuid>, "nearest npcs");
+        std::list<ObjectGuid> players = AI_VALUE(std::list<ObjectGuid>, "nearest players");
+        std::list<ObjectGuid> gos = AI_VALUE(std::list<ObjectGuid>, "nearest game objects");
+
+        struct CategoryPick { WorldObject* target; int weight; };
+        std::vector<CategoryPick> picks;
+        size_t configSize = sPlayerbotAIConfig.randomMovementTargets.size();
+
+        for (size_t idx = 0; idx < configSize; ++idx)
+        {
+            const std::string& type = sPlayerbotAIConfig.randomMovementTargets[idx];
+            int weight = 1 << (int)(configSize - 1 - idx);
+
+            if (type == "random")
+            {
+                picks.push_back({nullptr, weight});
+                continue;
+            }
+
+            std::vector<WorldObject*> matches;
+
+            if (type == "anynpcs")
+            {
+                matches = CollectValidUnits(ai, bot, npcs, [](Unit*) { return true; });
+            }
+            else if (type == "usefulnpcs")
+            {
+                matches = CollectValidUnits(ai, bot, npcs, [](Unit* u)
+                {
+                    Creature* c = dynamic_cast<Creature*>(u);
+                    return c && c->GetUInt32Value(UNIT_NPC_FLAGS) != UNIT_NPC_FLAG_NONE;
+                });
+            }
+            else if (type == "players")
+            {
+                matches = CollectValidUnits(ai, bot, players, [](Unit*) { return true; });
+            }
+            else if (type == "tradeskillitems")
+            {
+                for (std::list<ObjectGuid>::const_iterator gi = gos.begin(); gi != gos.end(); ++gi)
+                {
+                    LootObject loot(bot, *gi);
+                    if (loot.skillId != SKILL_NONE && bot->HasSkill(loot.skillId))
+                    {
+                        GameObject* go = ai->GetGameObject(*gi);
+                        if (go && bot->GetDistance(go) > sPlayerbotAIConfig.tooCloseDistance)
+                        {
+                            matches.push_back(go);
+                        }
+                    }
+                }
+            }
+            else if (type == "interactableitems")
+            {
+                matches = CollectValidGameObjects(ai, bot, gos, [](GameObject* go)
+                {
+                    uint32 t = go->GetGOInfo()->type;
+                    return t == GAMEOBJECT_TYPE_CHEST || t == GAMEOBJECT_TYPE_QUESTGIVER ||
+                           t == GAMEOBJECT_TYPE_SPELL_FOCUS || t == GAMEOBJECT_TYPE_GOOBER;
+                });
+            }
+            else if (type == "anyitems")
+            {
+                matches = CollectValidGameObjects(ai, bot, gos, [](GameObject*) { return true; });
+            }
+
+            if (!matches.empty())
+            {
+                picks.push_back({matches[urand(0, matches.size() - 1)], weight});
+            }
+        }
+
+        if (!picks.empty())
+        {
+            int totalWeight = 0;
+            for (vector<CategoryPick>::const_iterator i = picks.begin(); i != picks.end(); ++i)
+            {
+                totalWeight += i->weight;
+            }
+
+            int roll = urand(0, totalWeight - 1);
+            for (vector<CategoryPick>::const_iterator i = picks.begin(); i != picks.end(); ++i)
+            {
+                if (roll < i->weight)
+                {
+                    target = i->target;
+                    break;
+                }
+                roll -= i->weight;
+            }
+        }
+    }
+
+    if (target)
+    {
+        bool moved = MoveNear(target);
+        if (moved)
+        {
+            m_faceX = target->GetPositionX();
+            m_faceY = target->GetPositionY();
+            m_hasFaceTarget = true;
+        }
+        return moved;
+    }
+
+    // No specific target (empty config, or the "random" category won the
+    // weighted roll): fall back to a random ground position near the bot,
+    // rejecting underwater/off-mesh points.
     vector<WorldLocation> locs;
-    list<ObjectGuid> npcs = AI_VALUE(list<ObjectGuid>, "nearest npcs");
-    for (list<ObjectGuid>::iterator i = npcs.begin(); i != npcs.end(); i++)
-    {
-        WorldObject* target = ai->GetUnit(*i);
-        if (target && bot->GetDistance(target) > sPlayerbotAIConfig.tooCloseDistance)
-        {
-            WorldLocation loc(target->GetMapId(), target->GetPositionX(), target->GetPositionY(), target->GetPositionZ());
-            locs.push_back(loc);
-        }
-    }
-
-    list<ObjectGuid> players = AI_VALUE(list<ObjectGuid>, "nearest friendly players");
-    for (list<ObjectGuid>::iterator i = players.begin(); i != players.end(); i++)
-    {
-        WorldObject* target = ai->GetUnit(*i);
-        if (target && bot->GetDistance(target) > sPlayerbotAIConfig.tooCloseDistance)
-        {
-            WorldLocation loc(target->GetMapId(), target->GetPositionX(), target->GetPositionY(), target->GetPositionZ());
-            locs.push_back(loc);
-        }
-    }
-
-    list<ObjectGuid> gos = AI_VALUE(list<ObjectGuid>, "nearest game objects");
-    for (list<ObjectGuid>::iterator i = gos.begin(); i != gos.end(); i++)
-    {
-        WorldObject* target = ai->GetGameObject(*i);
-
-        if (target && bot->GetDistance(target) > sPlayerbotAIConfig.tooCloseDistance)
-        {
-            WorldLocation loc(target->GetMapId(), target->GetPositionX(), target->GetPositionY(), target->GetPositionZ());
-            locs.push_back(loc);
-        }
-    }
-
     float distance = sPlayerbotAIConfig.grindDistance;
     Map* map = bot->GetMap();
     for (int i = 0; i < 10; ++i)
@@ -562,8 +682,8 @@ bool MoveRandomAction::Execute(Event event)
         return false;
     }
 
-    WorldLocation target = locs[urand(0, locs.size() - 1)];
-    return MoveNear(target.mapid, target.coord_x, target.coord_y, target.coord_z);
+    WorldLocation randomLoc = locs[urand(0, locs.size() - 1)];
+    return MoveNear(randomLoc.mapid, randomLoc.coord_x, randomLoc.coord_y, randomLoc.coord_z);
 }
 
 bool MoveToLootAction::Execute(Event event)

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -350,7 +350,9 @@ bool MovementAction::Follow(Unit* target, float distance, float angle)
  */
 float MovementAction::CalculateAggroFreeDistance(float bx, float by, float angle, float maxDist)
 {
-    if (!ai->HasStrategy("cautious"))
+    if (!ai->HasStrategy("cautious") ||
+        bot->HasAuraType(SPELL_AURA_MOD_STEALTH) ||
+        bot->HasAuraType(SPELL_AURA_MOD_INVISIBILITY))
     {
         return maxDist;
     }

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
@@ -60,14 +60,18 @@ namespace ai
     class MoveRandomAction : public MovementAction
     {
     public:
-        MoveRandomAction(PlayerbotAI* ai) : MovementAction(ai, "move random") {}
+        MoveRandomAction(PlayerbotAI* ai) : MovementAction(ai, "move random"), m_hasFaceTarget(false), m_faceX(0.0f), m_faceY(0.0f) {}
         virtual bool Execute(Event event);
         virtual bool isPossible()
         {
-            return MovementAction::isPossible() &&
+            return !bot->GetGroup() &&
+                    MovementAction::isPossible() &&
                     AI_VALUE2(uint8, "health", "self target") > sPlayerbotAIConfig.mediumHealth &&
                     (!AI_VALUE2(uint8, "mana", "self target") || AI_VALUE2(uint8, "mana", "self target") > sPlayerbotAIConfig.mediumMana);
         }
+    private:
+        bool m_hasFaceTarget;
+        float m_faceX, m_faceY;
     };
 
     class MoveToLootAction : public MovementAction

--- a/src/modules/Bots/playerbot/strategy/actions/PetitionSignAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/PetitionSignAction.cpp
@@ -1,0 +1,41 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "PetitionSignAction.h"
+
+using namespace std;
+using namespace ai;
+
+bool PetitionSignAction::Execute(Event event)
+{
+    Player* master = GetMaster();
+    if (!master)
+    {
+        return false;
+    }
+
+    WorldPacket p(event.getPacket());
+    p.rpos(0);
+
+    ObjectGuid petitionGuid;
+    p >> petitionGuid;
+
+    ObjectGuid ownerGuid;
+    p >> ownerGuid;
+
+    if (!ai->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_INVITE, false, master, true))
+    {
+        return false;
+    }
+
+    if (bot->GetGuildId())
+    {
+        ai->TellMaster("Sorry, I am in a guild already");
+        return false;
+    }
+
+    WorldPacket packet(CMSG_PETITION_SIGN);
+    packet << petitionGuid;
+    packet << uint8(0);
+    bot->GetSession()->HandlePetitionSignOpcode(packet);
+    return true;
+}

--- a/src/modules/Bots/playerbot/strategy/actions/PetitionSignAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/PetitionSignAction.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../Action.h"
+#include "InventoryAction.h"
+
+namespace ai
+{
+    class PetitionSignAction : public Action {
+        public:
+            PetitionSignAction(PlayerbotAI* ai) : Action(ai, "petition sign") {}
+            virtual bool Execute(Event event);
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/actions/PositionAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/PositionAction.cpp
@@ -116,3 +116,54 @@ bool MoveToPositionAction::Execute(Event event)
     return MoveTo(bot->GetMapId(), pos.x, pos.y, pos.z, true);
 }
 
+bool GotoAction::Execute(Event event)
+{
+    if (!m_positionName.empty() && getMSTime() >= m_deadline)
+    {
+        m_positionName.clear();
+        m_deadline = 0;
+        return false;
+    }
+
+    string param = event.getParam();
+    if (param.empty())
+    {
+        return false;
+    }
+
+    string posName = param;
+    uint32 seconds = 5;
+    size_t space = param.find(' ');
+    if (space != string::npos)
+    {
+        posName = param.substr(0, space);
+        string timeStr = param.substr(space + 1);
+        if (!timeStr.empty())
+        {
+            seconds = (uint32)max(1, atoi(timeStr.c_str()));
+        }
+    }
+
+    if (posName == m_positionName)
+    {
+        return MoveTo(m_targetMapId, m_targetX, m_targetY, m_targetZ, true);
+    }
+
+    ai::Position pos = context->GetValue<ai::PositionMap&>("position")->Get()[posName];
+    if (!pos.isSet())
+    {
+        ostringstream out; out << "Position " << posName << " is not set";
+        ai->TellMaster(out);
+        return false;
+    }
+
+    m_positionName = posName;
+    m_targetMapId = bot->GetMapId();
+    m_targetX = (float)pos.x;
+    m_targetY = (float)pos.y;
+    m_targetZ = (float)pos.z;
+    m_deadline = getMSTime() + seconds * 1000;
+
+    return MoveTo(m_targetMapId, m_targetX, m_targetY, m_targetZ, true);
+}
+

--- a/src/modules/Bots/playerbot/strategy/actions/PositionAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/PositionAction.h
@@ -33,4 +33,17 @@ namespace ai
         {}
     };
 
+    class GotoAction : public MovementAction
+    {
+    public:
+        GotoAction(PlayerbotAI* ai) : MovementAction(ai, "goto") {}
+        virtual bool Execute(Event event);
+
+    private:
+        string m_positionName;
+        uint32 m_deadline = 0;
+        float m_targetX = 0, m_targetY = 0, m_targetZ = 0;
+        uint32 m_targetMapId = 0;
+    };
+
 }

--- a/src/modules/Bots/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
@@ -200,10 +200,20 @@ void SuggestWhatToDoAction::spam(string msg)
         return;
     }
 
+    if (sPlayerbotAIConfig.whisperToZoneOnly && bot->GetZoneId() != player->GetZoneId())
+    {
+        return;
+    }
+
     if (sPlayerbotAIConfig.whisperDistance && !bot->GetGroup() && sRandomPlayerbotMgr.IsRandomBot(bot) &&
         player->GetSession()->GetSecurity() < SEC_GAMEMASTER &&
         (bot->GetMapId() != player->GetMapId() || bot->GetDistance(player) > sPlayerbotAIConfig.whisperDistance))
         return;
+
+    if ((int)bot->getLevel() - (int)player->getLevel() > 5)
+    {
+        return;
+    }
 
     bot->Whisper(msg, LANG_UNIVERSAL, player->GetObjectGuid());
 }

--- a/src/modules/Bots/playerbot/strategy/actions/TradeStatusAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/TradeStatusAction.cpp
@@ -147,13 +147,14 @@ bool TradeStatusAction::CheckTrade()
         item = master->GetTradeData()->GetItem((TradeSlots)slot);
         if (item)
         {
-            ostringstream out; out << item->GetProto()->ItemId;
+            ItemPrototype const* proto = item->GetProto();
+            ostringstream out; out << proto->ItemId;
             ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", out.str());
-            if (!auctionbot.GetBuyPrice(item->GetProto()) || usage == ITEM_USAGE_NONE)
+            if (usage == ITEM_USAGE_NONE || proto->Quality < ITEM_QUALITY_NORMAL || !proto->SellPrice)
             {
-                ostringstream out;
-                out << chat->formatItem(item->GetProto()) << " - I don't need this";
-                ai->TellMaster(out);
+                ostringstream reason;
+                reason << chat->formatItem(proto) << " - I don't need this";
+                ai->TellMaster(reason);
                 return false;
             }
         }

--- a/src/modules/Bots/playerbot/strategy/actions/UseItemAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/UseItemAction.cpp
@@ -4,7 +4,56 @@
 
 #include "../../PlayerbotAIConfig.h"
 #include "DBCStore.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
 using namespace ai;
+
+static Item* FindEquippedItemByName(Player* bot, string const& name)
+{
+    string lname = name;
+    strToLower(lname);
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+        if (!item)
+        {
+            continue;
+        }
+        string iname = item->GetProto()->Name1;
+        strToLower(iname);
+        if (iname.find(lname) != string::npos || lname.find(iname) != string::npos)
+        {
+            return item;
+        }
+    }
+    return nullptr;
+}
+
+class AnyUnitNameSubstrCheck
+{
+    public:
+        AnyUnitNameSubstrCheck(WorldObject const* obj, float range, string const& name)
+            : i_obj(obj), i_range(range), i_name(name)
+        {
+            strToLower(i_name);
+        }
+        WorldObject const& GetFocusObject() const { return *i_obj; }
+        bool operator()(Unit* u)
+        {
+            if (!i_obj->IsWithinDistInMap(u, i_range))
+            {
+                return false;
+            }
+            string uname = u->GetName();
+            strToLower(uname);
+            return uname.find(i_name) != string::npos || i_name.find(uname) != string::npos;
+        }
+    private:
+        WorldObject const* i_obj;
+        float i_range;
+        string i_name;
+};
 
 bool UseItemAction::Execute(Event event)
 {
@@ -14,19 +63,68 @@ bool UseItemAction::Execute(Event event)
         name = getName();
     }
 
+    size_t atPos = name.find('@');
+    if (atPos != string::npos)
+    {
+        string itemPart = name.substr(0, atPos);
+        string targetPart = name.substr(atPos + 1);
+        while (!itemPart.empty() && itemPart.back() == ' ')
+        {
+            itemPart.pop_back();
+        }
+        size_t start = targetPart.find_first_not_of(' ');
+        targetPart = (start != string::npos) ? targetPart.substr(start) : "";
+
+        list<Item*> items = AI_VALUE2(list<Item*>, "inventory items", itemPart);
+        if (items.empty())
+        {
+            ai->TellMaster("No item found matching '" + itemPart + "'");
+            return false;
+        }
+
+        list<Item*> targetItems = AI_VALUE2(list<Item*>, "inventory items", targetPart);
+        if (!targetItems.empty())
+        {
+            return UseItem(*items.begin(), ObjectGuid(), *targetItems.begin());
+        }
+
+        Item* equippedTarget = FindEquippedItemByName(bot, targetPart);
+        if (equippedTarget)
+        {
+            return UseItem(*items.begin(), ObjectGuid(), equippedTarget);
+        }
+
+        list<Unit*> units;
+        AnyUnitNameSubstrCheck u_check(bot, sPlayerbotAIConfig.sightDistance, targetPart);
+        MaNGOS::UnitListSearcher<AnyUnitNameSubstrCheck> searcher(units, u_check);
+        Cell::VisitAllObjects(bot, searcher, sPlayerbotAIConfig.sightDistance);
+
+        if (units.empty())
+        {
+            ai->TellMaster("No target found matching '" + targetPart + "'");
+            return false;
+        }
+
+        Unit* target = nullptr;
+        float closest = FLT_MAX;
+        for (list<Unit*>::iterator i = units.begin(); i != units.end(); ++i)
+        {
+            float dist = bot->GetDistance(*i);
+            if (dist < closest)
+            {
+                closest = dist;
+                target = *i;
+            }
+        }
+        return UseItem(*items.begin(), ObjectGuid(), target);
+    }
+
     list<Item*> items = AI_VALUE2(list<Item*>, "inventory items", name);
     list<ObjectGuid> gos = chat->parseGameobjects(name);
 
     if (gos.empty())
     {
-        if (items.size() > 1)
-        {
-            list<Item*>::iterator i = items.begin();
-            Item* itemTarget = *i++;
-            Item* item = *i;
-            return UseItemOnItem(item, itemTarget);
-        }
-        else if (!items.empty())
+        if (!items.empty())
         {
             return UseItemAuto(*items.begin());
         }
@@ -76,7 +174,7 @@ bool UseItemAction::UseItemOnItem(Item* item, Item* itemTarget)
     return UseItem(item, ObjectGuid(), itemTarget);
 }
 
-bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget)
+bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Object* target)
 {
     if (bot->CanUseItem(item) != EQUIP_ERR_OK)
     {
@@ -148,8 +246,9 @@ bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget)
         }
     }
 
-    if (itemTarget)
+    if (target && target->GetTypeId() == TYPEID_ITEM)
     {
+        Item* itemTarget = static_cast<Item*>(target);
 #if !defined(CLASSIC)
         if (item->GetProto()->Class == ITEM_CLASS_GEM)
         {
@@ -167,6 +266,38 @@ bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget)
             *packet << targetFlag << itemTarget->GetPackGUID();
             out << " on " << chat->formatItem(itemTarget->GetProto());
             targetSelected = true;
+        }
+    }
+    else if (target && target->GetTypeId() == TYPEID_UNIT)
+    {
+        Unit* unitTarget = static_cast<Unit*>(target);
+        uint32 targetFlag = unitTarget->IsAlive() ? TARGET_FLAG_UNIT : TARGET_FLAG_UNIT_CORPSE;
+        *packet << targetFlag << unitTarget->GetObjectGuid().WriteAsPacked();
+        out << " on " << unitTarget->GetName();
+        targetSelected = true;
+    }
+
+    if (target && targetSelected)
+    {
+        // m0 waits via WaitForSpellCast(uint32), an overload m3 does not
+        // have; build the transient Spell m3's own item-cast path below
+        // uses to wait on the same PlayerbotAI::WaitForSpellCast(Spell*).
+        for (int i = 0; i < MAX_ITEM_PROTO_SPELLS; i++)
+        {
+            uint32 spellId = item->GetProto()->Spells[i].SpellId;
+            if (!spellId || !ai->CanCastSpell(spellId, bot, false))
+            {
+                continue;
+            }
+
+            const SpellEntry* const pSpellInfo = sSpellStore.LookupEntry(spellId);
+            if (pSpellInfo)
+            {
+                Spell* spell = new Spell(bot, pSpellInfo, false);
+                ai->WaitForSpellCast(spell);
+                delete spell;
+            }
+            break;
         }
     }
 
@@ -264,7 +395,7 @@ bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget)
             ai->WaitForSpellCast(spell);
             delete spell;
         }
-        else if (!goGuid && !itemTarget)
+        else if (!goGuid && !target)
         {
             *packet << (uint32)TARGET_FLAG_SELF;
             targetSelected = true;

--- a/src/modules/Bots/playerbot/strategy/actions/UseItemAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/UseItemAction.h
@@ -18,7 +18,7 @@ namespace ai
     private:
         bool UseItemOnGameObject(Item* item, ObjectGuid go);
         bool UseItemOnItem(Item* item, Item* itemTarget);
-        bool UseItem(Item* item, ObjectGuid go, Item* itemTarget);
+        bool UseItem(Item* item, ObjectGuid go, Object* target);
         bool UseGameObject(ObjectGuid guid);
         bool SocketItem(Item * item, Item * gem, bool replace = false);
 

--- a/src/modules/Bots/playerbot/strategy/actions/WorldPacketActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/WorldPacketActionContext.h
@@ -22,6 +22,7 @@
 #include "ReadyCheckAction.h"
 #include "LfgActions.h"
 #include "SecurityCheckAction.h"
+#include "PetitionSignAction.h"
 #include "GuildAcceptAction.h"
 #include "ReleaseSpiritWithMasterAction.h"
 #include "SpiritHealerWithMasterAction.h"
@@ -62,6 +63,7 @@ namespace ai
             creators["uninvite"] = &WorldPacketActionContext::uninvite;
             creators["disband"] = &WorldPacketActionContext::disband;
             creators["security check"] = &WorldPacketActionContext::security_check;
+            creators["petition sign"] = &WorldPacketActionContext::petition_sign;
             creators["guild accept"] = &WorldPacketActionContext::guild_accept;
             creators["inventory change failure"] = &WorldPacketActionContext::inventory_change_failure;
             creators["release spirit with master"] = &WorldPacketActionContext::release_spirit_with_master;
@@ -70,6 +72,7 @@ namespace ai
 
     private:
         static Action* inventory_change_failure(PlayerbotAI* ai) { return new InventoryChangeFailureAction(ai); }
+        static Action* petition_sign(PlayerbotAI* ai) { return new PetitionSignAction(ai); }
         static Action* guild_accept(PlayerbotAI* ai) { return new GuildAcceptAction(ai); }
         static Action* release_spirit_with_master(PlayerbotAI* ai) { return new ReleaseSpiritWithMasterAction(ai); }
         static Action* spirit_healer_with_master(PlayerbotAI* ai) { return new SpiritHealerWithMasterAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -10,6 +10,7 @@ public:
     ChatCommandActionNodeFactoryInternal()
     {
         creators["tank attack chat shortcut"] = &tank_attack_chat_shortcut;
+        creators["goto"] = &goto_action;
     }
 
 private:
@@ -19,6 +20,16 @@ private:
             /*P*/ NULL,
             /*A*/ NULL,
             /*C*/ NextAction::array(0, new NextAction("attack my target", 100.0f), NULL));
+    }
+    static ActionNode* goto_action(PlayerbotAI* ai)
+    {
+        // m0 chains ->persist(3600000) here; that method is introduced by
+        // #350 (Phase 8, out of scope for this tranche) and does not exist
+        // in this tree yet, so the node is created without it.
+        return new ActionNode ("goto",
+            /*P*/ NULL,
+            /*A*/ NULL,
+            /*C*/ NULL);
     }
 };
 
@@ -135,6 +146,10 @@ void ChatCommandHandlerStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "ready",
         NextAction::array(0, new NextAction("ready check", relevance), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "goto",
+        NextAction::array(0, new NextAction("goto", 1000.0f), NULL)));
 }
 
 
@@ -176,6 +191,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* ai) : PassTr
     supported.push_back("spell");
     supported.push_back("rti");
     supported.push_back("position");
+    supported.push_back("goto");
     supported.push_back("summon");
     supported.push_back("who");
     supported.push_back("save mana");

--- a/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.cpp
@@ -1,0 +1,12 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "DpsTanksTargetStrategy.h"
+
+using namespace ai;
+
+void DpsTanksTargetStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
+{
+    triggers.push_back(new TriggerNode(
+        "no tanks target active",
+        NextAction::array(0, new NextAction("attack tanks target", 65.0f), NULL)));
+}

--- a/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.h
@@ -3,14 +3,13 @@
 
 namespace ai
 {
-    class DpsAssistStrategy : public NonCombatStrategy
+    class DpsTanksTargetStrategy : public NonCombatStrategy
     {
     public:
-        DpsAssistStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
-        virtual string getName() { return "dps assist"; }
+        DpsTanksTargetStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
+        virtual string getName() { return "dps tanks"; }
         virtual int GetType() { return STRATEGY_TYPE_DPS; }
-
-    public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);
     };
+
 }

--- a/src/modules/Bots/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/WorldPacketHandlerStrategy.cpp
@@ -76,6 +76,10 @@ void WorldPacketHandlerStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("security check", relevance), new NextAction("check mail", relevance), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "petition sign",
+        NextAction::array(0, new NextAction("petition sign", relevance), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "guild invite",
         NextAction::array(0, new NextAction("guild accept", relevance), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/mage/MageActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/MageActions.cpp
@@ -8,3 +8,87 @@ Value<Unit*>* CastPolymorphAction::GetTargetValue()
 {
     return context->GetValue<Unit*>("cc target", getName());
 }
+
+bool CastFlamestrikeAction::isUseful()
+{
+    if (!CastSpellAction::isUseful())
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (target && ai->HasNonCombatantInRange(5.0f,
+        target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
+    {
+        return false;
+    }
+    return true;
+}
+
+bool CastFrostNovaAction::isUseful()
+{
+    if (!CastSpellAction::isUseful())
+    {
+        return false;
+    }
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target)
+    {
+        return false;
+    }
+    if (target->getVictim() != bot &&
+        (!bot->GetGroup() || !target->getVictim() ||
+            !target->getVictim()->GetObjectGuid().IsPlayer()))
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    if (ai->HasNonCombatantInRange(10.0f) ||
+        AI_VALUE2(float, "distance", GetTargetName()) > sPlayerbotAIConfig.tooCloseDistance)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool CastBlizzardAction::isUseful()
+{
+    if (!CastSpellAction::isUseful())
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target || ai->HasNonCombatantInRange(8.0f,
+        target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
+    {
+        return false;
+    }
+    return true;
+}
+
+bool CastBlastWaveAction::isUseful()
+{
+    if (!CastSpellAction::isUseful())
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    if (ai->HasNonCombatantInRange(10.0f))
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/modules/Bots/playerbot/strategy/mage/MageActions.h
+++ b/src/modules/Bots/playerbot/strategy/mage/MageActions.h
@@ -51,13 +51,14 @@ namespace ai
     {
     public:
         CastFlamestrikeAction(PlayerbotAI* ai) : CastSpellAction(ai, "flamestrike") {}
+        virtual bool isUseful();
     };
 
     class CastFrostNovaAction : public CastSpellAction
     {
     public:
         CastFrostNovaAction(PlayerbotAI* ai) : CastSpellAction(ai, "frost nova") {}
-        virtual bool isUseful() { return AI_VALUE2(float, "distance", GetTargetName()) <= sPlayerbotAIConfig.tooCloseDistance; }
+        virtual bool isUseful();
     };
 
     class CastFrostboltAction : public CastSpellAction
@@ -70,6 +71,7 @@ namespace ai
     {
     public:
         CastBlizzardAction(PlayerbotAI* ai) : CastSpellAction(ai, "blizzard") {}
+        virtual bool isUseful();
     };
 
     class CastIceLanceAction : public CastSpellAction
@@ -209,6 +211,7 @@ namespace ai
     {
     public:
         CastBlastWaveAction(PlayerbotAI* ai) : CastSpellAction(ai, "blast wave") {}
+        virtual bool isUseful();
     };
 
     class CastInvisibilityAction : public CastBuffSpellAction

--- a/src/modules/Bots/playerbot/strategy/priest/PriestActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestActions.cpp
@@ -4,5 +4,16 @@
 
 using namespace ai;
 
-
+bool CastHolyNovaAction::isUseful()
+{
+    if (!CastSpellAction::isUseful() || ai->HasAura("shadowform", AI_VALUE(Unit*, "self target")))
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    return !ai->HasNonCombatantInRange(10.0f);
+}
 

--- a/src/modules/Bots/playerbot/strategy/priest/PriestActions.h
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestActions.h
@@ -112,9 +112,7 @@ namespace ai
     };
 
     BEGIN_SPELL_ACTION(CastHolyNovaAction, "holy nova")
-    virtual bool isUseful() {
-        return !ai->HasAura("shadowform", AI_VALUE(Unit*, "self target"));
-    }
+    virtual bool isUseful();
     END_SPELL_ACTION()
 
     BEGIN_RANGED_SPELL_ACTION(CastHolyFireAction, "holy fire")
@@ -205,6 +203,10 @@ namespace ai
     {
     public:
         CastPsychicScreamAction(PlayerbotAI* ai) : CastSpellAction(ai, "psychic scream") {}
+        virtual bool isUseful()
+        {
+            return CastSpellAction::isUseful() && (!ai->HasStrategy("cautious") || !ai->GetGroupTank(bot));
+        }
     };
 
     class CastDispersionAction : public CastSpellAction

--- a/src/modules/Bots/playerbot/strategy/shaman/CasterShamanStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/shaman/CasterShamanStrategy.cpp
@@ -18,7 +18,8 @@ private:
         return new ActionNode ("magma totem",
             /*P*/ NULL,
             /*A*/ NULL,
-            /*C*/ NextAction::array(0, new NextAction("fire nova"), NULL));
+            /*C*/ NextAction::array(0,
+                new NextAction("fire nova", ACTION_NORMAL), NULL));
     }
 };
 

--- a/src/modules/Bots/playerbot/strategy/shaman/MeleeShamanStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/shaman/MeleeShamanStrategy.cpp
@@ -34,7 +34,8 @@ private:
         return new ActionNode ("magma totem",
             /*P*/ NULL,
             /*A*/ NULL,
-            /*C*/ NextAction::array(0, new NextAction("fire nova"), NULL));
+            /*C*/ NextAction::array(0,
+                new NextAction("fire nova", ACTION_NORMAL), NULL));
     }
 };
 

--- a/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
@@ -68,6 +68,7 @@ namespace ai
             creators["runaway"] = &ChatTriggerContext::runaway;
             creators["warning"] = &ChatTriggerContext::warning;
             creators["position"] = &ChatTriggerContext::position;
+            creators["goto"] = &ChatTriggerContext::goto_action;
             creators["summon"] = &ChatTriggerContext::summon;
             creators["who"] = &ChatTriggerContext::who;
             creators["save mana"] = &ChatTriggerContext::save_mana;
@@ -97,6 +98,7 @@ namespace ai
         static Trigger* who(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "who"); }
         static Trigger* summon(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "summon"); }
         static Trigger* position(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "position"); }
+        static Trigger* goto_action(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "goto"); }
         static Trigger* runaway(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "runaway"); }
         static Trigger* warning(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "warning"); }
         static Trigger* revive(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "revive"); }

--- a/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -238,6 +238,13 @@ bool NotDpsTargetActiveTrigger::IsActive()
     return dps && target != dps;
 }
 
+bool NoTanksTargetActiveTrigger::IsActive()
+{
+    Unit* tanksTarget = AI_VALUE(Unit*, "dps tanks target");
+    Unit* target = AI_VALUE(Unit*, "current target");
+    return tanksTarget && target != tanksTarget;
+}
+
 bool EnemyPlayerIsAttacking::IsActive()
 {
     Unit* enemyPlayer = AI_VALUE(Unit*, "enemy player target");

--- a/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
@@ -553,6 +553,15 @@ namespace ai
         virtual bool IsActive();
     };
 
+    class NoTanksTargetActiveTrigger : public Trigger
+    {
+    public:
+        NoTanksTargetActiveTrigger(PlayerbotAI* ai) : Trigger(ai, "no tanks target active") {}
+
+    public:
+        virtual bool IsActive();
+    };
+
     class EnemyPlayerIsAttacking : public Trigger
     {
     public:

--- a/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
@@ -50,6 +50,7 @@ namespace ai
             creators["no target"] = &TriggerContext::NoTarget;
             creators["target in sight"] = &TriggerContext::TargetInSight;
             creators["not dps target active"] = &TriggerContext::not_dps_target_active;
+            creators["no tanks target active"] = &TriggerContext::no_tanks_target_active;
             creators["has nearest adds"] = &TriggerContext::has_nearest_adds;
             creators["enemy player is attacking"] = &TriggerContext::enemy_player_is_attacking;
 
@@ -149,6 +150,7 @@ namespace ai
         static Trigger* NoTarget(PlayerbotAI* ai) { return new NoTargetTrigger(ai); }
         static Trigger* TargetInSight(PlayerbotAI* ai) { return new TargetInSightTrigger(ai); }
         static Trigger* not_dps_target_active(PlayerbotAI* ai) { return new NotDpsTargetActiveTrigger(ai); }
+        static Trigger* no_tanks_target_active(PlayerbotAI* ai) { return new NoTanksTargetActiveTrigger(ai); }
         static Trigger* has_nearest_adds(PlayerbotAI* ai) { return new HasNearestAddsTrigger(ai); }
         static Trigger* enemy_player_is_attacking(PlayerbotAI* ai) { return new EnemyPlayerIsAttacking(ai); }
         static Trigger* Random(PlayerbotAI* ai) { return new RandomTrigger(ai, "random", 15); }

--- a/src/modules/Bots/playerbot/strategy/triggers/WorldPacketTriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/WorldPacketTriggerContext.h
@@ -43,6 +43,7 @@ namespace ai
             creators["lfg proposal"] = &WorldPacketTriggerContext::lfg_proposal;
             creators["lfg role check"] = &WorldPacketTriggerContext::lfg_role_check;
             creators["lfg leave"] = &WorldPacketTriggerContext::lfg_leave;
+            creators["petition sign"] = &WorldPacketTriggerContext::petition_sign;
             creators["guild invite"] = &WorldPacketTriggerContext::guild_invite;
             creators["master released spirit"] = &WorldPacketTriggerContext::master_released_spirit;
             creators["master spirit healer"] = &WorldPacketTriggerContext::master_spirit_healer;
@@ -52,6 +53,7 @@ namespace ai
 
     private:
         static Trigger* inventory_change_failure(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "inventory change failure"); }
+        static Trigger* petition_sign(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "petition sign"); }
         static Trigger* guild_invite(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "guild invite"); }
         static Trigger* master_released_spirit(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "master released spirit"); }
         static Trigger* master_spirit_healer(PlayerbotAI* ai) { return new WorldPacketTrigger(ai, "master spirit healer"); }

--- a/src/modules/Bots/playerbot/strategy/values/DpsTanksTargetValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/DpsTanksTargetValue.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "../Value.h"
+#include "TargetValue.h"
+
+namespace ai
+{
+    class DpsTanksTargetValue : public TargetValue
+    {
+    public:
+        DpsTanksTargetValue(PlayerbotAI* ai) : TargetValue(ai) {}
+
+    public:
+        Unit* Calculate() override
+        {
+            Player* tank = ai->GetGroupTank(bot);
+            if (!tank || !tank->IsAlive())
+            {
+                return AI_VALUE(Unit*, "least hp target");
+            }
+            return tank->getVictim();
+        }
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.cpp
+++ b/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.cpp
@@ -1,0 +1,23 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "NearestPlayersValue.h"
+
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+
+using namespace ai;
+using namespace MaNGOS;
+
+void NearestPlayersValue::FindUnits(list<Unit*> &targets)
+{
+    AnyFriendlyUnitInObjectRangeCheck u_check(bot, range);
+    UnitListSearcher<AnyFriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    Cell::VisitAllObjects(bot, searcher, range);
+}
+
+bool NearestPlayersValue::AcceptUnit(Unit* unit)
+{
+    ObjectGuid guid = unit->GetObjectGuid();
+    return guid.IsPlayer() && guid != ai->GetBot()->GetObjectGuid() && unit->IsAlive();
+}

--- a/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "../Value.h"
+#include "NearestUnitsValue.h"
+#include "../../PlayerbotAIConfig.h"
+
+namespace ai
+{
+    class NearestPlayersValue : public NearestUnitsValue
+    {
+    public:
+        NearestPlayersValue(PlayerbotAI* ai, float range = sPlayerbotAIConfig.sightDistance) :
+            NearestUnitsValue(ai) {}
+
+    protected:
+        void FindUnits(list<Unit*> &targets);
+        bool AcceptUnit(Unit* unit);
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -16,6 +16,7 @@
 #include "TankTargetValue.h"
 #include "PartyTankValue.h"
 #include "DpsTargetValue.h"
+#include "DpsTanksTargetValue.h"
 #include "CcTargetValue.h"
 #include "CurrentCcTargetValue.h"
 #include "PetTargetValue.h"
@@ -95,6 +96,7 @@ namespace ai
             creators["party tank"] = &ValueContext::party_tank;
             creators["dps target"] = &ValueContext::dps_target;
             creators["least hp target"] = &ValueContext::least_hp_target;
+            creators["dps tanks target"] = &ValueContext::dps_tanks_target;
             creators["enemy player target"] = &ValueContext::enemy_player_target;
             creators["cc target"] = &ValueContext::cc_target;
             creators["current cc target"] = &ValueContext::current_cc_target;
@@ -259,6 +261,7 @@ namespace ai
         static UntypedValue* party_tank(PlayerbotAI* ai) { return new PartyTankValue(ai); }
         static UntypedValue* dps_target(PlayerbotAI* ai) { return new DpsTargetValue(ai); }
         static UntypedValue* least_hp_target(PlayerbotAI* ai) { return new LeastHpTargetValue(ai); }
+        static UntypedValue* dps_tanks_target(PlayerbotAI* ai) { return new DpsTanksTargetValue(ai); }
         static UntypedValue* enemy_player_target(PlayerbotAI* ai) { return new EnemyPlayerValue(ai); }
         static UntypedValue* cc_target(PlayerbotAI* ai) { return new CcTargetValue(ai); }
         static UntypedValue* current_cc_target(PlayerbotAI* ai) { return new CurrentCcTargetValue(ai); }

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -60,6 +60,7 @@
 #include "LastSaidValue.h"
 #include "NearestFriendlyPlayersValue.h"
 #include "NearestNonBotPlayersValue.h"
+#include "NearestPlayersValue.h"
 #include "NewPlayerNearbyValue.h"
 #include "OutfitListValue.h"
 #include "RandomBotUpdateValue.h"
@@ -77,6 +78,7 @@ namespace ai
             creators["nearest game objects"] = &ValueContext::nearest_game_objects;
             creators["nearest npcs"] = &ValueContext::nearest_npcs;
             creators["nearest friendly players"] = &ValueContext::nearest_friendly_players;
+            creators["nearest players"] = &ValueContext::nearest_players;
             creators["possible targets"] = &ValueContext::possible_targets;
             creators["nearest adds"] = &ValueContext::nearest_adds;
             creators["nearest corpses"] = &ValueContext::nearest_corpses;
@@ -239,6 +241,7 @@ namespace ai
         static UntypedValue* log_level(PlayerbotAI* ai) { return new LogLevelValue(ai); }
         static UntypedValue* nearest_npcs(PlayerbotAI* ai) { return new NearestNpcsValue(ai); }
         static UntypedValue* nearest_friendly_players(PlayerbotAI* ai) { return new NearestFriendlyPlayersValue(ai); }
+        static UntypedValue* nearest_players(PlayerbotAI* ai) { return new NearestPlayersValue(ai); }
         static UntypedValue* nearest_corpses(PlayerbotAI* ai) { return new NearestCorpsesValue(ai); }
         static UntypedValue* possible_targets(PlayerbotAI* ai) { return new PossibleTargetsValue(ai); }
         static UntypedValue* nearest_adds(PlayerbotAI* ai) { return new NearestAdsValue(ai); }

--- a/src/modules/Bots/playerbot/strategy/warlock/TankWarlockStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/warlock/TankWarlockStrategy.h
@@ -9,6 +9,7 @@ namespace ai
     public:
         TankWarlockStrategy(PlayerbotAI* ai);
         virtual string getName() { return "tank"; }
+        virtual int GetType() { return STRATEGY_TYPE_TANK | STRATEGY_TYPE_RANGED; }
 
     public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);

--- a/src/modules/Bots/playerbot/strategy/warlock/WarlockActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/warlock/WarlockActions.cpp
@@ -1,5 +1,24 @@
 #include "botpch.h"
-//#include "../../playerbot.h"
-//#include "WarlockActions.h"
+#include "../../playerbot.h"
+#include "WarlockActions.h"
 
 using namespace ai;
+
+bool CastRainOfFireAction::isUseful()
+{
+    if (!CastSpellAction::isUseful())
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("cautious"))
+    {
+        return true;
+    }
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target || ai->HasNonCombatantInRange(8.0f,
+        target->GetPositionX(), target->GetPositionY(), target->GetPositionZ()))
+    {
+        return false;
+    }
+    return true;
+}

--- a/src/modules/Bots/playerbot/strategy/warlock/WarlockActions.h
+++ b/src/modules/Bots/playerbot/strategy/warlock/WarlockActions.h
@@ -104,6 +104,7 @@ namespace ai
     {
     public:
         CastRainOfFireAction(PlayerbotAI* ai) : CastSpellAction(ai, "rain of fire") {}
+        virtual bool isUseful();
     };
 
     class CastShadowfuryAction : public CastSpellAction
@@ -134,6 +135,11 @@ namespace ai
     {
     public:
         CastFearAction(PlayerbotAI* ai) : CastDebuffSpellAction(ai, "fear") {}
+        virtual bool isUseful()
+        {
+            return CastDebuffSpellAction::isUseful() &&
+                (!ai->HasStrategy("cautious") || !ai->GetGroupTank(bot));
+        }
     };
 
     class CastFearOnCcAction : public CastBuffSpellAction
@@ -142,6 +148,11 @@ namespace ai
         CastFearOnCcAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "fear on cc") {}
         virtual Value<Unit*>* GetTargetValue() { return context->GetValue<Unit*>("cc target", "fear"); }
         virtual bool Execute(Event event) { return ai->CastSpell("fear", GetTarget()); }
+        virtual bool isUseful()
+        {
+            return CastBuffSpellAction::isUseful() &&
+                (!ai->HasStrategy("cautious") || !ai->GetGroupTank(bot));
+        }
     };
 
     class CastLifeTapAction: public CastSpellAction


### PR DESCRIPTION
Ports Bo Zimmerman's engine-layer playerbot fixes from mangoszero to mangosthree. m0 is where playerbot development happens (94 of 161 commits to `src/modules/Bots` are his), and m3 had never had a sync — the module came in via #305 based on m1, whose last m0 sync was 2026-02-24.

Scope was set by auditing the actual code rather than the commit graph. Of 54 engine-layer candidates, **32 were already present** in adapted form, 25 further commits are Vanilla class/spell tuning that does not belong in Cata, and 2 are deferred. That leaves the 8 commits here. Nothing was cherry-picked — m0's bot tree was style-swept on 2026-06-03, so every hunk was transcribed by hand and restyled to this repo's rules (including bracing single-statement blocks, which m0 omits).

**Commits**

- `[Bots] Whisper & trade hygiene` — zone-only whispers, level-gap skip, trade accepts on usage/quality/sell-price
- `[Bots] Random-bot liveness & DB-load` — optional zone-population idle gate, event-value cache in front of `ai_playerbot_random_bots`
- `[Bots] Preserve bot groups across restarts` — `RandomBotKeepGroups`
- `[Bots] Group role strategies` — per-role tank/heal/dps strategies for grouped bots
- `[Bots] Movement behavior` — face target after random movement, configurable random-movement targets, `goto`
- `[Bots] Group DPS targeting & threat` — dps-tanks assist, tank-delay/threat gating, CC suppression
- `[Bots] Use-item-on-target syntax` — `use <item> @ <target>`
- `[Bots] Bots sign guild charters`

**Cata adaptations worth review**

- m0 skips bots via `GetRemoteAddress() == "bot"`. Bot sessions here are built with a null socket (`RandomPlayerbotFactory.cpp:90`) and never set that address, so the guard would silently never match — replaced with `GetPlayerbotAI() || IsRandomBot()`.
- `BotGroupNonCombatStrategies` defaults to `+follow,+loot`; this tree registers the strategy as `follow`, not m0's `follow master`.
- `IsFeared()`/`IsStunned()` → `isFeared()`/`hasUnitState(UNIT_STAT_STUNNED)`.
- Three m0 hunks were dropped because the structures they target do not exist here (`has threat` trigger, a frost-nova continuer, a `FleeManager` loop bound that already starts where m0 moves it). Documented in the relevant commit body.

**Build**: clean with `PLAYERBOTS=ON` and with `PLAYERBOTS=0` (the CI configuration), zero warnings. Smoke-tested on a 4.3.4 install — `World Initialization Complete`, bots spawn and log in.

Two core hooks are included, both inside `#ifdef ENABLE_PLAYERBOTS`: `PlayerZone.cpp` (zone bookkeeping) and `PlayerGroup.cpp` (role strategies).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/317)
<!-- Reviewable:end -->
