### PR TITLE
[Feat] LFG dungeon proposal

### DIFF
--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -1001,8 +1001,8 @@ void InitializeOpcodes()
     //OPCODE(CMSG_LFG_SEARCH_JOIN,                         STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSearchLfgJoinOpcode       );
     //OPCODE(CMSG_LFG_SEARCH_LEAVE,                        STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSearchLfgLeaveOpcode      );
     //OPCODE(SMSG_LFG_SEARCH_RESULTS,                      STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(SMSG_LFG_PROPOSAL_UPDATE,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(CMSG_LFG_PROPOSAL_RESULT,                     STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
+    OPCODE(SMSG_LFG_PROPOSAL_UPDATE,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(CMSG_LFG_PROPOSAL_RESULT,                     STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgProposalResultOpcode   );
     OPCODE(SMSG_LFG_ROLE_CHECK_UPDATE,                   STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_LFG_JOIN_RESULT,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_LFG_QUEUE_STATUS,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -387,7 +387,7 @@ class WorldSession
         void SendLfgQueueStatus(LFGPackets::QueueStatus const& status);
         void SendLfgRoleCheckUpdate(LFGPackets::RoleCheckUpdate const& roleCheck);
         void SendLfgRoleChosen(uint64 rawGuid, uint32 roles);
-        void SendLfgProposalUpdate(LFGProposal const& proposal);
+        void SendLfgProposalUpdate(LFGPackets::ProposalUpdate const& proposal);
         void SendLfgTeleportError(uint8 error);
         void SendLfgRewards(LFGRewards const& rewards);
         void SendLfgBootUpdate(LFGBoot const& boot);
@@ -1018,6 +1018,7 @@ class WorldSession
         void HandleLfgLockInfoRequestOpcode(WorldPacket& recv_data);
         void HandleLfgSetRolesOpcode(WorldPacket& recv_data);
         void HandleLfgGetStatusOpcode(WorldPacket& recv_data);
+        void HandleLfgProposalResultOpcode(WorldPacket& recv_data);
         void HandleSetTitleOpcode(WorldPacket& recv_data);
         void HandleRealmSplitOpcode(WorldPacket& recv_data);
         void HandleTimeSyncResp(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -135,6 +135,21 @@ void WorldSession::HandleLfgGetStatusOpcode(WorldPacket& /*recv_data*/)
     sLFGMgr.SendStatusUpdate(GetPlayer());
 }
 
+void WorldSession::HandleLfgProposalResultOpcode(WorldPacket& recv_data)
+{
+    LFGPackets::ProposalResult request;
+    LFGPackets::ReadProposalResult(recv_data, request);
+
+    DEBUG_FILTER_LOG(LOG_FILTER_LFG,
+        "CMSG_LFG_PROPOSAL_RESULT proposal %u accepted %u",
+        request.proposalId, uint32(request.accepted));
+
+    // The echoed ticket/instance guid are informational (spec V4); the
+    // session's own player is the identity that answers.
+    sLFGMgr.ProposalUpdate(request.proposalId, GetPlayer()->GetObjectGuid(),
+                           request.accepted);
+}
+
 void WorldSession::HandleSearchLfgJoinOpcode(WorldPacket& recv_data)
 {
     DEBUG_LOG("CMSG_LFG_SEARCH_JOIN");
@@ -379,48 +394,13 @@ void WorldSession::SendLfgRoleChosen(uint64 rawGuid, uint32 roles)
     SendPacket(&packet);
 }
 
-void WorldSession::SendLfgProposalUpdate(LFGProposal const& proposal)
+void WorldSession::SendLfgProposalUpdate(LFGPackets::ProposalUpdate const& proposal)
 {
-    Player* pPlayer = GetPlayer();
-    ObjectGuid plrGuid = pPlayer->GetObjectGuid();
-    ObjectGuid plrGroupGuid = proposal.groups.find(plrGuid)->second;
-
-    uint32 dungeonEntry = sLFGMgr.GetDungeonEntry(proposal.dungeonID);
-    bool showProposal = !proposal.isNew && proposal.groupRawGuid == plrGroupGuid.GetRawValue();
-
-    WorldPacket data(SMSG_LFG_PROPOSAL_UPDATE, 15 + (9 * proposal.currentRoles.size()));
-
-    data << uint32(dungeonEntry);                // Dungeon Entry
-    data << uint8(proposal.state);               // Proposal state
-    data << uint32(proposal.id);                 // ID of proposal
-    data << uint32(proposal.encounters);         // Encounters done
-    data << uint8(showProposal);                 // Show or hide proposal window [todo-this]
-    data << uint8(proposal.currentRoles.size()); // Size of group
-
-    for (playerGroupMap::const_iterator it = proposal.groups.begin(); it != proposal.groups.end(); ++it)
+    WorldPacket packet(SMSG_LFG_PROPOSAL_UPDATE, 36 + proposal.players.size() * 6);
+    if (LFGPackets::BuildProposalUpdate(packet, proposal))
     {
-        ObjectGuid grpPlrGuid = it->first;
-        uint8 grpPlrRole = proposal.currentRoles.find(grpPlrGuid)->second;
-        LFGProposalAnswer grpPlrAnswer = proposal.answers.find(grpPlrGuid)->second;
-
-        data << uint32(grpPlrRole);              // Player's role
-        data << uint8(grpPlrGuid == plrGuid);    // Is this player me?
-
-        if (it->second != 0)
-        {
-            data << uint8(it->second == ObjectGuid(proposal.groupRawGuid)); // Is player in the proposed group?
-            data << uint8(it->second == plrGroupGuid);          // Is player in the same group as myself?
-        }
-        else
-        {
-            data << uint8(0);
-            data << uint8(0);
-        }
-
-        data << uint8(grpPlrAnswer != LFG_ANSWER_PENDING);  // Has the player selected an answer?
-        data << uint8(grpPlrAnswer == LFG_ANSWER_AGREE);    // Has the player agreed to do the dungeon?
+        SendPacket(&packet);
     }
-    SendPacket(&data);
 }
 
 void WorldSession::SendLfgTeleportError(uint8 error)

--- a/src/game/WorldHandlers/LFGMgr.cpp
+++ b/src/game/WorldHandlers/LFGMgr.cpp
@@ -74,10 +74,13 @@ LFGMgr::~LFGMgr()
 
 void LFGMgr::Update()
 {
-    //todo: remove old queues, proposals & boot votes
+    //todo: remove old queues & boot votes
 
     // remove old role checks
     RemoveOldRoleChecks();
+
+    // remove expired dungeon proposals (45 s -- LFG_TIME_PROPOSAL)
+    RemoveOldProposals();
 
     // go through a waitTimeMap::iterator for each wait map and update times based on player count
     for (waitTimeMap::iterator tankItr = m_tankWaitTime.begin(); tankItr != m_tankWaitTime.end(); ++tankItr)
@@ -472,6 +475,14 @@ void LFGMgr::AddToQueue(ObjectGuid guid)
     {
         m_queueSet.insert(guid);
     }
+
+    // A complete party (1/1/3 seated) skips matching entirely -- this is
+    // how a full premade proposes the moment its role check passes.
+    if ((information->neededTanks == 0) && (information->neededHealers == 0) &&
+        (information->neededDps == 0))
+    {
+        SendDungeonProposal(guid, information);
+    }
 }
 
 void LFGMgr::RemoveFromQueue(ObjectGuid guid)
@@ -687,10 +698,7 @@ void LFGMgr::MergeGroups(ObjectGuid guidOne, ObjectGuid guidTwo, std::set<uint32
     if ((mainGroup->neededTanks == 0) && (mainGroup->neededHealers == 0) &&
         (mainGroup->neededDps == 0))
     {
-        // Proposal packets are Phase 7; announcing a match with the legacy
-        // WotLK-shaped SMSG_LFG_PROPOSAL_UPDATE would desync 4.3.4 clients.
-        DEBUG_FILTER_LOG(LOG_FILTER_LFG,
-            "LFGMgr: full match found, proposal deferred to Phase 7");
+        SendDungeonProposal(guidOne, mainGroup);
     }
 
     // guidTwo's players now live in guidOne's entry, so retire its queue slot

--- a/src/game/WorldHandlers/LFGMgr.cpp
+++ b/src/game/WorldHandlers/LFGMgr.cpp
@@ -426,6 +426,33 @@ void LFGMgr::CountAssignedRoles(roleMap const& roles, uint8& tanks,
     dps = seated.dps;
 }
 
+void LFGMgr::AssignRoles(roleMap const& selected, roleMap& assigned)
+{
+    std::vector<ObjectGuid> guids;
+    std::vector<uint8> masks;
+    guids.reserve(selected.size());
+    masks.reserve(selected.size());
+
+    for (roleMap::const_iterator it = selected.begin(); it != selected.end(); ++it)
+    {
+        guids.push_back(it->first);
+        masks.push_back(it->second);
+    }
+
+    std::vector<uint8> seats;
+    LFGRoleAssignment::Assign(masks, NORMAL_TANK_OR_HEALER_COUNT,
+                              NORMAL_TANK_OR_HEALER_COUNT, NORMAL_DAMAGE_COUNT,
+                              &seats);
+
+    assigned.clear();
+    for (size_t i = 0; i < guids.size(); ++i)
+    {
+        // Carry the leader bit through -- the client reads it for the crown.
+        uint8 leaderBit = masks[i] & PLAYER_ROLE_LEADER;
+        assigned[guids[i]] = uint8(seats[i] | leaderBit);
+    }
+}
+
 void LFGMgr::UpdateNeededRoles(ObjectGuid guid, LFGPlayers* information)
 {
     if (information->dungeonList.empty())

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -657,7 +657,7 @@ protected:
     bool IsProposalSameGroup(LFGProposal const& proposal);
 
     /// Fail a proposal: notify everyone, drop decliners, re-queue the rest.
-    proposalMap::iterator RemoveProposal(proposalMap::iterator itProposal, LfgUpdateType type);
+    void RemoveProposal(uint32 proposalId, LfgUpdateType type);
 
     /// Treat a mid-proposal leaver as a decliner; true when a proposal was hit.
     bool FailProposalForLeaver(ObjectGuid plrGuid);

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -371,6 +371,7 @@ struct LFGProposal
     uint64 groupLeaderGuid = 0;           ///< its leader; 0 until 7b
     bool isNew = true;                    ///< false only for offer-continue (7b)
     roleMap currentRoles;                 ///< participants and their role masks
+    roleMap assignedRoles;                ///< the one role each will actually fill
     proposalAnswerMap answers;            ///< per-player answer
     playerGroupMap groups;                ///< player -> original party guid (empty guid = solo)
     time_t joinedQueue = 0;               ///< queue join time, feeds wait stats
@@ -612,6 +613,9 @@ public:
     /// Seats each player into one of their selected roles, scarce roles first.
     static void CountAssignedRoles(roleMap const& roles, uint8& tanks,
                                    uint8& healers, uint8& dps);
+
+    /// Same seating, but reports the single role each player ended up filling.
+    static void AssignRoles(roleMap const& selected, roleMap& assigned);
 
     /// True when the class can perform every non-leader role in the mask.
     static bool CanPerformSelectedRoles(uint8 playerClass, uint8 roles);

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -363,17 +363,19 @@ struct LFGGroupStatus //todo: check for this in joinlfg function, not lfgplayers
 /// For SMSG_LFG_PROPOSAL_UPDATE
 struct LFGProposal
 {
-    uint32 id;                 // proposal id
-    uint32 dungeonID;          // dungeon id
-    LFGProposalState state;    // proposal state
-    uint32 encounters;         // encounters done
-    uint64 groupRawGuid;       // group raw guid value
-    uint64 groupLeaderGuid;    // group leader's guid
-    bool isNew;                // is new or old group
-    roleMap currentRoles;      // group player's roles
-    proposalAnswerMap answers; // answers to a proposal
-    playerGroupMap groups;     // data on which groups players belong/belonged to
-    time_t joinedQueue;        // time from when the players joined the queue
+    uint32 id = 0;                        ///< proposal id
+    uint32 dungeonID = 0;                 ///< dungeon ID (not entry)
+    LFGProposalState state = LFG_PROPOSAL_INITIATING;
+    uint32 encounters = 0;                ///< completed-encounter mask; 0 until 7b
+    uint64 groupRawGuid = 0;              ///< pre-existing LFG group guid; 0 until 7b
+    uint64 groupLeaderGuid = 0;           ///< its leader; 0 until 7b
+    bool isNew = true;                    ///< false only for offer-continue (7b)
+    roleMap currentRoles;                 ///< participants and their role masks
+    proposalAnswerMap answers;            ///< per-player answer
+    playerGroupMap groups;                ///< player -> original party guid (empty guid = solo)
+    time_t joinedQueue = 0;               ///< queue join time, feeds wait stats
+    time_t cancelTime = 0;                ///< expiry timestamp, seconds
+    ObjectGuid queueEntryGuid;            ///< m_playerData key this proposal was built from
 };
 
 // For SMSG_LFG_PLAYER_REWARD
@@ -654,8 +656,17 @@ protected:
     /// Are the players in a proposal already grouped up?
     bool IsProposalSameGroup(LFGProposal const& proposal);
 
-    /// Update a proposal after a player refused to join
-    void ProposalDeclined(ObjectGuid guid, LFGProposal* proposal);
+    /// Fail a proposal: notify everyone, drop decliners, re-queue the rest.
+    proposalMap::iterator RemoveProposal(proposalMap::iterator itProposal, LfgUpdateType type);
+
+    /// Treat a mid-proposal leaver as a decliner; true when a proposal was hit.
+    bool FailProposalForLeaver(ObjectGuid plrGuid);
+
+    /// Expire proposals older than LFG_TIME_PROPOSAL.
+    void RemoveOldProposals();
+
+    /// Build and send one member's view of a proposal.
+    void SendProposalUpdateToPlayer(ObjectGuid plrGuid, LFGProposal const& proposal);
 
     /// Updates a wait map with the amount of time it took the last player to join
     void UpdateWaitMap(LFGRoles role, uint32 dungeonID, time_t waitTime);
@@ -676,7 +687,7 @@ protected:
     void MergeGroups(ObjectGuid guidOne, ObjectGuid guidTwo, std::set<uint32> compatibleDungeons);
 
     /// Send a proposal to each member of a group
-    void SendDungeonProposal(LFGPlayers* lfgGroup);
+    void SendDungeonProposal(ObjectGuid queueGuid, LFGPlayers* lfgGroup);
 
     /// Send SMSG_LFG_QUEUE_STATUS to every member of one queue entry.
     void SendQueueStatusFor(ObjectGuid guid);

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -237,6 +237,11 @@ void LFGMgr::SendDungeonProposal(ObjectGuid queueGuid, LFGPlayers* lfgGroup)
     proposal.queueEntryGuid = queueGuid;
     proposal.currentRoles = lfgGroup->currentRoles;
 
+    // Pin each player to the single role they will fill. The selected masks
+    // stay in currentRoles so a declined proposal re-queues them just as
+    // flexible as they were; the packet and 7b's group both want the seat.
+    AssignRoles(proposal.currentRoles, proposal.assignedRoles);
+
     for (roleMap::const_iterator itr = proposal.currentRoles.begin();
          itr != proposal.currentRoles.end(); ++itr)
     {
@@ -318,8 +323,16 @@ void LFGMgr::SendProposalUpdateToPlayer(ObjectGuid plrGuid, LFGProposal const& p
         LFGProposalAnswer answer = (ansItr != proposal.answers.end())
             ? ansItr->second : LFG_ANSWER_PENDING;
 
+        // The seat, not the selection: sending the raw mask draws an icon per
+        // bit, so a player who offered to tank and heal shows up as a second
+        // tank beside the real one. Fall back to the mask if unseated.
+        roleMap::const_iterator seatItr = proposal.assignedRoles.find(memberGuid);
+        uint8 seat = (seatItr != proposal.assignedRoles.end() &&
+                      (seatItr->second & ~uint8(PLAYER_ROLE_LEADER)) != PLAYER_ROLE_NONE)
+            ? seatItr->second : itr->second;
+
         LFGPackets::ProposalUpdatePlayer member;
-        member.roles = itr->second;             // leader bit kept (client isLeader)
+        member.roles = seat;                    // leader bit kept (client isLeader)
         member.me = memberGuid == plrGuid;
         member.sameParty = !memberGroup.IsEmpty() && memberGroup == myGroup;
         // Wire bit 2 gates the client's "someone in your party did not

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -394,7 +394,7 @@ void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted
 
     if (!accepted)
     {
-        RemoveProposal(itProposal, LFG_UPDATE_PROPOSAL_DECLINED);
+        RemoveProposal(proposalID, LFG_UPDATE_PROPOSAL_DECLINED);
         return;
     }
 
@@ -761,9 +761,21 @@ LFGGroupStatus* LFGMgr::GetGroupStatus(ObjectGuid guid)
     }
 }
 
-proposalMap::iterator LFGMgr::RemoveProposal(proposalMap::iterator itProposal, LfgUpdateType type)
+void LFGMgr::RemoveProposal(uint32 proposalId, LfgUpdateType type)
 {
-    LFGProposal& proposal = itProposal->second;
+    proposalMap::iterator itProposal = m_proposalMap.find(proposalId);
+    if (itProposal == m_proposalMap.end())
+    {
+        return;
+    }
+
+    // Work on a copy and retire the map entry up front. Re-queueing a survivor
+    // set below can reach SendDungeonProposal, and its insert into
+    // m_proposalMap may rehash and invalidate every iterator into the map.
+    // Taking the id rather than an iterator keeps that off every caller too.
+    LFGProposal proposal = itProposal->second;
+    m_proposalMap.erase(itProposal);
+
     proposal.state = LFG_PROPOSAL_FAILED;
 
     DEBUG_FILTER_LOG(LOG_FILTER_LFG, "LFGMgr: proposal %u failed, update type %u",
@@ -879,7 +891,6 @@ proposalMap::iterator LFGMgr::RemoveProposal(proposalMap::iterator itProposal, L
         SendQueueStatusFor(newKey);
     }
 
-    return m_proposalMap.erase(itProposal);
 }
 
 bool LFGMgr::FailProposalForLeaver(ObjectGuid plrGuid)
@@ -893,7 +904,7 @@ bool LFGMgr::FailProposalForLeaver(ObjectGuid plrGuid)
         }
 
         itAnswer->second = LFG_ANSWER_DENY;
-        RemoveProposal(itr, LFG_UPDATE_PROPOSAL_DECLINED);
+        RemoveProposal(itr->first, LFG_UPDATE_PROPOSAL_DECLINED);
         return true;
     }
 
@@ -1292,15 +1303,22 @@ void LFGMgr::RemoveOldRoleChecks()
 void LFGMgr::RemoveOldProposals()
 {
     time_t now = time(NULL);
-    for (proposalMap::iterator itr = m_proposalMap.begin(); itr != m_proposalMap.end();)
+
+    // Collect first: removing a proposal re-queues its survivors, which can
+    // insert a fresh proposal and rehash the map out from under a live walk.
+    std::vector<uint32> expired;
+    for (proposalMap::const_iterator itr = m_proposalMap.begin();
+         itr != m_proposalMap.end(); ++itr)
     {
         if (itr->second.cancelTime <= now)
         {
-            itr = RemoveProposal(itr, LFG_UPDATE_PROPOSAL_FAILED);
+            expired.push_back(itr->first);
         }
-        else
-        {
-            ++itr;
-        }
+    }
+
+    for (std::vector<uint32>::const_iterator itr = expired.begin();
+         itr != expired.end(); ++itr)
+    {
+        RemoveProposal(*itr, LFG_UPDATE_PROPOSAL_FAILED);
     }
 }

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -31,6 +31,8 @@
 #include "GameEventMgr.h"
 #include "Group.h"
 #include "LFGMgr.h"
+#include "LFGProposalLogic.h"
+#include "Log.h"
 #include "Object.h"
 #include "Player.h"
 #include "PlayerRegistry.h"
@@ -217,101 +219,118 @@ bool LFGMgr::ValidateGroupRoles(roleMap groupMap)
     return (tankCount + dpsCount + healCount == groupMap.size()) ? true : false;
 }
 
-//todo: remove from queue, update queue average settings
-void LFGMgr::SendDungeonProposal(LFGPlayers* lfgGroup)
+//todo(7b): offer-continue proposals (isNew = false, encounters, groupRawGuid)
+void LFGMgr::SendDungeonProposal(ObjectGuid queueGuid, LFGPlayers* lfgGroup)
 {
-    ++m_proposalId; // increment number to make a new proposal id
-
-    std::set<uint32>::iterator dItr = lfgGroup->dungeonList.begin();
-
-    // note: group create function's parameters are leader guid & leader name
-    LFGProposal newProposal;
-    newProposal.id = m_proposalId;
-    newProposal.state = LFG_PROPOSAL_INITIATING;
-    newProposal.encounters = 0; // todo: check if group has already started a dungeon and are looking for another plr
-    newProposal.currentRoles = lfgGroup->currentRoles;
-    newProposal.dungeonID = *dItr;
-    newProposal.isNew = true;
-    newProposal.joinedQueue = lfgGroup->joinedTime;
-
-    bool premadeGroup = IsProposalSameGroup(newProposal);
-
-    // iterate through role map just so get everyone's guid
-    for (roleMap::iterator it = lfgGroup->currentRoles.begin(); it != lfgGroup->currentRoles.end(); ++it)
+    if (!lfgGroup || lfgGroup->dungeonList.empty() || lfgGroup->currentRoles.empty())
     {
-        ObjectGuid plrGuid = it->first;
-        SetPlayerState(plrGuid, LFG_STATE_PROPOSAL);
+        return;
+    }
+
+    ++m_proposalId;
+
+    LFGProposal proposal;
+    proposal.id = m_proposalId;
+    proposal.dungeonID = *lfgGroup->dungeonList.begin();
+    proposal.joinedQueue = lfgGroup->joinedTime;
+    proposal.cancelTime = time(NULL) + LFG_TIME_PROPOSAL;
+    proposal.queueEntryGuid = queueGuid;
+    proposal.currentRoles = lfgGroup->currentRoles;
+
+    for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+         itr != proposal.currentRoles.end(); ++itr)
+    {
+        ObjectGuid plrGuid = itr->first;
+        proposal.answers[plrGuid] = LFG_ANSWER_PENDING;
 
         Player* pPlayer = sPlayerRegistry.Find(plrGuid);
-        if (!pPlayer)
-        {
-            continue;
-        }
-
-        if (Group* pGroup = pPlayer->GetGroup())
-        {
-            ObjectGuid grpGuid = pGroup->GetObjectGuid();
-
-            SetPlayerUpdateType(plrGuid, LFG_UPDATE_PROPOSAL_BEGIN);
-
-            if (premadeGroup && pGroup->IsLeader(plrGuid))
-            {
-                newProposal.groupLeaderGuid = plrGuid.GetRawValue();
-            }
-
-            if (premadeGroup && !newProposal.groupRawGuid)
-            {
-                newProposal.groupRawGuid = grpGuid.GetRawValue();
-            }
-
-            newProposal.groups[plrGuid] = grpGuid;
-
-            SendLfgUpdate(plrGuid, GetPlayerStatus(plrGuid), true);
-        }
-        else
-        {
-            newProposal.groups[plrGuid] = ObjectGuid();
-
-            //SetPlayerUpdateType(plrGuid, LFG_UPDATE_GROUP_FOUND);
-            //SendLfgUpdate(plrGuid, GetPlayerStatus(plrGuid), false);
-
-            SetPlayerUpdateType(plrGuid, LFG_UPDATE_PROPOSAL_BEGIN);
-            SendLfgUpdate(plrGuid, GetPlayerStatus(plrGuid), false);
-        }
-
-        newProposal.answers[plrGuid] = LFG_ANSWER_PENDING;
-
-        // then send SMSG_LFG_PROPOSAL_UPDATE
-        pPlayer->GetSession()->SendLfgProposalUpdate(newProposal);
+        Group* pGroup = pPlayer ? pPlayer->GetGroup() : NULL;
+        proposal.groups[plrGuid] = pGroup ? pGroup->GetObjectGuid() : ObjectGuid();
     }
 
-    // then if group guid is set, call Group::SetAsLfgGroup()
-    if (premadeGroup)
+    // Freeze the queue entry: no more matching, no more queue status.
+    lfgGroup->currentState = LFG_STATE_PROPOSAL;
+    m_queueSet.erase(queueGuid);
+
+    m_proposalMap[proposal.id] = proposal;
+    LFGProposal const& stored = m_proposalMap[proposal.id];
+
+    for (roleMap::const_iterator itr = stored.currentRoles.begin();
+         itr != stored.currentRoles.end(); ++itr)
     {
-        Player* pGroupLeader = sPlayerRegistry.Find(ObjectGuid(newProposal.groupLeaderGuid));
+        ObjectGuid plrGuid = itr->first;
+        bool isParty = !stored.groups.find(plrGuid)->second.IsEmpty();
 
-        if (pGroupLeader)
-        {
-            Group* pGroup = pGroupLeader->GetGroup();
-            if (pGroup)
-            {
-                pGroup->SetAsLfgGroup();
-            }
-            else
-            {
-                // Log an error: group not found for group leader
-                // In the future, we should determine the right actions for this scenario.
-            }
-        }
-        else
-        {
-            // Log an error: group leader not found
-            // In the future, we should determine the right actions for this scenario.
-        }
+        SetPlayerState(plrGuid, LFG_STATE_PROPOSAL);
+        SetPlayerUpdateType(plrGuid, LFG_UPDATE_PROPOSAL_BEGIN);
+        SendLfgUpdate(plrGuid, GetPlayerStatus(plrGuid), isParty);
+        SendProposalUpdateToPlayer(plrGuid, stored);
     }
 
-    // also save the proposal
-    m_proposalMap[newProposal.id] = newProposal;
+    DEBUG_FILTER_LOG(LOG_FILTER_LFG,
+        "LFGMgr: proposal %u sent for dungeon %u to %u players",
+        stored.id, stored.dungeonID, uint32(stored.currentRoles.size()));
+}
+
+void LFGMgr::SendProposalUpdateToPlayer(ObjectGuid plrGuid, LFGProposal const& proposal)
+{
+    Player* pPlayer = sPlayerRegistry.Find(plrGuid);
+    if (!pPlayer)
+    {
+        return;
+    }
+
+    LFGPlayerStatus status = GetPlayerStatus(plrGuid);
+
+    // Show the recipient the dungeon they actually picked (their random
+    // entry) when the concrete dungeon is not in their selection
+    // (tc-preservation LFGHandler.cpp:594-599).
+    uint32 dungeonId = proposal.dungeonID;
+    if (!status.dungeonList.empty() &&
+        status.dungeonList.find(dungeonId) == status.dungeonList.end())
+    {
+        dungeonId = *status.dungeonList.begin();
+    }
+
+    playerGroupMap::const_iterator selfItr = proposal.groups.find(plrGuid);
+    ObjectGuid myGroup = (selfItr != proposal.groups.end())
+        ? selfItr->second : ObjectGuid();
+
+    LFGPackets::ProposalUpdate data;
+    data.ticket = status.ticket;
+    data.instanceId = 0;                        // TC parity; echoed back, unused
+    data.proposalId = proposal.id;
+    data.slot = GetDungeonEntry(dungeonId);
+    data.state = int8(proposal.state);
+    data.completedMask = proposal.encounters;
+    data.proposalSilent = false;                // every 7a proposal is new (C4)
+
+    for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+         itr != proposal.currentRoles.end(); ++itr)
+    {
+        ObjectGuid memberGuid = itr->first;
+
+        playerGroupMap::const_iterator grpItr = proposal.groups.find(memberGuid);
+        ObjectGuid memberGroup = (grpItr != proposal.groups.end())
+            ? grpItr->second : ObjectGuid();
+
+        proposalAnswerMap::const_iterator ansItr = proposal.answers.find(memberGuid);
+        LFGProposalAnswer answer = (ansItr != proposal.answers.end())
+            ? ansItr->second : LFG_ANSWER_PENDING;
+
+        LFGPackets::ProposalUpdatePlayer member;
+        member.roles = itr->second;             // leader bit kept (client isLeader)
+        member.me = memberGuid == plrGuid;
+        member.sameParty = !memberGroup.IsEmpty() && memberGroup == myGroup;
+        // Wire bit 2 gates the client's "someone in your party did not
+        // accept" message (spec C5); TC's proposal-group fill starves it.
+        member.myParty = member.sameParty;
+        member.responded = answer != LFG_ANSWER_PENDING;
+        member.accepted = answer == LFG_ANSWER_AGREE;
+        data.players.push_back(member);
+    }
+
+    pPlayer->GetSession()->SendLfgProposalUpdate(data);
 }
 
 bool LFGMgr::IsProposalSameGroup(LFGProposal const& proposal)
