### PR TITLE
[Feature] Raid UI: CUF profiles, roles and everyone-is-assistant

### DIFF
--- a/src/game/Object/CUFProfile.h
+++ b/src/game/Object/CUFProfile.h
@@ -1,0 +1,119 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+/**
+ * @file CUFProfile.h
+ * @brief CompactUnitFrame (raid frame) profiles, stored per character.
+ *
+ * The 4.3.4 client keeps its raid-frame layout server-side. On login it waits for
+ * SMSG_LOAD_CUF_PROFILES before firing COMPACT_UNIT_FRAME_PROFILES_LOADED; until
+ * that event arrives Blizzard_CompactUnitFrameProfiles.lua never activates a
+ * profile, so CompactRaidFrameManager keeps `container.enabled` nil and the raid
+ * frames stay hidden. Sending the packet -- even with no profiles -- lets the
+ * client build its default one.
+ */
+
+#ifndef MANGOS_H_CUFPROFILE
+#define MANGOS_H_CUFPROFILE
+
+#include "Platform/Define.h"
+
+#include <bitset>
+#include <string>
+
+/// Maximum number of CompactUnitFrame profiles the client accepts
+#define MAX_CUF_PROFILES 5
+
+/// Bit index of each boolean option inside CUFProfile::BoolOptions
+enum CUFBoolOptions
+{
+    CUF_KEEP_GROUPS_TOGETHER,
+    CUF_DISPLAY_PETS,
+    CUF_DISPLAY_MAIN_TANK_AND_ASSIST,
+    CUF_DISPLAY_HEAL_PREDICTION,
+    CUF_DISPLAY_AGGRO_HIGHLIGHT,
+    CUF_DISPLAY_ONLY_DISPELLABLE_DEBUFFS,
+    CUF_DISPLAY_POWER_BAR,
+    CUF_DISPLAY_BORDER,
+    CUF_USE_CLASS_COLORS,
+    CUF_DISPLAY_NON_BOSS_DEBUFFS,
+    CUF_DISPLAY_HORIZONTAL_GROUPS,
+    CUF_LOCKED,
+    CUF_SHOWN,
+    CUF_AUTO_ACTIVATE_2_PLAYERS,
+    CUF_AUTO_ACTIVATE_3_PLAYERS,
+    CUF_AUTO_ACTIVATE_5_PLAYERS,
+    CUF_AUTO_ACTIVATE_10_PLAYERS,
+    CUF_AUTO_ACTIVATE_15_PLAYERS,
+    CUF_AUTO_ACTIVATE_25_PLAYERS,
+    CUF_AUTO_ACTIVATE_40_PLAYERS,
+    CUF_AUTO_ACTIVATE_SPEC_1,
+    CUF_AUTO_ACTIVATE_SPEC_2,
+    CUF_AUTO_ACTIVATE_PVP,
+    CUF_AUTO_ACTIVATE_PVE,
+    CUF_UNK_145,
+    CUF_UNK_156,
+    CUF_UNK_157,
+
+    CUF_BOOL_OPTIONS_COUNT
+};
+
+/// One CompactUnitFrame layout as the client stores it
+struct CUFProfile
+{
+    CUFProfile() :
+        ProfileName(),
+        FrameHeight(0),
+        FrameWidth(0),
+        SortBy(0),
+        HealthText(0),
+        TopPoint(0),
+        BottomPoint(0),
+        LeftPoint(0),
+        TopOffset(0),
+        BottomOffset(0),
+        LeftOffset(0),
+        BoolOptions()
+    {
+    }
+
+    std::string ProfileName;
+    uint16 FrameHeight;
+    uint16 FrameWidth;
+    uint8  SortBy;
+    uint8  HealthText;
+
+    uint8  TopPoint;                                        ///< anchor points
+    uint8  BottomPoint;
+    uint8  LeftPoint;
+
+    uint16 TopOffset;                                       ///< anchor offsets
+    uint16 BottomOffset;
+    uint16 LeftOffset;
+
+    std::bitset<CUF_BOOL_OPTIONS_COUNT> BoolOptions;
+};
+
+#endif

--- a/src/game/Object/ObjectMgrInstanceData.cpp
+++ b/src/game/Object/ObjectMgrInstanceData.cpp
@@ -149,8 +149,8 @@ void ObjectMgr::LoadGroups()
 
     // -- loading members --
     count = 0;
-    //                                       0           1          2         3
-    result = CharacterDatabase.Query("SELECT `memberGuid`, `assistant`, `subgroup`, `groupId` FROM `group_member` ORDER BY `groupId`");
+    //                                       0             1            2           3          4
+    result = CharacterDatabase.Query("SELECT `memberGuid`, `assistant`, `subgroup`, `groupId`, `roles` FROM `group_member` ORDER BY `groupId`");
     if (!result)
     {
         BarGoLink bar2(1);
@@ -172,6 +172,7 @@ void ObjectMgr::LoadGroups()
             bool   assistent     = fields[1].GetBool();
             uint8  subgroup      = fields[2].GetUInt8();
             uint32 groupId       = fields[3].GetUInt32();
+            uint8  roles         = fields[4].GetUInt8();
             if (!group || group->GetId() != groupId)
             {
                 group = GetGroupById(groupId);
@@ -184,7 +185,7 @@ void ObjectMgr::LoadGroups()
                 }
             }
 
