### PR TITLE
[Feat] LFG lock info and dungeon list

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -156,6 +156,8 @@ DBCStorage <ItemRandomSuffixEntry>        sItemRandomSuffixStore(ItemRandomSuffi
 DBCStorage <ItemReforgeEntry>             sItemReforgeStore(ItemReforgefmt);
 DBCStorage <ItemSetEntry> sItemSetStore(ItemSetEntryfmt);
 DBCStorage <LfgDungeonsEntry> sLfgDungeonsStore(LfgDungeonsEntryfmt);
+LfgDungeonsByMapDifficultyMap sLfgDungeonsByMapDifficultyMap;
+LfgDungeonsByRandomIdMap sLfgDungeonsByRandomIdMap;
 DBCStorage <LiquidTypeEntry> sLiquidTypeStore(LiquidTypefmt);
 DBCStorage <LockEntry> sLockStore(LockEntryfmt);
 
@@ -676,6 +678,25 @@ void LoadDBCStores(const std::string& dataPath)
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sItemRandomSuffixStore,    dbcPath, "ItemRandomSuffix.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sItemSetStore,             dbcPath, "ItemSet.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLfgDungeonsStore,         dbcPath, "LFGDungeons.dbc");
+    // fill (mapId, difficulty) -> entry and Random_ID -> entry indices. 49
+    // rows carry mapID == -1 (LFD_CATA_ANALYSIS.md section 4.2) and are
+    // skipped for the first index; Random_ID == 0 means "not part of a
+    // random bucket" and is skipped for the second.
+    for (uint32 i = 0; i < sLfgDungeonsStore.GetNumRows(); ++i)
+        if (LfgDungeonsEntry const* entry = sLfgDungeonsStore.LookupEntry(i))
+        {
+            if (entry->mapID >= 0)
+            {
+                uint32 key = MAKE_PAIR32((uint32)entry->mapID, entry->difficulty);
+                sLfgDungeonsByMapDifficultyMap[key] = entry;
+            }
+
+            if (entry->Random_ID != 0)
+            {
+                sLfgDungeonsByRandomIdMap.insert(
+                    LfgDungeonsByRandomIdMap::value_type(entry->Random_ID, entry));
+            }
+        }
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLiquidTypeStore,          dbcPath, "LiquidType.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLockStore,                dbcPath, "Lock.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sMailTemplateStore,        dbcPath, "MailTemplate.dbc");
@@ -1432,6 +1453,34 @@ MapDifficultyEntry const* GetMapDifficultyData(uint32 mapId, Difficulty difficul
 {
     MapDifficultyMap::const_iterator itr = sMapDifficultyMap.find(MAKE_PAIR32(mapId, difficulty));
     return itr != sMapDifficultyMap.end() ? itr->second : NULL;
+}
+
+/**
+ * @brief Reverse-looks-up the LFGDungeons.dbc row for a given map/difficulty
+ *        pair. LFD_CATA_ANALYSIS.md section 4.2: 49 rows carry mapID == -1
+ *        and are never indexed here.
+ *
+ * @param mapId The map id.
+ * @param difficulty The dungeon difficulty (LfgDungeonsEntry::difficulty).
+ * @return Pointer to the LfgDungeonsEntry, or NULL when no row matches.
+ */
+LfgDungeonsEntry const* GetLfgDungeonByMapDifficulty(uint32 mapId, uint32 difficulty)
+{
+    LfgDungeonsByMapDifficultyMap::const_iterator itr = sLfgDungeonsByMapDifficultyMap.find(MAKE_PAIR32(mapId, difficulty));
+    return itr != sLfgDungeonsByMapDifficultyMap.end() ? itr->second : NULL;
+}
+
+/**
+ * @brief Returns every LFGDungeons.dbc row sharing a Random_ID -- the
+ *        dungeons a random-dungeon bucket (e.g. "Random Cataclysm Heroic")
+ *        can select from.
+ *
+ * @param randomId The bucket's Random_ID.
+ * @return Iterator bounds into sLfgDungeonsByRandomIdMap; empty when no rows match.
+ */
+LfgDungeonsByRandomIdBounds GetLfgDungeonsByRandomId(uint32 randomId)
+{
+    return sLfgDungeonsByRandomIdMap.equal_range(randomId);
 }
 
 PvPDifficultyEntry const* GetBattlegroundBracketByLevel(uint32 mapid, uint32 level)

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -29,6 +29,7 @@
 #include "Platform/Define.h"
 #include <string>
 #include <map>
+#include <utility>
 #include <vector>
 #include "DataStores/DBCStore.h"
 #include "DBCStructure.h"
@@ -148,6 +149,24 @@ bool Map2ZoneCoordinates(float& x, float& y, uint32 zone);
 typedef std::map<uint32/*pair32(map,diff)*/, MapDifficultyEntry const*> MapDifficultyMap;
 MapDifficultyEntry const* GetMapDifficultyData(uint32 mapId, Difficulty difficulty);
 
+/**
+ * Reverse index (mapId, difficulty) -> LfgDungeonsEntry, built once at DBC
+ * load. LFGDungeons.dbc carries 49 rows with mapID == -1
+ * (LFD_CATA_ANALYSIS.md section 4.2); those rows are never inserted here.
+ */
+typedef std::map<uint32/*pair32(map,diff)*/, LfgDungeonsEntry const*> LfgDungeonsByMapDifficultyMap;
+LfgDungeonsEntry const* GetLfgDungeonByMapDifficulty(uint32 mapId, uint32 difficulty);
+
+/**
+ * Reverse index Random_ID -> every LfgDungeonsEntry sharing it (the member
+ * dungeons of one "Random <Expansion> [Heroic]" bucket, e.g. Random_ID 12
+ * for id=301 "Random Cataclysm Heroic"). Rows with Random_ID == 0 (not part
+ * of any bucket) are never inserted.
+ */
+typedef std::multimap<uint32/*Random_ID*/, LfgDungeonsEntry const*> LfgDungeonsByRandomIdMap;
+typedef std::pair<LfgDungeonsByRandomIdMap::const_iterator, LfgDungeonsByRandomIdMap::const_iterator> LfgDungeonsByRandomIdBounds;
+LfgDungeonsByRandomIdBounds GetLfgDungeonsByRandomId(uint32 randomId);
+
 // natural order for difficulties up-down iteration
 // difficulties for dungeons/battleground ordered in normal way
 // and if more high version not exist must be used lesser version
@@ -260,6 +279,8 @@ extern DBCStorage <ItemRandomSuffixEntry>        sItemRandomSuffixStore;
 extern DBCStorage <ItemReforgeEntry>             sItemReforgeStore;
 extern DBCStorage <ItemSetEntry>                 sItemSetStore;
 extern DBCStorage <LfgDungeonsEntry>             sLfgDungeonsStore;
+extern LfgDungeonsByMapDifficultyMap             sLfgDungeonsByMapDifficultyMap;
+extern LfgDungeonsByRandomIdMap                  sLfgDungeonsByRandomIdMap;
 extern DBCStorage <LiquidTypeEntry>              sLiquidTypeStore;
 extern DBCStorage <LockEntry>                    sLockStore;
 extern DBCStorage <MailTemplateEntry>            sMailTemplateStore;

--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -1011,12 +1011,12 @@ void InitializeOpcodes()
     //OPCODE(SMSG_LFG_UPDATE_STATUS_NONE,                  STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(SMSG_LFG_SLOT_INVALID,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_LFG_SET_ROLES,                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
-    //OPCODE(CMSG_LFG_LOCK_INFO_REQUEST,                   STATUS_UNHANDLED, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
+    OPCODE(CMSG_LFG_LOCK_INFO_REQUEST,                   STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgLockInfoRequestOpcode  );
     //OPCODE(CMSG_LFG_SET_BOOT_VOTE,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     //OPCODE(SMSG_LFG_BOOT_PROPOSAL_UPDATE,                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(SMSG_LFG_PLAYER_INFO,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_LFG_PLAYER_INFO,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_LFG_TELEPORT,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
-    //OPCODE(SMSG_LFG_PARTY_INFO,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_LFG_PARTY_INFO,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_TITLE_EARNED,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_SET_TITLE,                               STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSetTitleOpcode            );
     OPCODE(CMSG_CANCEL_MOUNT_AURA,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleCancelMountAuraOpcode     );

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -389,6 +389,8 @@ class WorldSession
         void SendLfgTeleportError(uint8 error);
         void SendLfgRewards(LFGRewards const& rewards);
         void SendLfgBootUpdate(LFGBoot const& boot);
+        void SendLfgPlayerLockInfo();
+        void SendLfgPartyLockInfo();
         void SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res);
         void SendGroupInvite(Player* player, bool alreadyInGroup = false);
         void SendGuildInvite(Player* player, bool alreadyInGuild = false);
