### PR TITLE
[Feat] Wire LFGMgr into the world

### DIFF
--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -1054,7 +1054,7 @@ void InitializeOpcodes()
     //OPCODE(CMSG_MAELSTROM_GM_SENT_MAIL,                  STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     OPCODE(SMSG_RESET_FAILED_NOTIFY,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_REAL_GROUP_UPDATE,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    OPCODE(SMSG_LFG_DISABLED,                            STATUS_UNHANDLED,    PROCESS_INPLACE,  &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_LFG_DISABLED,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_ACTIVE_PVP_CHEAT,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     //OPCODE(CMSG_CHEAT_DUMP_ITEMS_DEBUG_ONLY,             STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     //OPCODE(SMSG_CHEAT_DUMP_ITEMS_DEBUG_ONLY_RESPONSE,    STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -71,6 +71,7 @@
 #include "Language.h"
 #include "SpellMgr.h"
 #include "Calendar.h"
+#include "LFGPackets.h"
 #include "GameTime.h"
 #include "Timer.h"
 #ifdef ENABLE_ELUNA
@@ -940,6 +941,16 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     data << uint32(10);
     data << uint32(60);
     SendPacket(&data);
+
+    // Dungeon Finder: tell the client up front when the feature is off, so
+    // the Dungeon Finder panel shows the disabled state instead of an empty
+    // list
+    if (!sWorld.getConfig(CONFIG_BOOL_LFG_ENABLE))
+    {
+        data.Initialize(SMSG_LFG_DISABLED, 0);
+        LFGPackets::BuildDisabled(data);
+        SendPacket(&data);
+    }
 
     // Send MOTD
     {

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -1108,10 +1108,8 @@ void LFGMgr::SendLfgJoinResult(ObjectGuid plrGuid, LfgJoinResult result, LFGStat
 
 void LFGMgr::RemoveOldRoleChecks()
 {
-    for (roleCheckMap::iterator roleItr = m_roleCheckMap.begin(); roleItr != m_roleCheckMap.end(); ++roleItr)
+    for (roleCheckMap::iterator roleItr = m_roleCheckMap.begin(); roleItr != m_roleCheckMap.end();)
     {
-        ObjectGuid groupGuid = roleItr->first;
-
         LFGRoleCheck roleCheck = roleItr->second;
         if ((roleCheck.waitForRoleTime - time(NULL)) <= 0) // no time left
         {
@@ -1127,7 +1125,11 @@ void LFGMgr::RemoveOldRoleChecks()
                 SendLfgUpdate(plrGuid, GetPlayerStatus(plrGuid), true);  // not in lfg system anymore
             }
 
-            m_roleCheckMap.erase(groupGuid);
+            roleItr = m_roleCheckMap.erase(roleItr);
+        }
+        else
+        {
+            ++roleItr;
         }
     }
 }

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1146,6 +1146,15 @@ void World::Update(uint32 diff)
         m_timers[WUPDATE_AHBOT].Reset();
     }
 
+    /// <li> Handle LFG (Dungeon Finder) queue and role-check processing
+    if (getConfig(CONFIG_BOOL_LFG_ENABLE) && m_timers[WUPDATE_LFGMGR].Passed())
+    {
+        sLFGMgr.Update();
+        m_timers[WUPDATE_LFGMGR].Reset();
+
+        DEBUG_FILTER_LOG(LOG_FILTER_LFG, "WORLD: LFGMgr::Update tick");
+    }
+
 #ifdef ENABLE_PLAYERBOTS
     sRandomPlayerbotMgr.UpdateAI(diff);
     sRandomPlayerbotMgr.UpdateSessions(diff);
@@ -1976,6 +1985,11 @@ void World::ResetDailyQuests()
 
     m_NextDailyQuestReset = time_t(m_NextDailyQuestReset + DAY);
     CharacterDatabase.PExecute("UPDATE `saved_variables` SET `NextDailyQuestResetTime` = '" UI64FMTD "'", uint64(m_NextDailyQuestReset));
+
+    if (getConfig(CONFIG_BOOL_LFG_ENABLE))
+    {
+        sLFGMgr.ResetDailyRecords();
+    }
 }
 
 void World::ResetWeeklyQuests()

--- a/src/game/WorldHandlers/World.h
+++ b/src/game/WorldHandlers/World.h
@@ -432,6 +432,9 @@ enum eConfigBoolValues
     // Cinematic flyover
     CONFIG_BOOL_CINEMATIC_FLYOVER_ENABLE,
     CONFIG_BOOL_CINEMATIC_FLYOVER_DEBUG,
+
+    // LFG (Dungeon Finder)
+    CONFIG_BOOL_LFG_ENABLE,
     CONFIG_BOOL_VALUE_COUNT
 };
 