-            if (!group->LoadMemberFromDB(memberGuidlow, subgroup, assistent))
+            if (!group->LoadMemberFromDB(memberGuidlow, subgroup, assistent, roles))
             {
                 sLog.outErrorDb("Incorrect entry in group_member table : member %s can not be added to group (Id: %u)!",
                                 memberGuid.GetString().c_str(), groupId);

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4707,6 +4707,9 @@ void Player::SendInitialPacketsAfterAddToMap()
     ResetTimeSync();
     SendTimeSync();
 
+    // client gates its whole raid UI on this arriving
+    GetSession()->SendLoadCUFProfiles();
+
     CastSpell(this, 836, true);                             // LOGINEFFECT
 
     // set some aura effects that send packet to player client after add player to map

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -72,6 +72,8 @@
 #include "ItemPrototype.h"
 #include "Item.h"
 #include "GlyphMgr.h"   // GlyphMgr is held by value on Player; brings in Glyph struct + GlyphUpdateState enum
+#include "CUFProfile.h" // raid-frame profiles are held by value on Player
+#include <memory>
 #include "HonorMgr.h"   // HonorMgr is held by value on Player; owns daily-kill rollover + RewardHonor calculation
 #include "CurrencyMgr.h" // CurrencyMgr is held by value on Player; brings in PlayerCurrency struct + PlayerCurrencyState/Flag enums + PlayerCurrenciesMap typedef
 #include "RuneMgr.h"    // RuneMgr is held by value on Player; brings in RuneType/RuneInfo/Runes + owns death-knight rune state
@@ -854,6 +856,7 @@ enum PlayerLoginQueryIndex
     PLAYER_LOGIN_QUERY_LOADWEEKLYQUESTSTATUS,
     PLAYER_LOGIN_QUERY_LOADMONTHLYQUESTSTATUS,
     PLAYER_LOGIN_QUERY_LOADCURRENCIES,
+    PLAYER_LOGIN_QUERY_LOADCUFPROFILES,
 
     MAX_PLAYER_LOGIN_QUERY
 };
@@ -1130,6 +1133,19 @@ class Player : public Unit
         void SendInitialPacketsBeforeAddToMap();
         void SendInitialPacketsAfterAddToMap();
         void SendInstanceResetWarning(uint32 mapid, Difficulty difficulty, uint32 time);
+
+        /// Raid-frame (CompactUnitFrame) profiles; \c NULL slots are unused.
+        CUFProfile* GetCUFProfile(uint8 id) const
+        {
+            MANGOS_ASSERT(id < MAX_CUF_PROFILES);
+            return m_cufProfiles[id].get();
+        }
+        void SaveCUFProfile(uint8 id, std::unique_ptr<CUFProfile> profile)
+        {
+            MANGOS_ASSERT(id < MAX_CUF_PROFILES);
+            m_cufProfiles[id] = std::move(profile);
+            m_cufProfilesChanged = true;
+        }
 
         Creature* GetNPCIfCanInteractWith(ObjectGuid guid, uint32 NpcFlagsmask);
         GameObject* GetGameObjectIfCanInteractWith(ObjectGuid guid, uint32 gameobject_type = MAX_GAMEOBJECT_TYPE);
@@ -3902,6 +3918,7 @@ class Player : public Unit
         void _LoadEquipmentSets(QueryResult* result);
         void _LoadBGData(QueryResult* result);
         void _LoadGlyphs(QueryResult* result) { m_glyphMgr.Load(result); }
+        void _LoadCUFProfiles(QueryResult* result);
         void _LoadIntoDataField(const char* data, uint32 startOffset, uint32 count);
 
         /*********************************************************/
@@ -3932,6 +3949,7 @@ class Player : public Unit
         void _SaveEquipmentSets();
         void _SaveBGData();
         void _SaveGlyphs() { m_glyphMgr.Save(); }
+        void _SaveCUFProfiles();
         void _SaveTalents();
         void _SaveStats();
 
@@ -4019,6 +4037,9 @@ class Player : public Unit
         ActionButtonList m_actionButtons[MAX_TALENT_SPEC_COUNT];
 
         GlyphMgr m_glyphMgr;   // per-spec glyph state + Load/Save/Apply lifecycle (extracted 2026-05-12)
+
+        std::unique_ptr<CUFProfile> m_cufProfiles[MAX_CUF_PROFILES]; // raid-frame layouts, echoed back on login
+        bool m_cufProfilesChanged = false;                           // only rewrite the table when the client edited them
 
         float m_auraBaseMod[BASEMOD_END][MOD_END];
         int16 m_baseRatingValue[MAX_COMBAT_RATING];

--- a/src/game/Object/PlayerLoad.cpp
+++ b/src/game/Object/PlayerLoad.cpp
@@ -461,6 +461,55 @@ void Player::_LoadAuras(QueryResult* result, uint32 timediff)
 // Player::_LoadGlyphs moved to GlyphMgr::Load (2026-05-12); thin delegating wrapper lives inline in Player.h.
 
 /**
+ * @brief Restores the character's raid-frame profiles.
+ *
+ * \arg \c result
+ *   Rows from `character_cuf_profiles`; may be NULL when none are stored.
+ */
+void Player::_LoadCUFProfiles(QueryResult* result)
+{
+    if (!result)
+    {
+        return;
+    }
+
+    do
+    {
+        Field* fields = result->Fetch();
+
+        uint8 id = fields[0].GetUInt8();
+        if (id >= MAX_CUF_PROFILES)
+        {
+            sLog.outError("Player::_LoadCUFProfiles: %s has a profile with invalid id %u, max is %u",
+                          GetGuidStr().c_str(), id, MAX_CUF_PROFILES);
+            continue;
+        }
+
+        std::unique_ptr<CUFProfile> profile(new CUFProfile());
+        profile->ProfileName  = fields[1].GetCppString();
+        profile->FrameHeight  = fields[2].GetUInt16();
+        profile->FrameWidth   = fields[3].GetUInt16();
+        profile->SortBy       = fields[4].GetUInt8();
+        profile->HealthText   = fields[5].GetUInt8();
+        profile->BoolOptions  = std::bitset<CUF_BOOL_OPTIONS_COUNT>(fields[6].GetUInt32());
+        profile->TopPoint     = fields[7].GetUInt8();
+        profile->BottomPoint  = fields[8].GetUInt8();
+        profile->LeftPoint    = fields[9].GetUInt8();
+        profile->TopOffset    = fields[10].GetUInt16();
+        profile->BottomOffset = fields[11].GetUInt16();
+        profile->LeftOffset   = fields[12].GetUInt16();
+
+        m_cufProfiles[id] = std::move(profile);
+    }
+    while (result->NextRow());
+
+    delete result;
+
+    // straight from the DB, so nothing to write back yet
+    m_cufProfilesChanged = false;
+}
+
+/**
  * @brief Restores corpse state for a dead player or cleans it up for a living one.
  */
 void Player::LoadCorpse()