@@ -1011,6 +1013,7 @@ class WorldSession
         void HandleSearchLfgJoinOpcode(WorldPacket& recv_data);
         void HandleSearchLfgLeaveOpcode(WorldPacket& recv_data);
         void HandleSetLfgCommentOpcode(WorldPacket& recv_data);
+        void HandleLfgLockInfoRequestOpcode(WorldPacket& recv_data);
         void HandleSetTitleOpcode(WorldPacket& recv_data);
         void HandleRealmSplitOpcode(WorldPacket& recv_data);
         void HandleTimeSyncResp(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -44,7 +44,9 @@
 #include <vector>
 #include <set>
 #include "WorldSession.h"
+#include "Group.h"
 #include "LFGMgr.h"
+#include "LFGPackets.h"
 #include "Log.h"
 #include "Player.h"
 #include "WorldPacket.h"
@@ -120,6 +122,26 @@ void WorldSession::HandleSetLfgCommentOpcode(WorldPacket& recv_data)
     std::string comment;
     recv_data >> comment;
     DEBUG_LOG("LFG comment \"%s\"", comment.c_str());
+}
+
+/// Fires on Dungeon Finder panel open (LFDFrame.xml's OnShow calls both
+/// RequestLFDPlayerLockInfo and RequestLFDPartyLockInfo, each a separate
+/// CMSG_LFG_LOCK_INFO_REQUEST distinguished by this one bit -- section 3.22).
+void WorldSession::HandleLfgLockInfoRequestOpcode(WorldPacket& recv_data)
+{
+    DEBUG_LOG("CMSG_LFG_LOCK_INFO_REQUEST");
+
+    LFGPackets::LockInfoRequest request;
+    LFGPackets::ReadLockInfoRequest(recv_data, request);
+
+    if (request.player)
+    {
+        SendLfgPlayerLockInfo();
+    }
+    else
+    {
+        SendLfgPartyLockInfo();
+    }
 }
 
 void WorldSession::SendLfgSearchResults(LfgType type, uint32 entry)
