### PR TITLE
[Log] Attribute each packet dump to its session instead of "SOCKET"

### DIFF
--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -324,6 +324,19 @@ proto::SessionId WorldGateway::Attach(const proto::AuthRequest& request,
     return id;
 }
 
+void WorldGateway::TracePacket(proto::SessionId session, const WorldPacket& packet,
+                               bool incoming)
+{
+    // Both directions, from the one place that sees every packet on the wire. It used to
+    // be two: this side keyed on the SessionId, WorldSession::SendPacket on the account
+    // id, so one field carried two numbering schemes and named neither.
+    if (sLog.IsPacketLoggingEnabled())
+    {
+        sLog.outWorldPacketDump(session, packet.GetOpcode(),
+                                LookupOpcodeName(packet.GetOpcode()), &packet, incoming);
+    }
+}
+
 void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
 {
     // WorldSocket.cpp:864-868: opcodes outside the known table were rejected
@@ -335,16 +348,6 @@ void WorldGateway::Deliver(proto::SessionId session, WorldPacket&& packet)
         sLog.outError("WorldGateway: received nonexistent opcode 0x%.4X",
                       packet.GetOpcode());
         return;
-    }
-
-    // Dump incoming packet (opt-in via PacketLoggingEnabled; off by default).
-    // WorldSocket.cpp:875-879 did this with the ACE socket fd as the "SOCKET:"
-    // field; the proto SessionId is the modern equivalent -- a slot assigned
-    // once at Attach() and released at Detach(), same lifetime shape as a fd.
-    if (sLog.IsPacketLoggingEnabled())
-    {
-        sLog.outWorldPacketDump(session, packet.GetOpcode(),
-                                LookupOpcodeName(packet.GetOpcode()), &packet, true);
     }
 
     std::shared_ptr<SessionMailbox> mailbox;

--- a/src/game/Server/WorldGateway.h
+++ b/src/game/Server/WorldGateway.h
@@ -63,6 +63,9 @@ class WorldGateway : public proto::IWorldGateway
                                 const std::shared_ptr<proto::IClientLink>& link,
                                 const std::shared_ptr<proto::AuthContext>& context) override;
 
+        void TracePacket(proto::SessionId session, const WorldPacket& packet,
+                         bool incoming) override;
+
         void Deliver(proto::SessionId session, WorldPacket&& packet) override;
 
         void Detach(proto::SessionId session) override;

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -295,18 +295,10 @@ void WorldSession::SendPacket(WorldPacket const* packet)
 
 #endif                                                  // !MANGOS_DEBUG
 
-    // Dump outgoing packet (opt-in via PacketLoggingEnabled; off by default).
-    // WorldSocket.cpp:240-244 did this with the ACE socket fd as the "SOCKET:"
-    // field; WorldSession has no proto::SessionId of its own to mirror that
-    // with (the gateway keys sessions the other way, WorldSession -> nothing),
-    // so the account id fills the same "stable per-connection identifier"
-    // role here -- it does not change across a reconnect the way a freshly
-    // assigned slot id would.
-    if (sLog.IsPacketLoggingEnabled())
-    {
-        sLog.outWorldPacketDump(GetAccountId(), packet->GetOpcode(),
-                                LookupOpcodeName(packet->GetOpcode()), packet, false);
-    }
+    // The dump is NOT taken here any more. The account id this used to key it on was a
+    // different numbering scheme from the SessionId the incoming side used, so the two
+    // halves of one log could not be told apart. ClientConnection traces both directions
+    // now, which also catches what never reaches this function: the auth handshake.
 
     // SendPacket is void and safe to call on a dead link -- unlike the old
     // WorldSocket::SendPacket, there is no failure to react to here.

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -88,6 +88,7 @@ namespace proto
           m_codec(),
           m_seed(MakeAuthSeed()),
           m_session(INVALID_SESSION_ID),
+          m_traceSession(INVALID_SESSION_ID),
           m_closed(false)
     {
         s_openConnections.fetch_add(1, std::memory_order_relaxed);
@@ -112,6 +113,7 @@ namespace proto
         WorldPacket connection(MSG_WOW_CONNECTION, 46);
         connection << std::string("RLD OF WARCRAFT CONNECTION - SERVER TO CLIENT");
 
+        m_gateway.TracePacket(INVALID_SESSION_ID, connection, false);
         const std::vector<uint8> connectionWire =
             PacketCodec::Encode(connection, PacketCodec::HeaderEncryptor());
         wire.insert(wire.end(), connectionWire.begin(), connectionWire.end());
@@ -128,6 +130,7 @@ namespace proto
 
         // Neither packet is encrypted: the crypt is not armed yet, and the
         // client cannot key its own cipher until it has the challenge.
+        m_gateway.TracePacket(INVALID_SESSION_ID, challenge, false);
         const std::vector<uint8> challengeWire =
             PacketCodec::Encode(challenge, PacketCodec::HeaderEncryptor());
         wire.insert(wire.end(), challengeWire.begin(), challengeWire.end());
@@ -154,6 +157,9 @@ namespace proto
                 [&](WorldPacket&& packet) -> bool
                 {
                     ++decoded;
+                    // Before the move, which empties it.
+                    m_gateway.TracePacket(m_traceSession.load(std::memory_order_relaxed),
+                                          packet, true);
                     if (!HandlePacket(std::move(packet)))
                     {
                         fatal = true;
@@ -386,6 +392,7 @@ namespace proto
         }
 
         m_session = session;
+        m_traceSession.store(session, std::memory_order_relaxed);
 
         DEBUG_LOG("proto: account '%s' authenticated from %s",
                   request.account.c_str(), m_address.c_str());
@@ -411,6 +418,8 @@ namespace proto
         {
             return;
         }
+
+        m_gateway.TracePacket(m_traceSession.load(std::memory_order_relaxed), packet, false);
 
         std::vector<uint8_t> wire;
         {
@@ -448,5 +457,6 @@ namespace proto
             m_gateway.Detach(m_session);
             m_session = INVALID_SESSION_ID;
         }
+        m_traceSession.store(INVALID_SESSION_ID, std::memory_order_relaxed);
     }
 }

