### PR TITLE
[Fix] Group: honour the convert-to-party request and test the raid flag as a bit

### DIFF
--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -349,6 +349,52 @@ void Group::ConvertToRaid()
 }
 
 /**
+ * @brief Converts the group back to party mode; a party has one subgroup and no raid roles.
+ */
+void Group::ConvertToParty()
+{
+    m_groupType = GroupType(m_groupType & ~GROUPTYPE_RAID);
+
+    // main tank / main assistant only exist in a raid
+    m_mainTankGuid.Clear();
+    m_mainAssistantGuid.Clear();
+
+    // a party is a single subgroup, so everyone collapses into subgroup 0
+    for (member_witerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        citr->group     = 0;
+        citr->assistant = false;
+
+        Player* player = sObjectMgr.GetPlayer(citr->guid);
+        if (player && player->GetGroup() == this)
+        {
+            player->GetGroupRef().setSubGroup(0);
+        }
+    }
+
+    _initRaidSubGroupsCounter();
+
+    if (!isBGGroup())
+    {
+        CharacterDatabase.PExecute("UPDATE `groups` SET `groupType` = %u, `mainTank` = '0', `mainAssistant` = '0' WHERE `groupId`='%u'",
+                                   uint8(m_groupType), m_Id);
+        CharacterDatabase.PExecute("UPDATE `group_member` SET `subgroup` = '0', `assistant` = '0' WHERE `groupId`='%u'", m_Id);
+    }
+
+    SendUpdate();
+
+    // update quest related GO states (quest activity dependent from raid membership)
+    for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        Player* player = sObjectMgr.GetPlayer(citr->guid);
+        if (player)
+        {
+            player->UpdateForQuestWorldObjects();
+        }
+    }
+}
+
+/**
  * @brief Adds a pending invitation for a player.
  *
  * @param player The invited player.

--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -337,12 +337,14 @@ class Group
         ObjectGuid GetObjectGuid() const { return ObjectGuid(HIGHGUID_GROUP, GetId()); }
         bool IsFull() const
         {
-            return (m_groupType == GROUPTYPE_NORMAL) ? (m_memberSlots.size() >= MAX_GROUP_SIZE) : (m_memberSlots.size() >= MAX_RAID_SIZE);
+            return isRaidGroup() ? (m_memberSlots.size() >= MAX_RAID_SIZE) : (m_memberSlots.size() >= MAX_GROUP_SIZE);
         }
         GroupType GetGroupType() const { return m_groupType; }
+        /// m_groupType is a flag set, so test the bit; an equality check misses
+        /// GROUPTYPE_BGRAID and any future flag OR-ed alongside it.
         bool isRaidGroup() const
         {
-            return m_groupType == GROUPTYPE_RAID;
+            return (m_groupType & GROUPTYPE_RAID) != 0;
         }
         bool isBGGroup()   const
         {
@@ -432,6 +434,7 @@ class Group
 
         // some additional raid methods
         void ConvertToRaid();
+        void ConvertToParty();                              ///< raid -> party, collapses every member into subgroup 0
 
         void SetBattlegroundGroup(BattleGround* bg)
         {

--- a/src/game/WorldHandlers/GroupHandler.cpp
+++ b/src/game/WorldHandlers/GroupHandler.cpp
@@ -686,12 +686,16 @@ void WorldSession::HandleRaidTargetUpdateOpcode(WorldPacket& recv_data)
 }
 
 /**
- * @brief Converts the current party into a raid group.
+ * @brief Converts the current group between party and raid mode.
  *
- * @param recv_data The received opcode packet.
+ * @param recv_data The received opcode packet; carries the target mode.
  */
-void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& /*recv_data*/)
+void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& recv_data)
 {
+    // Lua ConvertToRaid() sends 1, ConvertToParty() sends 0 on the same opcode
+    uint8 toRaid;
+    recv_data >> toRaid;
+
     Group* group = GetPlayer()->GetGroup();
     if (!group)
     {
@@ -708,11 +712,26 @@ void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& /*recv_data*/)
     {
         return;
     }
+
+    // a party cannot hold more than MAX_GROUP_SIZE players
+    if (!toRaid && group->GetMembersCount() > MAX_GROUP_SIZE)
+    {
+        SendPartyResult(PARTY_OP_INVITE, "", ERR_GROUP_FULL);
+        return;
+    }
     /********************/
 
     // everything is fine, do it (is it 0 (PARTY_OP_INVITE) correct code)
     SendPartyResult(PARTY_OP_INVITE, "", ERR_PARTY_RESULT_OK);
-    group->ConvertToRaid();
+
+    if (toRaid)
+    {
+        group->ConvertToRaid();
+    }
+    else
+    {
+        group->ConvertToParty();
+    }
 }
 
 /**


### PR DESCRIPTION
Two group bugs found while making the 4.3.4 raid UI work.

**Convert to Party did the opposite of what it says.** `CMSG_GROUP_RAID_CONVERT`
carries a single byte — the client's `ConvertToRaid()` sends `1`, `ConvertToParty()`
sends `0`, on the same opcode. Both Lua bindings decompile to identical code apart
from that immediate. The handler discarded the payload and always called
`ConvertToRaid()`, and `Group::ConvertToParty()` did not exist. Added it: clears the
raid flag, drops main tank/assistant, collapses every member into subgroup 0 in
memory, in the live `GroupReference`, and in both tables. Converting a raid larger
than `MAX_GROUP_SIZE` now returns `ERR_GROUP_FULL` instead of producing an
impossible party.

**`isRaidGroup()` compared for equality.** `m_groupType` is a flag set, so
`m_groupType == GROUPTYPE_RAID` is false for `GROUPTYPE_BGRAID` — battleground raids
did not count as raids, which quietly disabled assistants, main tank/assistant and
subgroup moves there. Now a bit test. `IsFull()` had the mirror image of the same
bug and is expressed in terms of `isRaidGroup()`.

`GROUPTYPE_BG` is never set on its own (only `GROUPTYPE_BGRAID`), so the only
behaviour changes are the corrections above plus LFD groups capping at 5 rather
than 40.

Builds clean with `PLAYERBOTS=0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/319)
<!-- Reviewable:end -->