@@ -611,5 +633,60 @@ void WorldSession::SendLfgBootUpdate(LFGBoot const& boot)
     SendPacket(&data);
 }
 
+/// Builds and sends SMSG_LFG_PLAYER_INFO for the requesting player. Drives
+/// the padlocks in the Dungeon Finder's own list (LFG_LOCK_INFO_RECEIVED).
+/// randomDungeons is intentionally left empty: the reward fields it carries
+/// (Completion/Purse/shortage-tier quantities) are Phase 9's job, and the
+/// client tolerates an empty array here -- it just leaves the "Type:"
+/// dropdown in specific-dungeon mode (section 1.3) until that phase lands.
+void WorldSession::SendLfgPlayerLockInfo()
+{
+    Player* player = GetPlayer();
+
+    LFGPackets::PlayerInfo info;
+    info.lockedDungeons = sLFGMgr.GetPlayerLockList(player);
+
+    WorldPacket data(SMSG_LFG_PLAYER_INFO, 5 + info.lockedDungeons.size() * 16);
+    if (LFGPackets::BuildPlayerInfo(data, info))
+    {
+        SendPacket(&data);
+    }
+}
+
+/// Builds and sends SMSG_LFG_PARTY_INFO for the requesting player's group.
+/// Self is skipped (section 3.11); with no group this sends a valid,
+/// empty member list.
+void WorldSession::SendLfgPartyLockInfo()
+{
+    Player* player = GetPlayer();
+
+    LFGPackets::PartyInfo info;
+
+    if (Group* group = player->GetGroup())
+    {
+        ObjectGuid selfGuid = player->GetObjectGuid();
+
+        for (GroupReference* itr = group->GetFirstMember(); itr != NULL; itr = itr->next())
+        {
+            Player* member = itr->getSource();
+            if (!member || member->GetObjectGuid() == selfGuid)
+            {
+                continue;
+            }
+
+            LFGPackets::LFGPartyInfoMember memberInfo;
+            memberInfo.guid = member->GetObjectGuid().GetRawValue();
+            memberInfo.lockedDungeons = sLFGMgr.GetPlayerLockList(member);
+
+            info.members.push_back(memberInfo);
+        }
+    }
+
+    WorldPacket data(SMSG_LFG_PARTY_INFO, 1 + info.members.size() * 12);
+    if (LFGPackets::BuildPartyInfo(data, info))
+    {
+        SendPacket(&data);
+    }
+}
 
 