--- a/src/game/Object/PlayerLoadFromDB.cpp
+++ b/src/game/Object/PlayerLoadFromDB.cpp
@@ -564,6 +564,7 @@ bool Player::LoadFromDB(ObjectGuid guid, SqlQueryHolder* holder)
     UpdateNextMailTimeAndUnreads();
 
     _LoadGlyphs(holder->GetResult(PLAYER_LOGIN_QUERY_LOADGLYPHS));
+    _LoadCUFProfiles(holder->GetResult(PLAYER_LOGIN_QUERY_LOADCUFPROFILES));
 
     _LoadAuras(holder->GetResult(PLAYER_LOGIN_QUERY_LOADAURAS), time_diff);
     ApplyGlyphs(true);

--- a/src/game/Object/PlayerSave.cpp
+++ b/src/game/Object/PlayerSave.cpp
@@ -334,6 +334,7 @@ void Player::SaveToDB()
     _SaveEquipmentSets();
     GetSession()->SaveTutorialsData();                      // changed only while character in game
     _SaveGlyphs();
+    _SaveCUFProfiles();
     _SaveTalents();
 
     CharacterDatabase.CommitTransaction();
@@ -515,6 +516,55 @@ void Player::_SaveAuras()
 }
 
 // Player::_SaveGlyphs moved to GlyphMgr::Save (2026-05-12); thin delegating wrapper lives inline in Player.h.
+
+/**
+ * @brief Writes the character's raid-frame profiles, but only if the client changed them.
+ */
+void Player::_SaveCUFProfiles()
+{
+    if (!m_cufProfilesChanged)
+    {
+        return;
+    }
+
+    static SqlStatementID delProfiles;
+    static SqlStatementID insProfile;
+
+    SqlStatement stmt = CharacterDatabase.CreateStatement(delProfiles,
+                        "DELETE FROM `character_cuf_profiles` WHERE `guid` = ?");
+    stmt.PExecute(GetGUIDLow());
+
+    for (uint8 i = 0; i < MAX_CUF_PROFILES; ++i)
+    {
+        CUFProfile const* profile = m_cufProfiles[i].get();
+        if (!profile)
+        {
+            continue;
+        }
+
+        stmt = CharacterDatabase.CreateStatement(insProfile,
+               "INSERT INTO `character_cuf_profiles` (`guid`,`id`,`name`,`frameHeight`,`frameWidth`,`sortBy`,"
+               "`healthText`,`boolOptions`,`topPoint`,`bottomPoint`,`leftPoint`,`topOffset`,`bottomOffset`,`leftOffset`) "
+               "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)");
+        stmt.addUInt32(GetGUIDLow());
+        stmt.addUInt8(i);
+        stmt.addString(profile->ProfileName);
+        stmt.addUInt16(profile->FrameHeight);
+        stmt.addUInt16(profile->FrameWidth);
+        stmt.addUInt8(profile->SortBy);
+        stmt.addUInt8(profile->HealthText);
+        stmt.addUInt32(uint32(profile->BoolOptions.to_ulong()));
+        stmt.addUInt8(profile->TopPoint);
+        stmt.addUInt8(profile->BottomPoint);
+        stmt.addUInt8(profile->LeftPoint);
+        stmt.addUInt16(profile->TopOffset);
+        stmt.addUInt16(profile->BottomOffset);
+        stmt.addUInt16(profile->LeftOffset);
+        stmt.Execute();
+    }
+
+    m_cufProfilesChanged = false;
+}
 
 /**
  * @brief Saves inventory state changes and queued item records to the database.

--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -639,6 +639,13 @@ void InitializeOpcodes()
     OPCODE(CMSG_REQUEST_ACCOUNT_DATA,                    STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandleRequestAccountData        );
     OPCODE(CMSG_UPDATE_ACCOUNT_DATA,                     STATUS_AUTHED,   PROCESS_THREADUNSAFE, &WorldSession::HandleUpdateAccountData         );
     OPCODE(SMSG_UPDATE_ACCOUNT_DATA,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(CMSG_SAVE_CUF_PROFILES,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSaveCUFProfiles           );
+    OPCODE(SMSG_LOAD_CUF_PROFILES,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(CMSG_SET_ROLE,                                STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSetRoleOpcode             );
+    OPCODE(CMSG_ROLE_POLL_BEGIN,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleRolePollBeginOpcode       );
+    OPCODE(SMSG_ROLE_POLL_BEGIN,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_ROLE_CHANGED_INFORM,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(CMSG_SET_EVERYONE_IS_ASSISTANT,               STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSetEveryoneIsAssistantOpcode);
     OPCODE(SMSG_CLEAR_FAR_SIGHT_IMMEDIATE,               STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_CHANGEPLAYER_DIFFICULTY_RESULT,          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_GM_TEACH,                                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -504,6 +504,7 @@ class WorldSession
         AccountData* GetAccountData(AccountDataType type) { return &m_accountData[type]; }
         void SetAccountData(AccountDataType type, time_t time_, const std::string& data);
         void SendAccountDataTimes(uint32 mask);
+        void SendLoadCUFProfiles();                         ///< raid-frame profiles; client blocks its raid UI until this arrives
         void LoadGlobalAccountData();
         void LoadAccountData(QueryResult* result, uint32 mask);
         void LoadTutorialsData();
@@ -701,6 +702,10 @@ class WorldSession
 
         void HandleUpdateAccountData(WorldPacket& recvPacket);
         void HandleRequestAccountData(WorldPacket& recvPacket);
+        void HandleSaveCUFProfiles(WorldPacket& recvPacket);
+        void HandleSetRoleOpcode(WorldPacket& recv_data);
+        void HandleRolePollBeginOpcode(WorldPacket& recv_data);
+        void HandleSetEveryoneIsAssistantOpcode(WorldPacket& recv_data);
         void HandleSetActionButtonOpcode(WorldPacket& recvPacket);
 
         void HandleGameObjectUseOpcode(WorldPacket& recPacket);

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -166,6 +166,7 @@ bool LoginQueryHolder::Initialize()
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMAILS,           "SELECT `id`,`messageType`,`sender`,`receiver`,`subject`,`body`,`expire_time`,`deliver_time`,`money`,`cod`,`checked`,`stationery`,`mailTemplateId`,`has_items` FROM `mail` WHERE `receiver` = '%u' ORDER BY `id` DESC", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADMAILEDITEMS,     "SELECT `data`, `text`, `mail_id`, `item_guid`, `item_template` FROM `mail_items` JOIN `item_instance` ON `item_guid` = `guid` WHERE `receiver` = '%u'", m_guid.GetCounter());
     res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADCURRENCIES,      "SELECT `id`, `totalCount`, `weekCount`, `seasonCount`, `flags` FROM `character_currencies` WHERE `guid` = '%u'", m_guid.GetCounter());
+    res &= SetPQuery(PLAYER_LOGIN_QUERY_LOADCUFPROFILES,     "SELECT `id`, `name`, `frameHeight`, `frameWidth`, `sortBy`, `healthText`, `boolOptions`, `topPoint`, `bottomPoint`, `leftPoint`, `topOffset`, `bottomOffset`, `leftOffset` FROM `character_cuf_profiles` WHERE `guid` = '%u'", m_guid.GetCounter());
 
     return res;
 }

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -62,6 +62,7 @@
 #include "MapPersistentStateMgr.h"
 #include "Util.h"
 #include "LootMgr.h"
+#include <atomic>
 
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
@@ -305,7 +306,7 @@ bool Group::LoadGroupFromDB(Field* fields)
  * @param assistant True if the member is an assistant.
  * @return true if the member was loaded successfully; otherwise false.
  */