@@ -351,106 +370,96 @@ bool LFGMgr::IsProposalSameGroup(LFGProposal const& proposal)
     return isSameGroup;
 }
 
-// From a CMSG_LFG_PROPOSAL_RESPONSE call
+// From CMSG_LFG_PROPOSAL_RESULT
 void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted)
 {
-    //note: create a group here if it doesn't exist and everyone accepted proposal
-    LFGProposal* proposal = GetProposalData(proposalID);
-
-    if (!proposal)
+    proposalMap::iterator itProposal = m_proposalMap.find(proposalID);
+    if (itProposal == m_proposalMap.end())
     {
         return;
     }
 
-    bool allOkay = true; // true if everyone answered LFG_ANSWER_AGREE
+    LFGProposal& proposal = itProposal->second;
 
-    // Update answer map to given value
-    LFGProposalAnswer plrAnswer = (LFGProposalAnswer)accepted;
-    proposal->answers[plrGuid] = plrAnswer;
-
-    // If the player declined, the proposal is over
-    if (plrAnswer == LFG_ANSWER_DENY)
+    proposalAnswerMap::iterator itAnswer = proposal.answers.find(plrGuid);
+    if (itAnswer == proposal.answers.end())
     {
-        ProposalDeclined(plrGuid, proposal);
+        return;                     // not a member of this proposal
     }
 
-    for (proposalAnswerMap::iterator it = proposal->answers.begin(); it != proposal->answers.end(); ++it)
+    itAnswer->second = accepted ? LFG_ANSWER_AGREE : LFG_ANSWER_DENY;
+
+    DEBUG_FILTER_LOG(LOG_FILTER_LFG, "LFGMgr: proposal %u answer %u from %s",
+        proposalID, uint32(accepted), plrGuid.GetString().c_str());
+
+    if (!accepted)
     {
-        if (it->second != LFG_ANSWER_AGREE)
+        RemoveProposal(itProposal, LFG_UPDATE_PROPOSAL_DECLINED);
+        return;
+    }
+
+    bool allAgreed = true;
+    for (proposalAnswerMap::const_iterator itr = proposal.answers.begin();
+         itr != proposal.answers.end(); ++itr)
+    {
+        if (itr->second != LFG_ANSWER_AGREE)
         {
-            allOkay = false;
+            allAgreed = false;
+            break;
         }
     }
 
-    // if !allOkay, send proposal updates to all
-    if (!allOkay)
+    if (!allAgreed)
     {
-        for (proposalAnswerMap::iterator itr = proposal->answers.begin(); itr != proposal->answers.end(); ++itr)
+        // Everyone's popup shows the new answer.
+        for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+             itr != proposal.currentRoles.end(); ++itr)
         {
-            ObjectGuid proposalPlrGuid  = itr->first;
-            Player* pProposalPlayer = sPlayerRegistry.Find(proposalPlrGuid);
-            if (pProposalPlayer)
-            {
-                pProposalPlayer->GetSession()->SendLfgProposalUpdate(*proposal);
-            }
+            SendProposalUpdateToPlayer(itr->first, proposal);
         }
 
         return;
     }
 