--- a/src/proto/ClientConnection.h
+++ b/src/proto/ClientConnection.h
@@ -150,6 +150,12 @@ namespace proto
 
             SessionId m_session;
 
+            /// The same id, readable off the network thread. SendPacket runs on the
+            /// world thread while m_session is written here on the network thread, so
+            /// the trace needs a copy it can read without a race. Tracing only --
+            /// m_session stays the authority.
+            std::atomic<SessionId> m_traceSession;
+
             std::atomic<bool> m_closed;
 
             net::Sender m_sender;

--- a/src/proto/IWorldGateway.h
+++ b/src/proto/IWorldGateway.h
@@ -181,6 +181,16 @@ namespace proto
                                      const std::shared_ptr<AuthContext>& context) = 0;
 
             /**
+             * @brief Record one packet in the packet dump, in either direction.
+             *
+             * `session` is INVALID_SESSION_ID for the pre-auth handshake only.
+             * Without it a dump cannot say which of several connected clients a
+             * packet belongs to, which is most of what a packet dump is for.
+             */
+            virtual void TracePacket(SessionId session, const WorldPacket& packet,
+                                     bool incoming) = 0;
+
+            /**
              * @brief Hand a decoded packet to an attached session.
              *
              * The protocol layer has already framed and decrypted it and knows

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -1225,7 +1225,7 @@ void Log::outErrorScriptLib(const char* err, ...)
     }
 }
 
-void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming)
+void Log::outWorldPacketDump(uint32 session, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming)
 {
     if (!worldLogfile)
     {
@@ -1242,13 +1242,14 @@ void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeNam
     std::string out;
     out.reserve(packet->size() * 3 + packet->size() / 16 + 128);
 
-    // header[512] is ample for the fixed text plus a (short, compile-time)
-    // opcode-name constant; snprintf is bounded, so output stays byte-identical
-    // to the previous fprintf for every real opcode name.
+    // SESSION, not SOCKET: the incoming side keyed this on the proto SessionId and the
+    // outgoing side on the account id, two numbering schemes in one field that named
+    // neither. header[512] is ample for the fixed text plus a (short, compile-time)
+    // opcode-name constant, and snprintf is bounded.
     char header[512];
-    snprintf(header, sizeof(header), "\n%s:\nSOCKET: %u\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
+    snprintf(header, sizeof(header), "\n%s:\nSESSION: %u\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA:\n",
         incoming ? "CLIENT" : "SERVER",
-        socket, packet->size(), opcodeName, opcode);
+        session, packet->size(), opcodeName, opcode);
     out += header;
 
     char hexbuf[4];

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -311,16 +311,16 @@ class Log : public MaNGOS::Singleton<Log>
         /**
          * @brief any log level
          *
-         * Called from WorldGateway::Deliver (incoming) and WorldSession::SendPacket
-         * (outgoing) -- see IsPacketLoggingEnabled()'s comment below.
+         * Called from WorldGateway::TracePacket, i.e. from ClientConnection on the
+         * network thread in both directions -- see IsPacketLoggingEnabled() below.
          *
-         * @param socket
+         * @param session which client stream the packet belongs to; 0 pre-auth
          * @param opcode
          * @param opcodeName
          * @param packet
          * @param incoming
          */
-        void outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming);
+        void outWorldPacketDump(uint32 session, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming);
         /**
          * @brief any log level
          *


### PR DESCRIPTION
The dump was taken in two places that keyed it on two different numbering schemes: WorldGateway::Deliver used the proto SessionId, WorldSession::SendPacket used the account id. Session 1 and account 1 both printed as "SOCKET: 1" and are not the same thing, so a log looked attributable while it was not -- and the field named neither.

Route both directions through IWorldGateway::TracePacket, called from ClientConnection, which is the one place that sees every packet on the wire. Print the SessionId as SESSION. The field is 0 only for the pre-auth handshake.

This also dumps what never reached WorldSession::SendPacket: the Cata handshake pair MSG_WOW_CONNECTION and SMSG_AUTH_CHALLENGE, encoded inline in onConnect, and the SMSG_AUTH_RESPONSE that goes straight down the link. Nothing is lost the other way -- the only m_Socket->SendPacket call is the one WorldSession::SendPacket made immediately after the dump it used to take.

ClientConnection keeps an atomic copy of the id: SendPacket runs on the world thread while m_session is written on the network thread, so the trace needs a copy it can read without a race.

Brings the shape in line with mangos_zero, mangos_one and mangos_two.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/323)
<!-- Reviewable:end -->