--- a/src/game/WorldHandlers/LFGLockReason.h
+++ b/src/game/WorldHandlers/LFGLockReason.h
@@ -1,0 +1,208 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_LFGLOCKREASON_H
+#define MANGOS_LFGLOCKREASON_H
+
+/**
+ * @file LFGLockReason.h
+ * @brief Pure LFG dungeon-lock-reason decision, decoupled from Player,
+ * ObjectMgr, and DBCStores.
+ *
+ * LFGMgr::GetPlayerLockList (LFGMgr.cpp) gathers the primitives below from
+ * the real player/DBC/world-DB state and calls Compute(); the decision
+ * itself lives here so it can be unit tested without linking `game` --
+ * src/tests/CMakeLists.txt only links `proto`/`shared` into mangos_tests,
+ * the same boundary LFGPackets.h documents at its own top comment.
+ *
+ * The reason codes below are the wire contract (the client's
+ * LFG_INSTANCE_INVALID_CODES index, LFD_CATA_ANALYSIS.md section 1.9) and
+ * carry the same numeric values as LFGMgr.h's LFGForbiddenTypes enum. They
+ * are declared again here, independently, rather than shared, for the same
+ * reason LFGPackets.h does not include LFGMgr.h: LFGMgr.h pulls in Group.h
+ * and the rest of the game headers that boundary excludes.
+ */
+
+#include "Platform/Define.h"
+
+namespace LFGLockReason
+{
+    // ------------------------------------------------------------------
+    // Wire-protocol reason codes (LFD_CATA_ANALYSIS.md section 1.9).
+    // Compute() below only ever returns a subset of these -- the rest
+    // (AREA_NOT_EXPLORED, the attunement pair, the TOO_SOON pair, and
+    // TEMPORARILY_DISABLED) have no existing m3 data source to drive them
+    // and are declared here only so a future caller has the right numeric
+    // constant to reach for instead of inventing one.
+    // ------------------------------------------------------------------
+
+    const uint32 REASON_NONE                = 0;    ///< not locked
+    const uint32 REASON_EXPANSION           = 1;    ///< EXPANSION_TOO_LOW
+    const uint32 REASON_LOW_LEVEL           = 2;    ///< LEVEL_TOO_LOW
+    const uint32 REASON_HIGH_LEVEL          = 3;    ///< LEVEL_TOO_HIGH
+    const uint32 REASON_LOW_GEAR_SCORE      = 4;    ///< GEAR_TOO_LOW, numeric sub-reasons
+    const uint32 REASON_HIGH_GEAR_SCORE     = 5;    ///< GEAR_TOO_HIGH, numeric sub-reasons
+    const uint32 REASON_RAID                = 6;    ///< RAID_LOCKED
+    const uint32 REASON_AREA_NOT_EXPLORED   = 9;    ///< AREA_NOT_EXPLORED, no data source yet
+    const uint32 REASON_ATTUNEMENT_LOW      = 1001; ///< renders LEVEL_TOO_LOW
+    const uint32 REASON_ATTUNEMENT_HIGH     = 1002; ///< renders LEVEL_TOO_HIGH
+    const uint32 REASON_QUEST_INCOMPLETE    = 1022;
+    const uint32 REASON_MISSING_ITEM        = 1025;
+    const uint32 REASON_TOO_SOON_REALM      = 1029; ///< both 1029/1030 render TOO_SOON
+    const uint32 REASON_TOO_SOON_CHARACTER  = 1030;
+    const uint32 REASON_NOT_IN_SEASON       = 1031;
+    const uint32 REASON_MISSING_ACHIEVEMENT = 1034;
+    const uint32 REASON_TEMPORARILY_DISABLED = 10000;
+
+    /// LfgType::LFG_TYPE_RAID (LFGMgr.h) -- duplicated as a literal for the
+    /// same independence reason as the codes above.
+    const uint32 DUNGEON_TYPE_RAID = 2;
+
+    /**
+     * Inputs needed to decide one dungeon's lock reason for one player.
+     * Deliberately plain data; the caller gathers every field from Player,
+     * DBCStores, and ObjectMgr::GetDungeonFinderRequirements so this
+     * function needs none of them. Field-for-field mirror of the decision
+     * tree that used to live inline in LFGMgr::FindRandomDungeonsNotForPlayer
+     * (LFGMgr.cpp).
+     */
+    struct CheckInput
+    {
+        uint32 playerLevel = 0;
+        uint32 playerExpansion = 0;
+        bool   isAlliance = true;
+
+        uint32 dungeonExpansionLevel = 0;
+        uint32 dungeonTypeID = 0;          ///< LfgType
+        uint32 dungeonMinLevel = 0;
+        uint32 dungeonMaxLevel = 0;
+
+        bool   isSeasonal = false;
+        bool   seasonActive = false;
+
+        /// False both when no dungeonfinder_requirements row exists for
+        /// (mapId, difficulty) AND when the caller could not even look one
+        /// up -- LFGDungeons.dbc has 49 rows with mapID == -1
+        /// (LFD_CATA_ANALYSIS.md Phase 5's trap); the caller must not cast
+        /// that to uint32 and must simply leave hasRequirements false.
+        bool   hasRequirements = false;
+        uint32 requiredItemLevel = 0;      ///< 0 == no gear floor
+        uint32 currentItemLevel = 0;       ///< Player::GetEquipGearScore(false, false)
+        bool   requiresAchievement = false;
+        bool   hasAchievement = true;
+        bool   requiresAllianceQuest = false;
+        bool   hasCompletedAllianceQuest = true;
+        bool   requiresHordeQuest = false;
+        bool   hasCompletedHordeQuest = true;
+        bool   requiresItem1 = false;
+        bool   hasItem1 = true;
+        bool   requiresItem2 = false;
+        bool   hasItem2 = true;
+    };
+
+    /**
+     * Result of a lock check. reason == REASON_NONE means "not locked".
+     * subReason1/subReason2 are meaningful only for the two gear-score
+     * reasons (required item level, current item level -- section 1.9's
+     * sub-reason contract); every other reason leaves them 0.
+     */
+    struct Result
+    {
+        uint32 reason = REASON_NONE;
+        uint32 subReason1 = 0;
+        uint32 subReason2 = 0;
+    };
+
+    /**
+     * Decide why (if at all) a player is locked out of one dungeon. Checks
+     * run in the same precedence as the original inline version: expansion,
+     * raid type, level bounds, season, then -- only when a requirements row
+     * was found -- gear, achievement, quest, item. The first failing check
+     * wins, exactly as the original if/else-if chain did.
+     */
+    inline Result Compute(CheckInput const& in)
+    {
+        Result result;
+
+        if (in.dungeonExpansionLevel > in.playerExpansion)
+        {
+            result.reason = REASON_EXPANSION;
+        }
+        else if (in.dungeonTypeID == DUNGEON_TYPE_RAID)
+        {
+            result.reason = REASON_RAID;
+        }
+        else if (in.dungeonMinLevel > in.playerLevel)
+        {
+            result.reason = REASON_LOW_LEVEL;
+        }
+        else if (in.dungeonMaxLevel < in.playerLevel)
+        {
+            result.reason = REASON_HIGH_LEVEL;
+        }
+        else if (in.isSeasonal && !in.seasonActive)
+        {
+            result.reason = REASON_NOT_IN_SEASON;
+        }
+        else if (in.hasRequirements)
+        {
+            if (in.requiredItemLevel != 0 && in.currentItemLevel < in.requiredItemLevel)
+            {
+                result.reason = REASON_LOW_GEAR_SCORE;
+                result.subReason1 = in.requiredItemLevel;
+                result.subReason2 = in.currentItemLevel;
+            }
+            else if (in.requiresAchievement && !in.hasAchievement)
+            {
+                result.reason = REASON_MISSING_ACHIEVEMENT;
+            }
+            else if (in.isAlliance && in.requiresAllianceQuest
+                     && !in.hasCompletedAllianceQuest)
+            {
+                result.reason = REASON_QUEST_INCOMPLETE;
+            }
+            else if (!in.isAlliance && in.requiresHordeQuest
+                     && !in.hasCompletedHordeQuest)
+            {
+                result.reason = REASON_QUEST_INCOMPLETE;
+            }
+            else if (in.requiresItem1)
+            {
+                if (!in.hasItem1 && (!in.requiresItem2 || !in.hasItem2))
+                {
+                    result.reason = REASON_MISSING_ITEM;
+                }
+            }
+            else if (in.requiresItem2 && !in.hasItem2)
+            {
+                result.reason = REASON_MISSING_ITEM;
+            }
+        }
+
+        return result;
+    }
+}
+
+#endif