--- a/src/game/WorldHandlers/WorldConfig.cpp
+++ b/src/game/WorldHandlers/WorldConfig.cpp
@@ -444,6 +444,9 @@ void World::LoadConfigSettings(bool reload)
     setConfig(CONFIG_BOOL_RESTRICTED_LFG_CHANNEL,      "Channel.RestrictedLfg", true);
     setConfig(CONFIG_BOOL_SILENTLY_GM_JOIN_TO_CHANNEL, "Channel.SilentlyGMJoin", false);
 
+    ///- Load the LFG (Dungeon Finder) related config options
+    setConfig(CONFIG_BOOL_LFG_ENABLE, "LFG.Enable", false);
+
     setConfig(CONFIG_BOOL_TALENTS_INSPECTING,           "TalentsInspecting", true);
     setConfig(CONFIG_BOOL_CHAT_FAKE_MESSAGE_PREVENTING, "ChatFakeMessagePreventing", false);
 

--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -294,6 +294,7 @@ MaxWhoListReturns                 = 49
 #    LogFilter_Calendar
 #    LogFilter_CellEnvelope
 #    LogFilter_DeckMinions
+#    LogFilter_Lfg
 #        Log filters (active by default - meaning: the filter is active, hence the log is not displayed)
 #        Default: 1 - not include with any log level
 #                 0 - include in log if log level permit
@@ -417,6 +418,7 @@ LogFilter_Damage             = 1
 LogFilter_Combat             = 1
 LogFilter_SpellCast          = 1
 LogFilter_Calendar           = 1
+LogFilter_Lfg                = 1
 LogWhispers                  = 1
 WorldLogFile                 = "world-packets.log"
 PacketLoggingEnabled         = 0
@@ -1395,6 +1397,20 @@ CinematicFlyover.TimeoutSec         = 120
 CinematicFlyover.Debug              = 0
 CinematicFlyover.BodyEntry          = 12999
 CinematicFlyover.VisibilityDistance = 250
+
+################################################################################
+# LFG (DUNGEON FINDER)
+#
+#    LFG.Enable
+#        Enable the Dungeon Finder (Looking For Group) system.
+#        While disabled, clients are sent SMSG_LFG_DISABLED on login and the
+#        Dungeon Finder panel shows the feature-disabled state.
+#        Default: 0 (disabled)
+#                 1 (enabled)
+#
+################################################################################
+
+LFG.Enable = 0
 
 ################################################################################
 # SERVER RATES

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -99,6 +99,7 @@ LogFilterData logFilterData[LOG_FILTER_COUNT] =
     { "grid_add",            "LogFilter_GridAdd",            true  },
     { "db_scripts",          "LogFilter_DbScripts",          true  },
     { "deck_minions",        "LogFilter_DeckMinions",        true  },
+    { "lfg",                 "LogFilter_Lfg",                true  },
 };
 
 /**

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -87,9 +87,10 @@ enum LogFilters
     LOG_FILTER_GRID_ADD           = 0x200000,               // 21 object added to a grid cell ("X enters grid[x,y]") - high-volume, mostly creatures
     LOG_FILTER_DB_SCRIPTS         = 0x400000,               // 22 db_scripts command processing trace (execution, not errors)
     LOG_FILTER_DECK_MINIONS       = 0x800000,               // 23 minions drawn across a deck boundary: board, step ashore, reconcile
+    LOG_FILTER_LFG                = 0x1000000,              // 24 Dungeon Finder / Raid Finder queue and proposal trace
 };
 
-#define LOG_FILTER_COUNT            24
+#define LOG_FILTER_COUNT            25
 
 /**
  * @brief Configuration data for individual log filters


### PR DESCRIPTION
Drives `LFGMgr::Update()` from `World::Update` every 30s through the existing `WUPDATE_LFGMGR` timer, and calls `ResetDailyRecords()` from the daily quest reset. Both gated behind a new `LFG.Enable` config option, defaulting **off**, so this is inert unless enabled.

The timer had been dead since it was added: `World.h` declared it and `World.cpp` set a 30s interval, but nothing ever read it — those were the only two occurrences of the symbol in the tree.

Also sends `SMSG_LFG_DISABLED` on login when LFG is off, using the packet builder from #326. That exposed a second latent bug: the opcode was registered `STATUS_UNHANDLED`, and `WorldSession::SendPacket` silently drops any such packet before it reaches the wire. Nothing had ever tried to send it, so the mis-registration was invisible. Every server-to-client opcode that is actually sent uses `STATUS_NEVER` — 483 of them against 13 stragglers.

Adds `LOG_FILTER_LFG` rather than borrowing an unrelated filter bit.

Fixes iterator invalidation in `RemoveOldRoleChecks`, which erased from `m_roleCheckMap` by key while iterating. Dead code until now; the tick would reach it on the first expired role check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/327)
<!-- Reviewable:end -->