-bool Group::LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant)
+bool Group::LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant, uint8 roles)
 {
     MemberSlot member;
     member.guid      = ObjectGuid(HIGHGUID_PLAYER, guidLow);
@@ -318,6 +319,7 @@ bool Group::LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant)
 
     member.group     = subgroup;
     member.assistant = assistant;
+    member.roles     = roles;
     m_memberSlots.push_back(member);
 
     SubGroupCounterIncrease(subgroup);
@@ -346,6 +348,60 @@ void Group::ConvertToRaid()
         {
             player->UpdateForQuestWorldObjects();
         }
+}
+
+/**
+ * @brief Flags every member as assistant (PartyFlags bit 0x40).
+ *
+ * @param apply true to set, false to clear.
+ */
+void Group::SetEveryoneIsAssistant(bool apply)
+{
+    if (apply)
+    {
+        m_groupType = GroupType(m_groupType | GROUPTYPE_EVERYONE_ASSISTANT);
+    }
+    else
+    {
+        m_groupType = GroupType(m_groupType & ~GROUPTYPE_EVERYONE_ASSISTANT);
+    }
+
+    if (!isBGGroup())
+    {
+        CharacterDatabase.PExecute("UPDATE `groups` SET `groupType` = %u WHERE `groupId`='%u'", uint8(m_groupType), m_Id);
+    }
+
+    SendUpdate();
+}
+
+/**
+ * @brief Records the role a member picked and republishes the roster.
+ *
+ * @param guid Member to update.
+ * @param roles Role mask from the client.
+ */
+void Group::SetLfgRoles(ObjectGuid guid, uint8 roles)
+{
+    member_witerator slot = _getMemberWSlot(guid);
+    if (slot == m_memberSlots.end())
+    {
+        return;
+    }
+
+    if (slot->roles == roles)
+    {
+        return;
+    }
+
+    slot->roles = roles;
+
+    if (!isBGGroup())
+    {
+        CharacterDatabase.PExecute("UPDATE `group_member` SET `roles` = '%u' WHERE `memberGuid`='%u'",
+                                   roles, guid.GetCounter());
+    }
+
+    SendUpdate();
 }
 
 /**
@@ -1516,10 +1572,33 @@ void Group::SendTargetIconList(WorldSession* session)
 }
 
 /**
+ * Roster version stamped into SMSG_GROUP_LIST.
+ *
+ * The client drops a roster it has already seen: for a matching party GUID less
+ * than 60s old it compares stored >= incoming and discards the packet. That makes
+ * a per-group counter unsafe, because group ids are reused and a fresh group
+ * starting at 1 would be rejected against the previous occupant's higher value. A
+ * server-wide counter can never regress. Zero disables the check, so it is skipped.
+ */
+static std::atomic<uint32> s_groupListSequence(0);
+
+static uint32 NextGroupListSequence()
+{
+    uint32 seq = ++s_groupListSequence;
+    if (seq == 0)                                           // wrapped
+    {
+        seq = ++s_groupListSequence;
+    }
+    return seq;
+}
+
+/**
  * @brief Sends a full group list update to every connected member.
  */
 void Group::SendUpdate()
 {
+    uint32 const sequence = NextGroupListSequence();
+
     for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
     {
         Player* player = sObjectMgr.GetPlayer(citr->guid);
@@ -1532,7 +1611,7 @@ void Group::SendUpdate()
         data << uint8(m_groupType);                         // group type (flags in 3.3)
         data << uint8(citr->group);                         // groupid
         data << uint8(GetFlags(*citr));                     // group flags
-        data << uint8(isBGGroup() ? 1 : 0);                 // 2.0.x, isBattleGroundGroup?
+        data << uint8(citr->roles);                         // your own assigned role
         if (m_groupType & GROUPTYPE_LFD)
         {
             data << uint8(0);
@@ -1540,7 +1619,7 @@ void Group::SendUpdate()
             data << uint8(0);
         }
         data << GetObjectGuid();                            // group guid
-        data << uint32(0);                                  // 3.3, this value increments every time SMSG_GROUP_LIST is sent
+        data << uint32(sequence);                           // roster version; client drops anything it has already seen
         data << uint32(GetMembersCount() - 1);
         for (member_citerator citr2 = m_memberSlots.begin(); citr2 != m_memberSlots.end(); ++citr2)
         {
@@ -1557,7 +1636,7 @@ void Group::SendUpdate()
             data << uint8(onlineState);                     // online-state
             data << uint8(citr2->group);                    // groupid
             data << uint8(GetFlags(*citr2));                // group flags
-            data << uint8(0);                               // roles mask
+            data << uint8(citr2->roles);                    // assigned role
         }
 
         data << m_leaderGuid;                               // leader guid

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -349,6 +349,52 @@ void Group::ConvertToRaid()
 }
 
 /**
+ * @brief Converts the group back to party mode; a party has one subgroup and no raid roles.
+ */
+void Group::ConvertToParty()
+{
+    m_groupType = GroupType(m_groupType & ~GROUPTYPE_RAID);
+
+    // main tank / main assistant only exist in a raid
+    m_mainTankGuid.Clear();
+    m_mainAssistantGuid.Clear();
+
+    // a party is a single subgroup, so everyone collapses into subgroup 0
+    for (member_witerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        citr->group     = 0;
+        citr->assistant = false;
+
+        Player* player = sObjectMgr.GetPlayer(citr->guid);
+        if (player && player->GetGroup() == this)
+        {
+            player->GetGroupRef().setSubGroup(0);
+        }
+    }
+
+    _initRaidSubGroupsCounter();
+
+    if (!isBGGroup())
+    {
+        CharacterDatabase.PExecute("UPDATE `groups` SET `groupType` = %u, `mainTank` = '0', `mainAssistant` = '0' WHERE `groupId`='%u'",
+                                   uint8(m_groupType), m_Id);
+        CharacterDatabase.PExecute("UPDATE `group_member` SET `subgroup` = '0', `assistant` = '0' WHERE `groupId`='%u'", m_Id);
+    }
+
+    SendUpdate();
+
+    // update quest related GO states (quest activity dependent from raid membership)
+    for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        Player* player = sObjectMgr.GetPlayer(citr->guid);
+        if (player)
+        {
+            player->UpdateForQuestWorldObjects();
+        }
+    }
+}
+
+/**
  * @brief Adds a pending invitation for a player.
  *
  * @param player The invited player.

--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -337,12 +337,14 @@ class Group
         ObjectGuid GetObjectGuid() const { return ObjectGuid(HIGHGUID_GROUP, GetId()); }
         bool IsFull() const
         {
-            return (m_groupType == GROUPTYPE_NORMAL) ? (m_memberSlots.size() >= MAX_GROUP_SIZE) : (m_memberSlots.size() >= MAX_RAID_SIZE);
+            return isRaidGroup() ? (m_memberSlots.size() >= MAX_RAID_SIZE) : (m_memberSlots.size() >= MAX_GROUP_SIZE);
         }
         GroupType GetGroupType() const { return m_groupType; }
+        /// m_groupType is a flag set, so test the bit; an equality check misses
+        /// GROUPTYPE_BGRAID and any future flag OR-ed alongside it.
         bool isRaidGroup() const
         {
-            return m_groupType == GROUPTYPE_RAID;
+            return (m_groupType & GROUPTYPE_RAID) != 0;
         }
         bool isBGGroup()   const
         {
@@ -432,6 +434,7 @@ class Group
 
         // some additional raid methods
         void ConvertToRaid();
+        void ConvertToParty();                              ///< raid -> party, collapses every member into subgroup 0
 
         void SetBattlegroundGroup(BattleGround* bg)
         {

--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -154,6 +154,8 @@ enum GroupType
     // 0x04?
     GROUPTYPE_LFD    = 0x08,
     // 0x10, leave/change group?, I saw this flag when leaving group and after leaving BG while in group
+    GROUPTYPE_ONE_PERSON_PARTY   = 0x20,                   ///< client: Lua_IsOnePersonParty
+    GROUPTYPE_EVERYONE_ASSISTANT = 0x40,                   ///< client: Lua_IsEveryoneAssistant
 };
 
 enum GroupFlagMask
@@ -284,6 +286,8 @@ class Group
             uint8       group;
             /* Indicates whether the player is assistant. */
             bool        assistant;