--- a/src/game/WorldHandlers/LFGMgr.cpp
+++ b/src/game/WorldHandlers/LFGMgr.cpp
@@ -29,6 +29,7 @@
 #include "DBCStructure.h"
 #include "GameEventMgr.h"
 #include "Group.h"
+#include "LFGLockReason.h"
 #include "LFGMgr.h"
 #include "Object.h"
 #include "Player.h"
@@ -311,77 +312,93 @@ dungeonEntries LFGMgr::FindRandomDungeonsForPlayer(uint32 level, uint8 expansion
 
 dungeonForbidden LFGMgr::FindRandomDungeonsNotForPlayer(Player* plr)
 {
+    dungeonForbidden randomDungeons;
+
+    for (LFGLockedDungeon const& locked : GetPlayerLockList(plr))
+    {
+        randomDungeons[locked.slot] = locked.reason;
+    }
+
+    return randomDungeons;
+}
+
+std::vector<LFGLockedDungeon> LFGMgr::GetPlayerLockList(Player* plr)
+{
+    std::vector<LFGLockedDungeon> lockList;
+
     uint32 level = plr->getLevel();
     uint8 expansion = plr->GetSession()->Expansion();
-
-    dungeonForbidden randomDungeons;
+    bool isAlliance = plr->GetTeam() == ALLIANCE;
+    uint32 currentItemLevel = plr->GetEquipGearScore(false, false);
 
     for (uint32 id = 0; id < sLfgDungeonsStore.GetNumRows(); ++id)
     {
         LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(id);
-        if (dungeon)
+        if (!dungeon)
         {
-            uint32 forbiddenReason = 0;
+            continue;
+        }
 
-            if ((uint8)dungeon->expansionLevel > expansion)
-            {
-                forbiddenReason = (uint32)LFG_FORBIDDEN_EXPANSION;
-            }
-            else if (dungeon->typeID == LFG_TYPE_RAID)
-            {
-                forbiddenReason = (uint32)LFG_FORBIDDEN_RAID;
-            }
-            else if (dungeon->minLevel > level)
-            {
-                forbiddenReason = (uint32)LFG_FORBIDDEN_LOW_LEVEL;
-            }
-            else if (dungeon->maxLevel < level)
-            {
-                forbiddenReason = (uint32)LFG_FORBIDDEN_HIGH_LEVEL;
-            }
-            else if (IsSeasonal(dungeon->flags) && !IsSeasonActive(dungeon->ID)) // check pointers/function args
-            {
-                forbiddenReason = (uint32)LFG_FORBIDDEN_NOT_IN_SEASON;
-            }
-            else if (DungeonFinderRequirements const* req = sObjectMgr.GetDungeonFinderRequirements((uint32)dungeon->mapID, dungeon->difficulty))
-            {
-                if (req->minItemLevel && (plr->GetEquipGearScore(false,false) < req->minItemLevel))
-                {
-                    forbiddenReason = (uint32)LFG_FORBIDDEN_LOW_GEAR_SCORE;
-                }
-                else if (req->achievement && !plr->GetAchievementMgr().HasAchievement(req->achievement))
-                {
-                    forbiddenReason = (uint32)LFG_FORBIDDEN_MISSING_ACHIEVEMENT;
-                }
-                else if (plr->GetTeam() == ALLIANCE && req->allianceQuestId && !plr->GetQuestRewardStatus(req->allianceQuestId))
-                {
-                    forbiddenReason = (uint32)LFG_FORBIDDEN_QUEST_INCOMPLETE;
-                }
-                else if (plr->GetTeam() == HORDE && req->hordeQuestId && !plr->GetQuestRewardStatus(req->hordeQuestId))
-                {
-                    forbiddenReason = (uint32)LFG_FORBIDDEN_QUEST_INCOMPLETE;
-                }
-                else
-                    if (req->item)
-                    {
-                        if (!plr->HasItemCount(req->item, 1) && (!req->item2 || !plr->HasItemCount(req->item2, 1)))
-                        {
-                            forbiddenReason = LFG_FORBIDDEN_MISSING_ITEM;
-                        }
-                    }
-                    else if (req->item2 && !plr->HasItemCount(req->item2, 1))
-                    {
-                        forbiddenReason = LFG_FORBIDDEN_MISSING_ITEM;
-                    }
-            }
+        LFGLockReason::CheckInput in;
+        in.playerLevel = level;
+        in.playerExpansion = expansion;
+        in.isAlliance = isAlliance;
+        in.dungeonExpansionLevel = dungeon->expansionLevel;
+        in.dungeonTypeID = dungeon->typeID;
+        in.dungeonMinLevel = dungeon->minLevel;
+        in.dungeonMaxLevel = dungeon->maxLevel;
+        in.isSeasonal = IsSeasonal(dungeon->flags);
+        in.seasonActive = in.isSeasonal && IsSeasonActive(dungeon->ID);
 
-            if (forbiddenReason)
-            {
-                randomDungeons[dungeon->Entry()] = forbiddenReason;
-            }
+        // LFGDungeons.dbc carries 49 rows with mapID == -1
+        // (LFD_CATA_ANALYSIS.md section 4.2 / Phase 5's trap). Guard here
+        // rather than casting -1 to uint32 and handing 0xFFFFFFFF to
+        // GetDungeonFinderRequirements.
+        DungeonFinderRequirements const* req = (dungeon->mapID >= 0)
+            ? sObjectMgr.GetDungeonFinderRequirements(
+                  (uint32)dungeon->mapID, dungeon->difficulty)
+            : NULL;
+
+        if (req)
+        {
+            in.hasRequirements = true;
+            in.requiredItemLevel = req->minItemLevel;
+            in.currentItemLevel = currentItemLevel;
+
+            in.requiresAchievement = req->achievement != 0;
+            in.hasAchievement = !in.requiresAchievement
+                || plr->GetAchievementMgr().HasAchievement(req->achievement);
+
+            in.requiresAllianceQuest = req->allianceQuestId != 0;
+            in.hasCompletedAllianceQuest = !in.requiresAllianceQuest
+                || plr->GetQuestRewardStatus(req->allianceQuestId);
+
+            in.requiresHordeQuest = req->hordeQuestId != 0;
+            in.hasCompletedHordeQuest = !in.requiresHordeQuest
+                || plr->GetQuestRewardStatus(req->hordeQuestId);
+
+            in.requiresItem1 = req->item != 0;
+            in.hasItem1 = !in.requiresItem1
+                || plr->HasItemCount(req->item, 1);
+
+            in.requiresItem2 = req->item2 != 0;
+            in.hasItem2 = !in.requiresItem2
+                || plr->HasItemCount(req->item2, 1);
+        }
+
+        LFGLockReason::Result result = LFGLockReason::Compute(in);
+        if (result.reason != LFGLockReason::REASON_NONE)
+        {
+            LFGLockedDungeon locked;
+            locked.slot = dungeon->Entry();
+            locked.reason = result.reason;
+            locked.subReason1 = result.subReason1;
+            locked.subReason2 = result.subReason2;
+            lockList.push_back(locked);
         }
     }
-    return randomDungeons;
+
+    return lockList;
 }
 
 void LFGMgr::UpdateNeededRoles(ObjectGuid guid, LFGPlayers* information)

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -31,6 +31,7 @@
 #include "Common/TimeConstants.h"
 #include <ctime>
 #include <string>
+#include "LFGPackets.h"
 #include "Policies/Singleton.h"
 #include "Group.h"
 #include <set>
@@ -111,7 +112,14 @@ enum LfgType
     LFG_TYPE_RANDOM_DUNGEON       = 6
 };
 