-    // at this point everyone's good to join the dungeon!
+    // Success: state 2, TC packet sequence, then wipe -- 7b replaces the
+    // wipe with group formation + teleport (CreateDungeonGroup).
+    bool sendUpdate = proposal.state != LFG_PROPOSAL_SUCCESS;
+    proposal.state = LFG_PROPOSAL_SUCCESS;
+    time_t now = time(NULL);
 
-    time_t joinedTime = time(NULL);
-    bool sendProposalUpdate = proposal->state != LFG_PROPOSAL_SUCCESS;
-
-    // now update the proposal's state to successful and inform the players
-    proposal->state = LFG_PROPOSAL_SUCCESS;
-    for (roleMap::iterator rItr = proposal->currentRoles.begin(); rItr != proposal->currentRoles.end(); ++rItr)
+    for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+         itr != proposal.currentRoles.end(); ++itr)
     {
-        // get the player's role
-        uint8 proposalPlrRole   = rItr->second;
-        proposalPlrRole &= ~PLAYER_ROLE_LEADER;
+        ObjectGuid memberGuid = itr->first;
+        uint8 role = itr->second;
+        role &= ~PLAYER_ROLE_LEADER;
 
-        ObjectGuid proposalPlrGuid  = rItr->first;
-        Player* pProposalPlayer = sPlayerRegistry.Find(proposalPlrGuid);
-        if (!pProposalPlayer)
+        if (sendUpdate)
         {
-            continue;
+            SendProposalUpdateToPlayer(memberGuid, proposal);
         }
 
-        if (sendProposalUpdate)
-        {
-            pProposalPlayer->GetSession()->SendLfgProposalUpdate(*proposal);
-        }
+        UpdateWaitMap(LFGRoles(role), proposal.dungeonID,
+                      time_t(now - proposal.joinedQueue));
 
-        // amount of time spent in queue
-        int32 timeWaited = joinedTime - proposal->joinedQueue;
-
-        // tell the lfg system to update the average wait times on the next tick
-        UpdateWaitMap(LFGRoles(proposalPlrRole), proposal->dungeonID, timeWaited);
-
-        // send some updates to the player, depending on group status
-        LFGPlayerStatus proposalPlrStatus = GetPlayerStatus(proposalPlrGuid);
-        proposalPlrStatus.updateType = LFG_UPDATE_GROUP_FOUND;
-
-        if (pProposalPlayer->GetGroup())
-        {
-            SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, true);
-            RemoveFromQueue(pProposalPlayer->GetGroup()->GetObjectGuid()); // not the best way to handle this
-        }
-        else
-        {
-            SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, false);
-            RemoveFromQueue(proposalPlrGuid);
-        }
-
-        proposalPlrStatus.updateType = LFG_UPDATE_REMOVED_FROM_QUEUE;
-        SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, false);
-        SendLfgUpdate(proposalPlrGuid, proposalPlrStatus, true);
+        bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
+        LFGPlayerStatus status = GetPlayerStatus(memberGuid);
+        status.updateType = LFG_UPDATE_GROUP_FOUND;
+        SendLfgUpdate(memberGuid, status, isParty);
     }
 