+            /* Role mask the player picked (tank/healer/damage). */
+            uint8       roles = 0;
             uint32      lastMap;
         };
         typedef std::list<MemberSlot> MemberSlotList;
@@ -302,7 +306,7 @@ class Group
         // group manipulation methods
         bool   Create(ObjectGuid guid, const char* name);
         bool   LoadGroupFromDB(Field* fields);
-        bool   LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant);
+        bool   LoadMemberFromDB(uint32 guidLow, uint8 subgroup, bool assistant, uint8 roles = 0);
         bool   AddInvite(Player* player);
         uint32 RemoveInvite(Player* player);
         void   RemoveAllInvites();
@@ -435,6 +439,16 @@ class Group
         // some additional raid methods
         void ConvertToRaid();
         void ConvertToParty();                              ///< raid -> party, collapses every member into subgroup 0
+
+        void SetEveryoneIsAssistant(bool apply);            ///< PartyFlags bit 0x40; Lua_IsEveryoneAssistant
+        bool IsEveryoneAssistant() const { return (m_groupType & GROUPTYPE_EVERYONE_ASSISTANT) != 0; }
+
+        void SetLfgRoles(ObjectGuid guid, uint8 roles);     ///< role the client picked; echoed back in SMSG_GROUP_LIST
+        uint8 GetLfgRoles(ObjectGuid guid) const
+        {
+            member_citerator slot = _getMemberCSlot(guid);
+            return slot == m_memberSlots.end() ? 0 : slot->roles;
+        }
 
         void SetBattlegroundGroup(BattleGround* bg)
         {

--- a/src/game/WorldHandlers/GroupHandler.cpp
+++ b/src/game/WorldHandlers/GroupHandler.cpp
@@ -55,6 +55,7 @@
 #include "Player.h"
 #include "SpellAuras.h"
 #include "Group.h"
+#include "LFGMgr.h"                                         // LFGRoles: PLAYER_ROLE_*
 #include "SocialMgr.h"
 #include "Util.h"
 #include "DB2Structure.h"
@@ -732,6 +733,136 @@ void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& recv_data)
     {
         group->ConvertToParty();
     }