-/// Reasons a player cannot enter a dungeon
+/**
+ * Reasons a player cannot enter a dungeon -- the client's
+ * LFG_INSTANCE_INVALID_CODES index (LFD_CATA_ANALYSIS.md section 1.9).
+ * Values are the wire contract with client build 15595, not free to
+ * renumber. LFGLockReason.h (used by GetPlayerLockList) declares the same
+ * numeric values independently, kept in sync by hand since that header must
+ * not include this one -- see its own top comment for why.
+ */
 enum LFGForbiddenTypes
 {
     LFG_FORBIDDEN_EXPANSION             = 1,
@@ -120,12 +128,16 @@ enum LFGForbiddenTypes
     LFG_FORBIDDEN_LOW_GEAR_SCORE        = 4,
     LFG_FORBIDDEN_HIGH_GEAR_SCORE       = 5,
     LFG_FORBIDDEN_RAID                  = 6,
+    LFG_FORBIDDEN_AREA_NOT_EXPLORED     = 9,       ///< no data source yet; declared for future use
     LFG_FORBIDDEN_ATTUNEMENT_LOW_LEVEL  = 1001,
     LFG_FORBIDDEN_ATTUNEMENT_HIGH_LEVEL = 1002,
     LFG_FORBIDDEN_QUEST_INCOMPLETE      = 1022,
     LFG_FORBIDDEN_MISSING_ITEM          = 1025,
+    LFG_FORBIDDEN_TOO_SOON_REALM        = 1029,    ///< both 1029/1030 render as TOO_SOON client-side
+    LFG_FORBIDDEN_TOO_SOON_CHARACTER    = 1030,
     LFG_FORBIDDEN_NOT_IN_SEASON         = 1031,
-    LFG_FORBIDDEN_MISSING_ACHIEVEMENT   = 1034
+    LFG_FORBIDDEN_MISSING_ACHIEVEMENT   = 1034,
+    LFG_FORBIDDEN_TEMPORARILY_DISABLED  = 10000    ///< no data source yet; declared for future use
 };
 
 /// Spells that affect the mechanisms of the dungeon finder