-    CreateDungeonGroup(proposal);
-    m_proposalMap.erase(proposal->id);
+    sLog.outString("LFGMgr: proposal %u succeeded for dungeon %u -- "
+                   "group formation lands in Phase 7b", proposal.id,
+                   proposal.dungeonID);
+
+    for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+         itr != proposal.currentRoles.end(); ++itr)
+    {
+        m_playerStatusMap.erase(itr->first);
+    }
+
+    m_playerData.erase(proposal.queueEntryGuid);
+    m_proposalMap.erase(itProposal);
 }
 
 bool LFGMgr::HasLeaderFlag(roleMap const& roles)
@@ -752,67 +761,143 @@ LFGGroupStatus* LFGMgr::GetGroupStatus(ObjectGuid guid)
     }
 }
 
-void LFGMgr::ProposalDeclined(ObjectGuid guid, LFGProposal* proposal)
+proposalMap::iterator LFGMgr::RemoveProposal(proposalMap::iterator itProposal, LfgUpdateType type)
 {
-    Player* pPlayer = sPlayerRegistry.Find(guid);
+    LFGProposal& proposal = itProposal->second;
+    proposal.state = LFG_PROPOSAL_FAILED;
 
-    if (!pPlayer)
+    DEBUG_FILTER_LOG(LOG_FILTER_LFG, "LFGMgr: proposal %u failed, update type %u",
+        proposal.id, uint32(type));
+
+    // 1. Classify: decliners' whole units leave, everyone else re-queues.
+    std::vector<LFGProposalLogic::Member> members;
+    std::vector<ObjectGuid> memberGuids;
+    members.reserve(proposal.currentRoles.size());
+    memberGuids.reserve(proposal.currentRoles.size());
+
+    for (roleMap::const_iterator itr = proposal.currentRoles.begin();
+         itr != proposal.currentRoles.end(); ++itr)
     {
-        return;
+        ObjectGuid memberGuid = itr->first;
+        ObjectGuid unitGuid = proposal.groups.find(memberGuid)->second;
+
+        LFGProposalLogic::Member member;
+        member.guid = memberGuid.GetRawValue();
+        member.unitGuid = unitGuid.IsEmpty() ? member.guid : unitGuid.GetRawValue();
+        member.answer = int(proposal.answers.find(memberGuid)->second);
+        members.push_back(member);
+        memberGuids.push_back(memberGuid);
     }
 
-    bool leaveGroupLFG = false;
+    std::vector<LFGProposalLogic::Disposition> dispositions;
+    LFGProposalLogic::ResolveFailure(members, type == LFG_UPDATE_PROPOSAL_FAILED,
+                                     dispositions);
 
-    for (roleMap::iterator it = proposal->currentRoles.begin(); it != proposal->currentRoles.end(); ++it)
+    // Timeout flipped PENDING to DENY; reflect that in the packet's
+    // responded/accepted bits.
+    for (size_t i = 0; i < members.size(); ++i)
     {
-        ObjectGuid groupPlrGuid = it->first;
+        proposal.answers[memberGuids[i]] = LFGProposalAnswer(members[i].answer);
+    }
 
-        // update each player with a LFG_UPDATE_PROPOSAL_DECLINED
-        SetPlayerUpdateType(groupPlrGuid, LFG_UPDATE_PROPOSAL_DECLINED);
+    // 2. Notify. Proposal packet first, then the removed members' status
+    //    (tc-preservation LFGMgr.cpp:1224-1258; survivors follow in step 3).
+    for (size_t i = 0; i < members.size(); ++i)
+    {
+        ObjectGuid memberGuid = memberGuids[i];
+        bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
 
-        Player* pGroupPlayer = sPlayerRegistry.Find(groupPlrGuid);
-        if (!pGroupPlayer)
+        SendProposalUpdateToPlayer(memberGuid, proposal);
+
+        if (dispositions[i] != LFGProposalLogic::DISPOSITION_REMOVE)
         {
             continue;
         }
-        Group* pGroup = pGroupPlayer->GetGroup();
 
-        // if player was in a premade group and declined, remove the group.
-        if (groupPlrGuid == guid)
-        {
-            //LeaveLFG(pGroupPlayer, true);
-            if (pGroup && (pGroup->GetObjectGuid().GetRawValue() == proposal->groupRawGuid))
-            {
-                leaveGroupLFG = true;
-            }
+        LFGPlayerStatus status = GetPlayerStatus(memberGuid);
+        status.updateType = (members[i].answer == LFGProposalLogic::ANSWER_DENY)
+            ? type : LFG_UPDATE_REMOVED_FROM_QUEUE;
+        status.state = LFG_STATE_NONE;
+        status.dungeonList.clear();
+        SendLfgUpdate(memberGuid, status, isParty);
 
-            SendLfgUpdate(groupPlrGuid, GetPlayerStatus(groupPlrGuid), false);
-        }
-        else
-        {
-            if (proposal->groupRawGuid)
-            {
-                SendLfgUpdate(groupPlrGuid, GetPlayerStatus(groupPlrGuid), true);
-            }
-            else
-            {
-                SendLfgUpdate(groupPlrGuid, GetPlayerStatus(groupPlrGuid), false);
-            }
-        }
+        m_playerStatusMap.erase(memberGuid);
     }
 
-    if (!leaveGroupLFG)
+    // 3. Re-queue every survivor as one entry (m3 merged the originals
+    //    away -- spec C11).
+    uint64 newKeyRaw = LFGProposalLogic::PickRequeueKey(
+        members, dispositions, proposal.queueEntryGuid.GetRawValue());
+
+    playerData::iterator itEntry = m_playerData.find(proposal.queueEntryGuid);
+    if (newKeyRaw == 0)
     {
-        proposal->currentRoles.erase(guid);
-        proposal->answers.erase(guid);
-        proposal->groups.erase(guid);
+        if (itEntry != m_playerData.end())
+        {
+            m_playerData.erase(itEntry);
+        }
     }
     else
     {
-        m_proposalMap.erase(proposal->id);
+        LFGPlayers entry;
+        if (itEntry != m_playerData.end())
+        {
+            entry = itEntry->second;
+            m_playerData.erase(itEntry);
+        }
+
+        entry.currentState = LFG_STATE_QUEUED;
+        entry.currentRoles.clear();
+        for (size_t i = 0; i < members.size(); ++i)
+        {
+            if (dispositions[i] == LFGProposalLogic::DISPOSITION_REQUEUE)
+            {
+                entry.currentRoles[memberGuids[i]] =
+                    proposal.currentRoles.find(memberGuids[i])->second;
+            }
+        }
+
+        ObjectGuid newKey = ObjectGuid(newKeyRaw);
+        m_playerData[newKey] = entry;
+
+        for (size_t i = 0; i < members.size(); ++i)
+        {
+            if (dispositions[i] != LFGProposalLogic::DISPOSITION_REQUEUE)
+            {
+                continue;
+            }
+
+            ObjectGuid memberGuid = memberGuids[i];
+            bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
+
+            SetPlayerState(memberGuid, LFG_STATE_QUEUED);
+            SetPlayerUpdateType(memberGuid, LFG_UPDATE_ADDED_TO_QUEUE);
+            SendLfgUpdate(memberGuid, GetPlayerStatus(memberGuid), isParty);
+        }
+
+        AddToQueue(newKey);
+        SendQueueStatusFor(newKey);
     }
 
-    LeaveLFG(pPlayer, leaveGroupLFG);
+    return m_proposalMap.erase(itProposal);
+}
+
+bool LFGMgr::FailProposalForLeaver(ObjectGuid plrGuid)
+{
+    for (proposalMap::iterator itr = m_proposalMap.begin(); itr != m_proposalMap.end(); ++itr)
+    {
+        proposalAnswerMap::iterator itAnswer = itr->second.answers.find(plrGuid);
+        if (itAnswer == itr->second.answers.end())
+        {
+            continue;
+        }
+
+        itAnswer->second = LFG_ANSWER_DENY;
+        RemoveProposal(itr, LFG_UPDATE_PROPOSAL_DECLINED);
+        return true;
+    }
+
+    return false;
 }
 
 void LFGMgr::UpdateWaitMap(LFGRoles role, uint32 dungeonID, time_t waitTime)
