### PR TITLE
[Bots] Answer raid role checks

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -17,6 +17,7 @@
 #include "PlayerbotSecurity.h"
 #include "Util.h"
 #include "Group.h"
+#include "LFGMgr.h"                                         // LFGRoles: PLAYER_ROLE_TANK/HEALER/DAMAGE
 #include "Pet.h"
 #include "SpellAuras.h"
 #include "../ahbot/AhBot.h"
@@ -493,6 +494,26 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
         uint32 spellId;
         p >> spellId;
         SpellInterrupted(spellId);
+        return;
+    }
+    case SMSG_ROLE_POLL_BEGIN:
+    {
+        // a bot has no role-poll popup, so answer it straight from the strategy
+        // it is already running -- same source IsTank()/IsHeal() read.
+        if (Group* group = bot->GetGroup())
+        {
+            uint8 role = PLAYER_ROLE_DAMAGE;
+            if (ContainsStrategy(STRATEGY_TYPE_TANK))
+            {
+                role = PLAYER_ROLE_TANK;
+            }
+            else if (ContainsStrategy(STRATEGY_TYPE_HEAL))
+            {
+                role = PLAYER_ROLE_HEALER;
+            }
+
+            group->SetLfgRoles(bot->GetObjectGuid(), role);
+        }
         return;
     }
     case SMSG_SPELL_DELAYED:


### PR DESCRIPTION
Depends on #320 for `SMSG_ROLE_POLL_BEGIN` and `Group::SetLfgRoles`.

Bots already receive the role poll — `Group::BroadcastPacket` sends to every member
with a session — they just ignored it. Since a bot has no popup to click, it answers
from the strategy it is already running (`STRATEGY_TYPE_TANK` / `STRATEGY_TYPE_HEAL`),
the same source `IsTank()`/`IsHeal()` read, so the reported role matches how the bot
actually plays.

Without this the tank/healer/damage counters never count any bot, because roles only
reach the client through `SMSG_GROUP_LIST` and a bot never set one.

Builds clean with `PLAYERBOTS=1`; the file is not compiled with `PLAYERBOTS=0`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/322)
<!-- Reviewable:end -->