@@ -527,6 +539,18 @@ public:
      * @param plr The player to test against
      */
     dungeonForbidden FindRandomDungeonsNotForPlayer(Player* plr);
+
+    /**
+     * @brief Compute the full wire-shaped lock list for one player -- every
+     *        LFGDungeons.dbc row the player is currently locked out of, with
+     *        slot/reason/sub-reasons ready for SMSG_LFG_PLAYER_INFO /
+     *        SMSG_LFG_PARTY_INFO (LFGPackets::LFGLockedDungeon). Backs
+     *        FindRandomDungeonsNotForPlayer as well, so there is one
+     *        decision per dungeon, not two.
+     *
+     * @param plr The player to test against
+     */
+    std::vector<LFGLockedDungeon> GetPlayerLockList(Player* plr);
 
     /// Given the ID of a dungeon, spit out its entry
     uint32 GetDungeonEntry(uint32 ID);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRC_GRP_TESTS
     Utf8Test.cpp
     ByteBufferTest.cpp
     LFGPacketsTest.cpp
+    LFGLockReasonTest.cpp
     SessionMailboxTest.cpp
     SessionProtocolPolicyTest.cpp
     DatabaseConcurrencyTest.cpp

--- a/src/tests/LFGLockReasonTest.cpp
+++ b/src/tests/LFGLockReasonTest.cpp
@@ -1,0 +1,323 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "LFGLockReason.h"
+
+/**
+ * @file
+ * @brief Coverage for LFGLockReason::Compute -- the decision LFGMgr's
+ * GetPlayerLockList (LFGMgr.cpp) delegates to for every dungeon in every
+ * SMSG_LFG_PLAYER_INFO / SMSG_LFG_PARTY_INFO reply.
+ *
+ * Cases are built from a "everything passes" baseline (Deadmines-shaped:
+ * low-level, non-seasonal, no dungeonfinder_requirements row) with exactly
+ * one field flipped per test, so each case isolates one branch of the
+ * precedence chain. The precedence tests at the end pin the ordering itself
+ * -- expansion before raid before level before season before the
+ * requirements-gated checks -- matching the original inline decision tree
+ * in LFGMgr::FindRandomDungeonsNotForPlayer before this file existed.
+ */
+
+namespace
+{
+    LFGLockReason::CheckInput Baseline()
+    {
+        LFGLockReason::CheckInput in;
+        in.playerLevel = 20;
+        in.playerExpansion = 0;
+        in.isAlliance = true;
+
+        in.dungeonExpansionLevel = 0;
+        in.dungeonTypeID = 1;          // LFG_TYPE_DUNGEON
+        in.dungeonMinLevel = 15;
+        in.dungeonMaxLevel = 20;
+
+        in.isSeasonal = false;
+        in.seasonActive = false;
+
+        in.hasRequirements = false;    // no dungeonfinder_requirements row
+        return in;
+    }
+}
+
+TEST(LFGLockReason_Baseline_not_locked)
+{
+    LFGLockReason::Result result = LFGLockReason::Compute(Baseline());
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+    CHECK(result.subReason1 == 0);
+    CHECK(result.subReason2 == 0);
+}
+
+TEST(LFGLockReason_expansion_too_low)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonExpansionLevel = 3;      // Cataclysm dungeon
+    in.playerExpansion = 0;            // classic-only account
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_EXPANSION);
+}
+
+TEST(LFGLockReason_raid_type_always_locked)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonTypeID = LFGLockReason::DUNGEON_TYPE_RAID;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_RAID);
+}
+
+TEST(LFGLockReason_level_too_low)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.playerLevel = 10;               // below dungeonMinLevel (15)
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_LOW_LEVEL);
+}
+
+TEST(LFGLockReason_player_below_high_level_dungeon_min)
+{
+    // Halls of Reflection-shaped: high minLevel, level-20 player under it --
+    // the DoD's own verification scenario. The client's rendered string is
+    // "You must advance to a higher level," which is LOW_LEVEL (2), not
+    // HIGH_LEVEL (3): the player is too low for the dungeon, not the other
+    // way around.
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonMinLevel = 80;
+    in.dungeonMaxLevel = 80;
+    in.playerLevel = 20;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_LOW_LEVEL);
+}
+
+TEST(LFGLockReason_level_above_dungeon_max)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonMinLevel = 1;
+    in.dungeonMaxLevel = 10;
+    in.playerLevel = 20;               // above dungeonMaxLevel
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_HIGH_LEVEL);
+}
+
+TEST(LFGLockReason_seasonal_not_active)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.isSeasonal = true;
+    in.seasonActive = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NOT_IN_SEASON);
+}
+
+TEST(LFGLockReason_seasonal_active_not_locked)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.isSeasonal = true;
+    in.seasonActive = true;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_gear_too_low_carries_numeric_sub_reasons)
+{
+    // Section 1.9's sub-reason contract: codes 4/5 need numeric
+    // required/current item level, not zeros.
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiredItemLevel = 346;
+    in.currentItemLevel = 300;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_LOW_GEAR_SCORE);
+    CHECK(result.subReason1 == 346);
+    CHECK(result.subReason2 == 300);
+}
+
+TEST(LFGLockReason_gear_exactly_at_floor_not_locked)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiredItemLevel = 346;
+    in.currentItemLevel = 346;         // equal, not below -- should pass
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_no_requirements_row_skips_gear_check)
+{
+    // hasRequirements=false is also how the mapID==-1 guard in
+    // LFGMgr::GetPlayerLockList expresses "could not look up requirements"
+    // -- must never fall through to the gear/achievement/quest/item checks.
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = false;
+    in.requiredItemLevel = 999;        // would fail if evaluated
+    in.currentItemLevel = 0;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_missing_achievement)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiresAchievement = true;
+    in.hasAchievement = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_MISSING_ACHIEVEMENT);
+}
+
+TEST(LFGLockReason_quest_incomplete_alliance)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.isAlliance = true;
+    in.hasRequirements = true;
+    in.requiresAllianceQuest = true;
+    in.hasCompletedAllianceQuest = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_QUEST_INCOMPLETE);
+}
+
+TEST(LFGLockReason_quest_incomplete_horde)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.isAlliance = false;
+    in.hasRequirements = true;
+    in.requiresHordeQuest = true;
+    in.hasCompletedHordeQuest = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_QUEST_INCOMPLETE);
+}
+
+TEST(LFGLockReason_horde_player_ignores_alliance_quest_requirement)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.isAlliance = false;
+    in.hasRequirements = true;
+    in.requiresAllianceQuest = true;
+    in.hasCompletedAllianceQuest = false;  // irrelevant -- player is Horde
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_missing_item_when_only_item1_required)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiresItem1 = true;
+    in.hasItem1 = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_MISSING_ITEM);
+}
+
+TEST(LFGLockReason_item2_satisfies_when_item1_missing)
+{
+    // Original nested logic: item1 required, absent, but item2 (an
+    // alternate) is present -- that satisfies the requirement.
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiresItem1 = true;
+    in.hasItem1 = false;
+    in.requiresItem2 = true;
+    in.hasItem2 = true;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_item1_present_ignores_missing_item2)
+{
+    // item1 present satisfies the OR outright; item2's state never matters
+    // once item1 is required and held (matches the original's outer "if
+    // (req->item)" branch never falling into the item2-only else).
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiresItem1 = true;
+    in.hasItem1 = true;
+    in.requiresItem2 = true;
+    in.hasItem2 = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_NONE);
+}
+
+TEST(LFGLockReason_missing_item2_only)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.hasRequirements = true;
+    in.requiresItem1 = false;
+    in.requiresItem2 = true;
+    in.hasItem2 = false;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_MISSING_ITEM);
+}
+
+TEST(LFGLockReason_precedence_expansion_before_raid)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonTypeID = LFGLockReason::DUNGEON_TYPE_RAID;
+    in.dungeonExpansionLevel = 3;
+    in.playerExpansion = 0;
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_EXPANSION);
+}
+
+TEST(LFGLockReason_precedence_raid_before_level)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.dungeonTypeID = LFGLockReason::DUNGEON_TYPE_RAID;
+    in.dungeonMinLevel = 85;
+    in.playerLevel = 1;                // also fails the level check
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_RAID);
+}
+
+TEST(LFGLockReason_precedence_level_before_requirements)
+{
+    LFGLockReason::CheckInput in = Baseline();
+    in.playerLevel = 1;                // fails level too
+    in.hasRequirements = true;
+    in.requiredItemLevel = 500;
+    in.currentItemLevel = 0;           // also fails gear
+
+    LFGLockReason::Result result = LFGLockReason::Compute(in);
+    CHECK(result.reason == LFGLockReason::REASON_LOW_LEVEL);
+}