@@ -1200,6 +1285,22 @@ void LFGMgr::RemoveOldRoleChecks()
         else
         {
             ++roleItr;
+        }
+    }
+}
+
+void LFGMgr::RemoveOldProposals()
+{
+    time_t now = time(NULL);
+    for (proposalMap::iterator itr = m_proposalMap.begin(); itr != m_proposalMap.end();)
+    {
+        if (itr->second.cancelTime <= now)
+        {
+            itr = RemoveProposal(itr, LFG_UPDATE_PROPOSAL_FAILED);
+        }
+        else
+        {
+            ++itr;
         }
     }
 }

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -343,6 +343,13 @@ void LFGMgr::LeaveLFG(Player* plr, bool isGroup)
 
         ObjectGuid grpGuid = pGroup->GetObjectGuid();
 
+        // Leaving while the dungeon-ready popup is up counts as a decline
+        // (tc-preservation LFGMgr.cpp:709-729).
+        if (FailProposalForLeaver(plr->GetObjectGuid()))
+        {
+            return;
+        }
+
         if (m_roleCheckMap.count(grpGuid))
         {
             PerformRoleCheck(NULL, pGroup, 0);   // aborts the check and notifies everyone
@@ -376,6 +383,11 @@ void LFGMgr::LeaveLFG(Player* plr, bool isGroup)
     else
     {
         ObjectGuid plrGuid = plr->GetObjectGuid();
+
+        if (FailProposalForLeaver(plrGuid))
+        {
+            return;
+        }
 
         LFGPlayerStatus plrStatus = GetPlayerStatus(plrGuid);
         if (plrStatus.state == LFG_STATE_QUEUED || plrStatus.state == LFG_STATE_PROPOSAL)

--- a/src/game/WorldHandlers/LFGProposalLogic.h
+++ b/src/game/WorldHandlers/LFGProposalLogic.h
@@ -1,0 +1,151 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_LFGPROPOSALLOGIC_H
+#define MANGOS_LFGPROPOSALLOGIC_H
+
+/**
+ * @file LFGProposalLogic.h
+ * @brief Decides who gets removed and who gets re-queued when a dungeon
+ *        proposal fails, decoupled from LFGMgr.
+ *
+ * A failed proposal (decline or 45-second expiry) has to sort its members
+ * into two piles: the decliner and everyone who shared their original party
+ * leaves, everyone else goes back to the queue. LFGMgr::RemoveProposal
+ * (LFGMgrProposal.cpp) collects the participants and calls ResolveFailure();
+ * the decision lives here so it can be unit tested without linking `game` --
+ * src/tests/CMakeLists.txt only links `proto`/`shared` into mangos_tests, the
+ * same boundary LFGLockReason.h and LFGRoleAssignment.h document.
+ *
+ * Numeric parity with LFGMgr.h's LFGProposalAnswer is kept in sync by hand
+ * (precedent: LFGRoleAssignment.h) -- this header stays game-free.
+ */
+
+#include "Platform/Define.h"
+
+#include <vector>
+
+namespace LFGProposalLogic
+{
+    enum Answer
+    {
+        ANSWER_PENDING = -1,
+        ANSWER_DENY    = 0,
+        ANSWER_AGREE   = 1
+    };
+
+    enum Disposition
+    {
+        DISPOSITION_REQUEUE = 0,   ///< survivor: goes back to the queue
+        DISPOSITION_REMOVE  = 1    ///< decliner, or shares a unit with one
+    };
+
+    /// One proposal participant, reduced to what the outcome depends on.
+    struct Member
+    {
+        uint64 guid = 0;       ///< player guid, raw
+        uint64 unitGuid = 0;   ///< original party guid, or guid when solo
+        int answer = ANSWER_PENDING;
+    };
+
+    /// True when every member has agreed.
+    inline bool AllAgreed(std::vector<Member> const& members)
+    {
+        for (Member const& member : members)
+        {
+            if (member.answer != ANSWER_AGREE)
+            {
+                return false;
+            }
+        }
+
+        return !members.empty();
+    }
+
+    /// Resolves a failed proposal. On expiry every PENDING answer becomes
+    /// DENY (mutated in place so the caller can report it). A member is
+    /// removed when anyone in their unit denied; everyone else re-queues.
+    inline void ResolveFailure(std::vector<Member>& members, bool expired,
+                               std::vector<Disposition>& dispositions)
+    {
+        if (expired)
+        {
+            for (Member& member : members)
+            {
+                if (member.answer == ANSWER_PENDING)
+                {
+                    member.answer = ANSWER_DENY;
+                }
+            }
+        }
+
+        dispositions.assign(members.size(), DISPOSITION_REQUEUE);
+        for (size_t i = 0; i < members.size(); ++i)
+        {
+            if (members[i].answer != ANSWER_DENY)
+            {
+                continue;
+            }
+
+            for (size_t j = 0; j < members.size(); ++j)
+            {
+                if (members[j].unitGuid == members[i].unitGuid)
+                {
+                    dispositions[j] = DISPOSITION_REMOVE;
+                }
+            }
+        }
+    }
+
+    /// Queue key for the surviving members: keepKey when its unit survives,
+    /// else the smallest surviving unit guid; 0 when nobody survives.
+    inline uint64 PickRequeueKey(std::vector<Member> const& members,
+                                 std::vector<Disposition> const& dispositions,
+                                 uint64 keepKey)
+    {
+        uint64 best = 0;
+        for (size_t i = 0; i < members.size(); ++i)
+        {
+            if (dispositions[i] != DISPOSITION_REQUEUE)
+            {
+                continue;
+            }
+
+            if (members[i].unitGuid == keepKey)
+            {
+                return keepKey;
+            }
+
+            if (best == 0 || members[i].unitGuid < best)
+            {
+                best = members[i].unitGuid;
+            }
+        }
+
+        return best;
+    }
+}
+
+#endif

--- a/src/game/WorldHandlers/LFGRoleAssignment.h
+++ b/src/game/WorldHandlers/LFGRoleAssignment.h
@@ -84,20 +84,30 @@ namespace LFGRoleAssignment
     *   One entry per queued player; the leader bit is ignored.
     * \arg \c maxTanks \c maxHealers \c maxDps
     *   Slot capacity for the content being queued for (1/1/3 for 5-man).
+    * \arg \c assigned
+    *   Optional; when given, receives one entry per input holding the single
+    *   role that player ended up filling, or ROLE_NONE if they got no seat.
     * \return
     *   The seated counts. \c seated below \c masks.size() means at least one
     *   player selected no role, or only roles that were already full.
     */
     inline Counts Assign(std::vector<uint8> const& masks, uint8 maxTanks,
-                         uint8 maxHealers, uint8 maxDps)
+                         uint8 maxHealers, uint8 maxDps,
+                         std::vector<uint8>* assigned = nullptr)
     {
         Counts out;
-        std::vector<uint8> flexible;
 
-        for (std::vector<uint8>::const_iterator it = masks.begin();
-             it != masks.end(); ++it)
+        if (assigned)
         {
-            uint8 mask = *it & ~uint8(ROLE_LEADER);
+            assigned->assign(masks.size(), uint8(ROLE_NONE));
+        }
+
+        // Index of each player who did not pin themselves to one role.
+        std::vector<size_t> flexible;
+
+        for (size_t i = 0; i < masks.size(); ++i)
+        {
+            uint8 mask = masks[i] & ~uint8(ROLE_LEADER);
             switch (mask)
             {
                 case ROLE_TANK:
@@ -105,6 +115,10 @@ namespace LFGRoleAssignment
                     {
                         ++out.tanks;
                         ++out.seated;
+                        if (assigned)
+                        {
+                            (*assigned)[i] = ROLE_TANK;
+                        }
                     }
                     break;
                 case ROLE_HEALER:
@@ -112,6 +126,10 @@ namespace LFGRoleAssignment
                     {
                         ++out.healers;
                         ++out.seated;
+                        if (assigned)
+                        {
+                            (*assigned)[i] = ROLE_HEALER;
+                        }
                     }
                     break;
                 case ROLE_DAMAGE:
@@ -119,34 +137,50 @@ namespace LFGRoleAssignment
                     {
                         ++out.dps;
                         ++out.seated;
+                        if (assigned)
+                        {
+                            (*assigned)[i] = ROLE_DAMAGE;
+                        }
                     }
                     break;
                 default:
                     if (mask != ROLE_NONE)
                     {
-                        flexible.push_back(mask);
+                        flexible.push_back(i);
                     }
                     break;
             }
         }
 
-        for (std::vector<uint8>::const_iterator it = flexible.begin();
+        for (std::vector<size_t>::const_iterator it = flexible.begin();
              it != flexible.end(); ++it)
         {
-            if ((*it & ROLE_TANK) && out.tanks < maxTanks)
+            uint8 mask = masks[*it] & ~uint8(ROLE_LEADER);
+            uint8 seat = ROLE_NONE;
+
+            if ((mask & ROLE_TANK) && out.tanks < maxTanks)
             {
                 ++out.tanks;
-                ++out.seated;
+                seat = ROLE_TANK;
             }
-            else if ((*it & ROLE_HEALER) && out.healers < maxHealers)
+            else if ((mask & ROLE_HEALER) && out.healers < maxHealers)
             {
                 ++out.healers;
-                ++out.seated;
+                seat = ROLE_HEALER;
             }
-            else if ((*it & ROLE_DAMAGE) && out.dps < maxDps)
+            else if ((mask & ROLE_DAMAGE) && out.dps < maxDps)
             {
                 ++out.dps;
+                seat = ROLE_DAMAGE;
+            }
+
+            if (seat != ROLE_NONE)
+            {
                 ++out.seated;
+                if (assigned)
+                {
+                    (*assigned)[*it] = seat;
+                }
             }
         }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SRC_GRP_TESTS
     LFGPacketsTest.cpp
     LFGLockReasonTest.cpp
     LFGRoleAssignmentTest.cpp
+    LFGProposalLogicTest.cpp
     SessionMailboxTest.cpp
     SessionProtocolPolicyTest.cpp
     DatabaseConcurrencyTest.cpp

--- a/src/tests/LFGProposalLogicTest.cpp
+++ b/src/tests/LFGProposalLogicTest.cpp
@@ -1,0 +1,229 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "LFGProposalLogic.h"
+
+/**
+ * @file LFGProposalLogicTest.cpp
+ * @brief Coverage for LFGProposalLogic -- who gets dropped and who gets
+ * re-queued when a dungeon-ready proposal fails (decline or expiry), and
+ * which guid survivors re-queue under.
+ */
+
+namespace
+{
+    using namespace LFGProposalLogic;
+
+    Member M(uint64 guid, uint64 unit, int answer)
+    {
+        Member m;
+        m.guid = guid;
+        m.unitGuid = unit ? unit : guid;
+        m.answer = answer;
+        return m;
+    }
+}
+
+TEST(LFGProposalLogic_AllAgreed_empty_is_false)
+{
+    std::vector<Member> members;
+    CHECK(!AllAgreed(members));
+}
+
+TEST(LFGProposalLogic_AllAgreed_pending_is_false)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 0, ANSWER_AGREE));
+    members.push_back(M(2, 0, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_AGREE));
+    members.push_back(M(4, 0, ANSWER_AGREE));
+    members.push_back(M(5, 0, ANSWER_PENDING));
+
+    CHECK(!AllAgreed(members));
+}
+
+TEST(LFGProposalLogic_AllAgreed_five_agrees_is_true)
+{
+    std::vector<Member> members;
+    for (uint64 i = 1; i <= 5; ++i)
+    {
+        members.push_back(M(i, 0, ANSWER_AGREE));
+    }
+
+    CHECK(AllAgreed(members));
+}
+
+TEST(LFGProposalLogic_decline_removes_only_the_decliner)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 0, ANSWER_DENY));
+    members.push_back(M(2, 0, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_AGREE));
+    members.push_back(M(4, 0, ANSWER_AGREE));
+    members.push_back(M(5, 0, ANSWER_AGREE));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, false, dispositions);
+
+    REQUIRE(dispositions.size() == 5);
+    CHECK(dispositions[0] == DISPOSITION_REMOVE);
+    CHECK(dispositions[1] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[2] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[3] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[4] == DISPOSITION_REQUEUE);
+
+    CHECK(members[0].answer == ANSWER_DENY);
+    CHECK(members[1].answer == ANSWER_AGREE);
+}
+
+TEST(LFGProposalLogic_decline_takes_the_whole_party_along)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 100, ANSWER_DENY));
+    members.push_back(M(2, 100, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_AGREE));
+    members.push_back(M(4, 0, ANSWER_AGREE));
+    members.push_back(M(5, 0, ANSWER_AGREE));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, false, dispositions);
+
+    REQUIRE(dispositions.size() == 5);
+    CHECK(dispositions[0] == DISPOSITION_REMOVE);
+    CHECK(dispositions[1] == DISPOSITION_REMOVE);
+    CHECK(dispositions[2] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[3] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[4] == DISPOSITION_REQUEUE);
+}
+
+TEST(LFGProposalLogic_outsider_decline_keeps_the_party)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 100, ANSWER_AGREE));
+    members.push_back(M(2, 100, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_DENY));
+    members.push_back(M(4, 0, ANSWER_AGREE));
+    members.push_back(M(5, 0, ANSWER_AGREE));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, false, dispositions);
+
+    REQUIRE(dispositions.size() == 5);
+    CHECK(dispositions[0] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[1] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[2] == DISPOSITION_REMOVE);
+    CHECK(dispositions[3] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[4] == DISPOSITION_REQUEUE);
+}
+
+TEST(LFGProposalLogic_expiry_flips_pending_to_deny)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 0, ANSWER_AGREE));
+    members.push_back(M(2, 0, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_AGREE));
+    members.push_back(M(4, 0, ANSWER_AGREE));
+    members.push_back(M(5, 0, ANSWER_PENDING));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, true, dispositions);
+
+    REQUIRE(dispositions.size() == 5);
+    CHECK(dispositions[0] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[1] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[2] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[3] == DISPOSITION_REQUEUE);
+    CHECK(dispositions[4] == DISPOSITION_REMOVE);
+
+    CHECK(members[4].answer == ANSWER_DENY);
+    CHECK(members[0].answer == ANSWER_AGREE);
+}
+
+TEST(LFGProposalLogic_expiry_everyone_pending_removes_all)
+{
+    std::vector<Member> members;
+    for (uint64 i = 1; i <= 5; ++i)
+    {
+        members.push_back(M(i, 0, ANSWER_PENDING));
+    }
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, true, dispositions);
+
+    REQUIRE(dispositions.size() == 5);
+    for (size_t i = 0; i < dispositions.size(); ++i)
+    {
+        CHECK(dispositions[i] == DISPOSITION_REMOVE);
+        CHECK(members[i].answer == ANSWER_DENY);
+    }
+}
+
+TEST(LFGProposalLogic_requeue_key_keeps_surviving_key)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 0, ANSWER_DENY));
+    members.push_back(M(2, 0, ANSWER_AGREE));
+    members.push_back(M(3, 0, ANSWER_AGREE));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, false, dispositions);
+
+    uint64 key = PickRequeueKey(members, dispositions, 2);
+    CHECK(key == 2);
+}
+
+TEST(LFGProposalLogic_requeue_key_moves_off_removed_key)
+{
+    std::vector<Member> members;
+    members.push_back(M(1, 100, ANSWER_DENY));
+    members.push_back(M(2, 100, ANSWER_AGREE));
+    members.push_back(M(3, 50, ANSWER_AGREE));
+    members.push_back(M(4, 200, ANSWER_AGREE));
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, false, dispositions);
+
+    // keepKey (100) was removed along with its whole unit; the smallest
+    // surviving unit guid among {50, 200} is 50.
+    uint64 key = PickRequeueKey(members, dispositions, 100);
+    CHECK(key == 50);
+}
+
+TEST(LFGProposalLogic_requeue_key_zero_when_none_survive)
+{
+    std::vector<Member> members;
+    for (uint64 i = 1; i <= 5; ++i)
+    {
+        members.push_back(M(i, 0, ANSWER_PENDING));
+    }
+
+    std::vector<Disposition> dispositions;
+    ResolveFailure(members, true, dispositions);
+
+    uint64 key = PickRequeueKey(members, dispositions, 1);
+    CHECK(key == 0);
+}