+}
+
+/**
+ * Builds SMSG_ROLE_CHANGED_INFORM.
+ *
+ * Bit and byte order are transcribed from the client's own reader; the two GUIDs
+ * interleave, so this cannot use the single-GUID WriteGuidMask helpers.
+ */
+static void BuildRoleChangedInform(WorldPacket& data, ObjectGuid from, ObjectGuid changed,
+                                   uint32 oldRole, uint32 newRole)
+{
+    uint64 rawFrom = from.GetRawValue();
+    uint64 rawChanged = changed.GetRawValue();
+    uint8 const* f = (uint8 const*)&rawFrom;
+    uint8 const* c = (uint8 const*)&rawChanged;
+
+    data.WriteBit(f[1]); data.WriteBit(c[0]); data.WriteBit(c[2]); data.WriteBit(c[4]);
+    data.WriteBit(c[7]); data.WriteBit(c[3]); data.WriteBit(f[7]); data.WriteBit(c[5]);
+    data.WriteBit(f[5]); data.WriteBit(f[4]); data.WriteBit(f[3]); data.WriteBit(c[6]);
+    data.WriteBit(f[2]); data.WriteBit(f[6]); data.WriteBit(c[1]); data.WriteBit(f[0]);
+
+    data.FlushBits();
+
+    #define ROLE_SEQ(b) if (b) { data << uint8((b) ^ 1); }
+    ROLE_SEQ(f[7]); ROLE_SEQ(c[3]); ROLE_SEQ(f[6]); ROLE_SEQ(c[4]); ROLE_SEQ(c[0]);
+    data << uint32(newRole);
+    ROLE_SEQ(c[6]); ROLE_SEQ(c[2]); ROLE_SEQ(f[0]); ROLE_SEQ(f[4]); ROLE_SEQ(c[1]);
+    ROLE_SEQ(f[3]); ROLE_SEQ(f[5]); ROLE_SEQ(f[2]); ROLE_SEQ(c[5]); ROLE_SEQ(c[7]);
+    ROLE_SEQ(f[1]);
+    data << uint32(oldRole);
+    #undef ROLE_SEQ
+}
+
+/**
+ * @brief Records the role a player picked in the role-poll popup.
+ *
+ * @param recv_data The received opcode packet; uint32 role then a packed GUID.
+ */
+void WorldSession::HandleSetRoleOpcode(WorldPacket& recv_data)
+{
+    uint32 role;
+    recv_data >> role;
+
+    ObjectGuid changedUnit;
+    recv_data.ReadGuidMask<2, 6, 3, 7, 5, 1, 0, 4>(changedUnit);
+    recv_data.ReadGuidBytes<6, 4, 1, 3, 0, 5, 2, 7>(changedUnit);
+
+    // never trust the client with the spare bits
+    role &= (PLAYER_ROLE_LEADER | PLAYER_ROLE_TANK | PLAYER_ROLE_HEALER | PLAYER_ROLE_DAMAGE);
+
+    Group* group = GetPlayer()->GetGroup();
+    if (!group)
+    {
+        return;
+    }
+
+    // only the leader/assistants may re-role someone else
+    if (changedUnit != GetPlayer()->GetObjectGuid() &&
+        !group->IsLeader(GetPlayer()->GetObjectGuid()) &&
+        !group->IsAssistant(GetPlayer()->GetObjectGuid()))
+    {
+        return;
+    }
+
+    uint8 oldRole = group->GetLfgRoles(changedUnit);
+    if (oldRole == uint8(role))
+    {
+        return;
+    }
+
+    WorldPacket data(SMSG_ROLE_CHANGED_INFORM, 8 + 8 + 4 + 4);
+    BuildRoleChangedInform(data, GetPlayer()->GetObjectGuid(), changedUnit, oldRole, role);
+    group->BroadcastPacket(&data, false);
+
+    // roles also ride back to every client inside SMSG_GROUP_LIST
+    group->SetLfgRoles(changedUnit, uint8(role));
+}
+
+/**
+ * @brief Starts a role check; asks every member to re-pick their role.
+ *
+ * @param recv_data The received opcode packet; an empty body starts the poll.
+ */
+void WorldSession::HandleRolePollBeginOpcode(WorldPacket& recv_data)
+{
+    Group* group = GetPlayer()->GetGroup();
+    if (!group)
+    {
+        return;
+    }
+
+    if (!recv_data.empty())
+    {
+        return;
+    }
+
+    ObjectGuid guid = GetPlayer()->GetObjectGuid();
+    if (!group->IsLeader(guid) && !group->IsAssistant(guid))
+    {
+        return;
+    }
+
+    WorldPacket data(SMSG_ROLE_POLL_BEGIN, 8);
+    data.WriteGuidMask<1, 5, 7, 3, 2, 4, 0, 6>(guid);
+    data.WriteGuidBytes<4, 7, 0, 5, 1, 6, 2, 3>(guid);
+
+    group->BroadcastPacket(&data, true);
+}
+
+/**
+ * @brief Toggles the raid's "everyone is assistant" flag.
+ *
+ * @param recv_data The received opcode packet.
+ */
+void WorldSession::HandleSetEveryoneIsAssistantOpcode(WorldPacket& recv_data)
+{
+    bool apply = recv_data.ReadBit();
+
+    Group* group = GetPlayer()->GetGroup();
+    if (!group)
+    {
+        return;
+    }
+
+    if (!group->IsLeader(GetPlayer()->GetObjectGuid()))
+    {
+        return;
+    }
+
+    group->SetEveryoneIsAssistant(apply);
 }
 
 /**

--- a/src/game/WorldHandlers/GroupHandler.cpp
+++ b/src/game/WorldHandlers/GroupHandler.cpp
@@ -686,12 +686,16 @@ void WorldSession::HandleRaidTargetUpdateOpcode(WorldPacket& recv_data)
 }
 
 /**
- * @brief Converts the current party into a raid group.
+ * @brief Converts the current group between party and raid mode.
  *
- * @param recv_data The received opcode packet.
+ * @param recv_data The received opcode packet; carries the target mode.
  */
