### PR TITLE
[Bots] Report the real PlayerBots state in the startup banner

### DIFF
--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -899,16 +899,16 @@ void World::showFooter()
     modules_.insert("      ScriptDev3 (SD3) : Enabled");
 #endif
 
-    // PLAYERBOTS can be included or excluded but also disabled via mangos.conf
+    // PLAYERBOTS is included at build time and switched at runtime by
+    // AiPlayerbot.Enabled in aiplayerbot.conf
 #ifdef ENABLE_PLAYERBOTS
-    bool playerBotActive = sConfig.GetBoolDefault("PlayerbotAI.DisableBots", true);
-    if (playerBotActive)
+    if (sPlayerbotAIConfig.enabled)
     {
-        modules_.insert("            PlayerBots : Disabled");
+        modules_.insert("            PlayerBots : Enabled");
     }
     else
     {
-        modules_.insert("            PlayerBots : Enabled");
+        modules_.insert("            PlayerBots : Disabled");
     }
 #endif
 


### PR DESCRIPTION
The startup banner always printed `PlayerBots : Disabled`, even with bots enabled and hundreds logged in.

`World::showFooter()` read `PlayerbotAI.DisableBots` through `sConfig`, which parses `mangosd.conf`. That key is not defined in `mangosd.conf`, `aiplayerbot.conf`, or any `.conf.dist` in the tree — so `GetBoolDefault` always returned its `true` default and the banner reported Disabled unconditionally. It is also the only read of that key anywhere in the source.

Read `sPlayerbotAIConfig.enabled` instead, which is what actually gates the module and is backed by `AiPlayerbot.Enabled` in `aiplayerbot.conf`. The playerbot config is loaded before `showFooter()` runs, so the value is populated by then.

Verified on a running 4.3.4 server: the banner now reports `PlayerBots : Enabled` with `AiPlayerbot.Enabled = 1`.

Entirely inside `#ifdef ENABLE_PLAYERBOTS`, so the `PLAYERBOTS=0` CI build is unaffected. Both configurations build clean.

Note for the sibling forks: mangoszero and mangosone read the same non-existent key (`World.cpp:976` and `World.cpp:959`) and register `CONFIG_BOOL_PLAYERBOT_DISABLE` without any conf entry backing it, so their banners misreport the same way. Not fixed here — flagging it since the fix would differ slightly per fork.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/318)
<!-- Reviewable:end -->