### PR DESCRIPTION
Answers `CMSG_LFG_LOCK_INFO_REQUEST` with `SMSG_LFG_PLAYER_INFO` / `SMSG_LFG_PARTY_INFO`, which is what populates the Dungeon Finder's dungeon list and the per-dungeon lock reasons. Builds on #326 and #327.

Lock-reason computation moves into `LFGLockReason.h` as pure functions, so the precedence rules are testable without a live `Player`: expansion before raid, raid before level, level before requirements. That ordering matters — the client shows only the first reason, so getting it wrong mislabels why a dungeon is greyed out.

Also guards a real crash-adjacent bug in the requirements lookup. `LfgDungeonsEntry::mapID` is `int32` and 49 of the 240 rows carry `-1` (random and seasonal entries with no map). Those were being passed to a `uint32` parameter, turning into `0xFFFFFFFF` and querying a map id that cannot exist:

```cpp
DungeonFinderRequirements const* req = (dungeon->mapID >= 0)
    ? sObjectMgr.GetDungeonFinderRequirements((uint32)dungeon->mapID, dungeon->difficulty)
    : NULL;
```

Verified in-game on a level-85 character: the list populates with the Cataclysm heroics, and the dropdown offers Specific Dungeons plus the three random categories. Lock count drops 240 to 214 at 85.

Tests: 22 new cases covering each lock reason and the precedence chain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/328)
<!-- Reviewable:end -->