-void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& /*recv_data*/)
+void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& recv_data)
 {
+    // Lua ConvertToRaid() sends 1, ConvertToParty() sends 0 on the same opcode
+    uint8 toRaid;
+    recv_data >> toRaid;
+
     Group* group = GetPlayer()->GetGroup();
     if (!group)
     {
@@ -708,11 +712,26 @@ void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& /*recv_data*/)
     {
         return;
     }
+
+    // a party cannot hold more than MAX_GROUP_SIZE players
+    if (!toRaid && group->GetMembersCount() > MAX_GROUP_SIZE)
+    {
+        SendPartyResult(PARTY_OP_INVITE, "", ERR_GROUP_FULL);
+        return;
+    }
     /********************/
 
     // everything is fine, do it (is it 0 (PARTY_OP_INVITE) correct code)
     SendPartyResult(PARTY_OP_INVITE, "", ERR_PARTY_RESULT_OK);
-    group->ConvertToRaid();
+
+    if (toRaid)
+    {
+        group->ConvertToRaid();
+    }
+    else
+    {
+        group->ConvertToParty();
+    }
 }
 
 /**

--- a/src/game/WorldHandlers/GroupMemberState.cpp
+++ b/src/game/WorldHandlers/GroupMemberState.cpp
@@ -165,8 +165,8 @@ bool Group::_addMember(ObjectGuid guid, const char* name, bool isAssistant, uint
     if (!isBGGroup())
     {
         // insert into group table
-        CharacterDatabase.PExecute("INSERT INTO `group_member` (`groupId`,`memberGuid`,`assistant`,`subgroup`) VALUES ('%u','%u','%u','%u')",
-                                   m_Id, member.guid.GetCounter(), ((member.assistant == 1) ? 1 : 0), member.group);
+        CharacterDatabase.PExecute("INSERT INTO `group_member` (`groupId`,`memberGuid`,`assistant`,`subgroup`,`roles`) VALUES ('%u','%u','%u','%u','%u')",
+                                   m_Id, member.guid.GetCounter(), ((member.assistant == 1) ? 1 : 0), member.group, member.roles);
     }
 
     return true;

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -909,6 +909,171 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
 }
 
 /**
+ * @brief Sends the character's raid-frame (CompactUnitFrame) profiles.
+ *
+ * The 4.3.4 client will not fire COMPACT_UNIT_FRAME_PROFILES_LOADED until this
+ * arrives, and Blizzard_CompactUnitFrameProfiles.lua activates no profile until
+ * it does -- which leaves CompactRaidFrameManager's container disabled and the
+ * raid frames hidden. An empty list is valid: the client then builds its own
+ * default profile.
+ */
+void WorldSession::SendLoadCUFProfiles()
+{
+    Player* player = GetPlayer();
+    if (!player)
+    {
+        return;
+    }
+
+    std::vector<CUFProfile const*> profiles;
+    for (uint8 i = 0; i < MAX_CUF_PROFILES; ++i)
+    {
+        if (CUFProfile const* profile = player->GetCUFProfile(i))
+        {
+            profiles.push_back(profile);
+        }
+    }
+
+    WorldPacket data(SMSG_LOAD_CUF_PROFILES, 3 + profiles.size() * 32);
+
+    data.WriteBits(profiles.size(), 20);
+
+    // bit order below is the client's, not a sensible one -- do not "tidy" it
+    for (CUFProfile const* profile : profiles)
+    {
+        data.WriteBit(profile->BoolOptions[CUF_UNK_157]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_10_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_5_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_25_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_HEAL_PREDICTION]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_PVE]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_HORIZONTAL_GROUPS]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_40_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_3_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_AGGRO_HIGHLIGHT]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_BORDER]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_2_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_NON_BOSS_DEBUFFS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_MAIN_TANK_AND_ASSIST]);
+        data.WriteBit(profile->BoolOptions[CUF_UNK_156]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_SPEC_2]);
+        data.WriteBit(profile->BoolOptions[CUF_USE_CLASS_COLORS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_POWER_BAR]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_SPEC_1]);
+        data.WriteBits(profile->ProfileName.size(), 8);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_ONLY_DISPELLABLE_DEBUFFS]);
+        data.WriteBit(profile->BoolOptions[CUF_KEEP_GROUPS_TOGETHER]);
+        data.WriteBit(profile->BoolOptions[CUF_UNK_145]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_15_PLAYERS]);
+        data.WriteBit(profile->BoolOptions[CUF_DISPLAY_PETS]);
+        data.WriteBit(profile->BoolOptions[CUF_AUTO_ACTIVATE_PVP]);
+    }
+
+    data.FlushBits();
+
+    for (CUFProfile const* profile : profiles)
+    {
+        data << uint16(profile->LeftOffset);
+        data << uint16(profile->FrameHeight);
+        data << uint16(profile->BottomOffset);
+        data << uint8(profile->BottomPoint);
+        data << uint16(profile->TopOffset);
+        data << uint8(profile->TopPoint);
+        data << uint8(profile->HealthText);
+        data << uint8(profile->SortBy);
+        data << uint16(profile->FrameWidth);
+        data << uint8(profile->LeftPoint);
+        data.append(profile->ProfileName.c_str(), profile->ProfileName.size());
+    }
+
+    SendPacket(&data);
+}
+
+/**
+ * @brief Stores raid-frame profiles the client edited.
+ *
+ * @param recv_data The received opcode packet.
+ */
+void WorldSession::HandleSaveCUFProfiles(WorldPacket& recv_data)
+{
+    DEBUG_LOG("WORLD: Received opcode CMSG_SAVE_CUF_PROFILES");
+
+    Player* player = GetPlayer();
+    if (!player)
+    {
+        recv_data.rfinish();
+        return;
+    }
+
+    uint8 count = uint8(recv_data.ReadBits(20));
+    if (count > MAX_CUF_PROFILES)
+    {
+        sLog.outError("HandleSaveCUFProfiles: %s sent %u profiles, max is %u",
+                      player->GetName(), count, MAX_CUF_PROFILES);
+        recv_data.rfinish();
+        return;
+    }
+
+    std::unique_ptr<CUFProfile> profiles[MAX_CUF_PROFILES];
+    uint8 nameLengths[MAX_CUF_PROFILES];
+
+    // the read order differs from the write order -- both are the client's
+    for (uint8 i = 0; i < count; ++i)
+    {
+        profiles[i].reset(new CUFProfile());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_SPEC_2, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_10_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_UNK_157, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_HEAL_PREDICTION, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_SPEC_1, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_PVP, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_POWER_BAR, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_15_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_40_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_PETS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_5_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_ONLY_DISPELLABLE_DEBUFFS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_2_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_UNK_156, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_NON_BOSS_DEBUFFS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_MAIN_TANK_AND_ASSIST, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_AGGRO_HIGHLIGHT, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_3_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_BORDER, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_USE_CLASS_COLORS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_UNK_145, recv_data.ReadBit());
+        nameLengths[i] = uint8(recv_data.ReadBits(8));
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_PVE, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_DISPLAY_HORIZONTAL_GROUPS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_AUTO_ACTIVATE_25_PLAYERS, recv_data.ReadBit());
+        profiles[i]->BoolOptions.set(CUF_KEEP_GROUPS_TOGETHER, recv_data.ReadBit());
+    }
+
+    for (uint8 i = 0; i < count; ++i)
+    {
+        recv_data >> profiles[i]->TopPoint;
+        profiles[i]->ProfileName = recv_data.ReadString(nameLengths[i]);
+        recv_data >> profiles[i]->BottomOffset;
+        recv_data >> profiles[i]->FrameHeight;
+        recv_data >> profiles[i]->FrameWidth;
+        recv_data >> profiles[i]->TopOffset;
+        recv_data >> profiles[i]->HealthText;
+        recv_data >> profiles[i]->BottomPoint;
+        recv_data >> profiles[i]->SortBy;
+        recv_data >> profiles[i]->LeftOffset;
+        recv_data >> profiles[i]->LeftPoint;
+
+        player->SaveCUFProfile(i, std::move(profiles[i]));
+    }
+
+    // slots the client no longer uses
+    for (uint8 i = count; i < MAX_CUF_PROFILES; ++i)
+    {
+        player->SaveCUFProfile(i, std::unique_ptr<CUFProfile>());
+    }
+}
+
+/**
  * @brief Consumes an account-data update packet.
  *
  * @param recv_data The received opcode packet.

--- a/src/proto/Opcodes.h
+++ b/src/proto/Opcodes.h
@@ -607,6 +607,13 @@ enum OpcodesList
     CMSG_REQUEST_ACCOUNT_DATA                             = 0x6505, // 4.3.4 15595
     CMSG_UPDATE_ACCOUNT_DATA                              = 0x4736, // 4.3.4 15595
     SMSG_UPDATE_ACCOUNT_DATA                              = 0x6837, // 4.3.4 15595
+    CMSG_SAVE_CUF_PROFILES                                = 0x730E, // 4.3.4 15595
+    SMSG_LOAD_CUF_PROFILES                                = 0x50B1, // 4.3.4 15595
+    CMSG_SET_ROLE                                         = 0x25B1, // 4.3.4 15595
+    CMSG_ROLE_POLL_BEGIN                                  = 0x0430, // 4.3.4 15595
+    SMSG_ROLE_POLL_BEGIN                                  = 0x70B0, // 4.3.4 15595
+    SMSG_ROLE_CHANGED_INFORM                              = 0x39A6, // 4.3.4 15595
+    CMSG_SET_EVERYONE_IS_ASSISTANT                        = 0x2530, // 4.3.4 15595
     SMSG_CLEAR_FAR_SIGHT_IMMEDIATE                        = 0x2A04, // 4.3.4 15595
     SMSG_CHANGEPLAYER_DIFFICULTY_RESULT                   = 0x2217, // 4.3.4 15595
     CMSG_GM_TEACH                                         = 0x1210,

--- a/src/shared/revision_data.h.in
+++ b/src/shared/revision_data.h.in
@@ -51,8 +51,8 @@
 
     #define CHAR_DB_VERSION_NR          "22"
     #define CHAR_DB_STRUCTURE_NR        "8"
-    #define CHAR_DB_CONTENT_NR          "1"
-    #define CHAR_DB_UPDATE_DESCRIPT     "ai_playerbot_tables"
+    #define CHAR_DB_CONTENT_NR          "3"
+    #define CHAR_DB_UPDATE_DESCRIPT     "Add_character_cuf_profiles"
 
     #define WORLD_DB_VERSION_NR         "22"
     #define WORLD_DB_STRUCTURE_NR       "6"


### PR DESCRIPTION
Depends on #319 (contains its commit; the diff shrinks once that merges).
Needs database PR mangosthree/database for `Rel22_08_002` and `Rel22_08_003`.

**Raid frames never appeared.** The 4.3.4 client stores its CompactUnitFrame
layout server-side and waits for `SMSG_LOAD_CUF_PROFILES` (0x50B1) before firing
`COMPACT_UNIT_FRAME_PROFILES_LOADED`. Until that fires,
`CompactUnitFrameProfiles_ValidateProfilesLoaded` activates no profile, so
`CompactRaidFrameManager_SetIsShown`/`_SetLocked` never run — and those are the only
writers of both the Lock/Show button text and `container.enabled`. One missing packet,
two symptoms: hidden raid frames and blank buttons. An empty list is enough; the
client then builds its own default. Profiles persist in `character_cuf_profiles`.

**Roles were never stored.** `SMSG_GROUP_LIST` sent `isBGGroup()` where the client
reads your own role, and a hardcoded `0` for every member, so role icons and the
tank/healer/damage counters could never populate. `MemberSlot` now carries the role,
`CMSG_SET_ROLE` (0x25B1) records it, `CMSG_ROLE_POLL_BEGIN` drives Role Check, and
`SMSG_ROLE_CHANGED_INFORM` reports changes. Persisted in `group_member.roles`.

**Everyone-is-assistant** sets PartyFlags bit `0x40`, which the client reads for
`IsEveryoneAssistant()`.

**SequenceNum** was hardcoded `0`, which disables the client's duplicate-roster check
outright. Now a server-wide counter — deliberately not per-group, since group ids are
reused and a fresh group starting at 1 would be rejected against the previous
occupant's higher value.

Opcode values and packet layouts were taken from the 4.3.4 client's own readers and
writers, then confirmed against live captures. Builds clean with `PLAYERBOTS=0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/320)
<!-- Reviewable:end -->