--- a/src/tests/LFGRoleAssignmentTest.cpp
+++ b/src/tests/LFGRoleAssignmentTest.cpp
@@ -211,6 +211,61 @@ TEST(LFGRoleAssignment_flexible_paladin_with_full_group_takes_damage)
     CHECK(c.seated == 5);
 }
 
+TEST(LFGRoleAssignment_reports_the_seat_each_player_took)
+{
+    // The proposal packet sends one icon per role bit, so it needs the seat
+    // rather than the selection -- otherwise a tank+healer shows as a second
+    // tank next to the real one.
+    std::vector<uint8> masks;
+    masks.push_back(ROLE_TANK);
+    masks.push_back(uint8(ROLE_TANK | ROLE_HEALER | ROLE_DAMAGE));
+    masks.push_back(ROLE_DAMAGE);
+
+    std::vector<uint8> seats;
+    Counts c = Assign(masks, TANKS_5MAN, HEALS_5MAN, DPS_5MAN, &seats);
+
+    REQUIRE(seats.size() == 3);
+    CHECK(seats[0] == ROLE_TANK);
+    CHECK(seats[1] == ROLE_HEALER);   // tank was taken, healer was the gap
+    CHECK(seats[2] == ROLE_DAMAGE);
+    CHECK(c.seated == 3);
+}
+
+TEST(LFGRoleAssignment_unseated_player_reports_no_role)
+{
+    std::vector<uint8> masks;
+    masks.push_back(ROLE_TANK);
+    masks.push_back(ROLE_TANK);
+
+    std::vector<uint8> seats;
+    Counts c = Assign(masks, TANKS_5MAN, HEALS_5MAN, DPS_5MAN, &seats);
+
+    REQUIRE(seats.size() == 2);
+    CHECK(seats[0] == ROLE_TANK);
+    CHECK(seats[1] == ROLE_NONE);
+    CHECK(c.seated == 1);
+}
+
+TEST(LFGRoleAssignment_seat_is_always_a_single_bit)
+{
+    std::vector<uint8> masks;
+    for (int i = 0; i < 5; ++i)
+    {
+        masks.push_back(uint8(ROLE_TANK | ROLE_HEALER | ROLE_DAMAGE));
+    }
+
+    std::vector<uint8> seats;
+    Assign(masks, TANKS_5MAN, HEALS_5MAN, DPS_5MAN, &seats);
+
+    REQUIRE(seats.size() == 5);
+    for (size_t i = 0; i < seats.size(); ++i)
+    {
+        // exactly one bit set
+        CHECK(seats[i] != ROLE_NONE);
+        CHECK((seats[i] & (seats[i] - 1)) == 0);
+    }
+}
+
 TEST(LFGRoleAssignment_all_flexible_fills_every_slot)
 {
     std::vector<uint8> masks;


### PR DESCRIPTION
Turns a completed match into the dungeon-ready popup: fires `SMSG_LFG_PROPOSAL_UPDATE`, registers and handles `CMSG_LFG_PROPOSAL_RESULT`, tracks each member's answer, and expires a proposal after 45 seconds. Builds on #329.

Group formation and teleport are deliberately not here — a proposal everyone accepts is marked succeeded and logged. That keeps this reviewable and lets the wire behaviour be checked on its own.

**Fixes a use-after-free that would have fired on the first decline.** `ProposalUpdate` called `ProposalDeclined`, which does `m_proposalMap.erase(proposal->id)`, then carried on iterating `proposal->answers` through the freed pointer. Retiring a proposal now takes the id, copies the entry and erases it up front, so no caller holds an iterator across the re-queue — which can itself insert into the same `unordered_map` and rehash it.

**A second trigger site was required.** The completeness check only ran from `MergeGroups`, which needs two entries to merge, so a full premade group would never have proposed at all. `AddToQueue` now checks as well.

`LFG_TIME_PROPOSAL` was declared and never used; it is a bare 45 seconds and needed no correction — unlike the role-check timer #329 fixed.

**One deliberate divergence from TrinityCore**, evidenced: the proposal packet's per-member "in my party" bit is filled per recipient rather than from the proposal's group set. Wire bit 2 is the sole gate for the client's "someone in your party did not accept" message, and TrinityCore's fill starves it.

Members are sent the single role they will actually fill rather than their raw selection — the client draws one icon per bit, so a player who offered to tank and heal otherwise appears as a second tank beside the real one.

Verified in-game with five clients: popup, accept, decline, leave-during-proposal, and the 45-second expiry re-queueing survivors. 100 LFG tests, 0 failed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/330)
<!-- Reviewable:end -->
