### PR TITLE
[Feat] LFG group formation and teleport

### DIFF
--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -789,6 +789,23 @@ class ObjectMgr
         DungeonFinderRewardsMap const& GetDungeonFinderRewardsMap() const { return mDungeonFinderRewardsMap; }
         DungeonFinderItemsMap const& GetDungeonFinderItemsMap() const { return mDungeonFinderItemsMap; }
 
+        struct LfgDungeonEntrance
+        {
+            float x;
+            float y;
+            float z;
+            float o;
+        };
+        typedef std::unordered_map<uint32 /*dungeonId*/, LfgDungeonEntrance> LfgDungeonEntranceMap;
+
+        /// Entrance override for one LFGDungeons.dbc id; NULL = fall back to
+        /// GetMapEntranceTrigger (multi-wing maps only carry overrides).
+        LfgDungeonEntrance const* GetLfgDungeonEntrance(uint32 dungeonId) const
+        {
+            LfgDungeonEntranceMap::const_iterator itr = mLfgDungeonEntranceMap.find(dungeonId);
+            return itr != mLfgDungeonEntranceMap.end() ? &itr->second : NULL;
+        }
+
         // Static wrappers for various accessors
         static GameObjectInfo const* GetGameObjectInfo(uint32 id);                  ///< Wrapper for sGOStorage.LookupEntry
         static Player* GetPlayer(const char* name);                                 ///< Wrapper for sPlayerRegistry.FindByName
@@ -877,6 +894,7 @@ class ObjectMgr
         void LoadDungeonFinderRequirements();
         void LoadDungeonFinderRewards();
         void LoadDungeonFinderItems();
+        void LoadLfgDungeonEntrances();
 
         void LoadNPCSpellClickSpells();
         void LoadSpellTemplate();
@@ -1501,6 +1519,7 @@ class ObjectMgr
         DungeonFinderRequirementsMap mDungeonFinderRequirementsMap;
         DungeonFinderRewardsMap mDungeonFinderRewardsMap;
         DungeonFinderItemsMap mDungeonFinderItemsMap;
+        LfgDungeonEntranceMap mLfgDungeonEntranceMap;
 
         // character reserved names
         typedef std::set<std::wstring> ReservedNamesMap;

--- a/src/game/Object/ObjectMgrDungeonFinder.cpp
+++ b/src/game/Object/ObjectMgrDungeonFinder.cpp
@@ -269,3 +269,52 @@ void ObjectMgr::LoadDungeonFinderItems()
     sLog.outString();
     sLog.outString(">> Loaded %u Dungeon Finder Items", count);
 }
+
+void ObjectMgr::LoadLfgDungeonEntrances()
+{
+    uint32 count = 0;
+    mLfgDungeonEntranceMap.clear();    // in case of a reload
+
+    //                                                 0            1             2             3             4
+    QueryResult* result = WorldDatabase.Query("SELECT `dungeonId`, `position_x`, `position_y`, `position_z`, `orientation` FROM `lfg_dungeon_entrances`");
+
+    if (!result)
+    {
+        BarGoLink bar(1);
+        bar.step();
+        sLog.outString();
+        sLog.outString(">> Loaded 0 LFG dungeon entrance overrides. DB table `lfg_dungeon_entrances` is empty.");
+        return;
+    }
+
+    BarGoLink bar(result->GetRowCount());
+
+    do
+    {
+        Field* fields = result->Fetch();
+        bar.step();
+
+        uint32 dungeonId = fields[0].GetUInt32();
+        if (!sLfgDungeonsStore.LookupEntry(dungeonId))
+        {
+            sLog.outString();
+            sLog.outErrorDb("Table `lfg_dungeon_entrances` has a row for nonexistent dungeon %u, skipped.", dungeonId);
+            continue;
+        }
+
+        LfgDungeonEntrance entrance;
+        entrance.x = fields[1].GetFloat();
+        entrance.y = fields[2].GetFloat();
+        entrance.z = fields[3].GetFloat();
+        entrance.o = fields[4].GetFloat();
+        mLfgDungeonEntranceMap[dungeonId] = entrance;
+
+        ++count;
+    }
+    while (result->NextRow());
+
+    delete result;
+
+    sLog.outString();
+    sLog.outString(">> Loaded %u LFG dungeon entrance overrides", count);
+}

--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -158,6 +158,7 @@ DBCStorage <ItemSetEntry> sItemSetStore(ItemSetEntryfmt);
 DBCStorage <LfgDungeonsEntry> sLfgDungeonsStore(LfgDungeonsEntryfmt);
 LfgDungeonsByMapDifficultyMap sLfgDungeonsByMapDifficultyMap;
 LfgDungeonsByRandomIdMap sLfgDungeonsByRandomIdMap;
+DBCStorage <LfgDungeonsGroupingMapEntry> sLfgDungeonsGroupingMapStore(LfgDungeonsGroupingMapEntryfmt);
 DBCStorage <LiquidTypeEntry> sLiquidTypeStore(LiquidTypefmt);
 DBCStorage <LockEntry> sLockStore(LockEntryfmt);
 
@@ -531,7 +532,7 @@ void LoadDBCStores(const std::string& dataPath)
         exit(1);
     }
 
-    const uint32 DBCFilesCount = 129;
+    const uint32 DBCFilesCount = 130;
 
     BarGoLink bar(DBCFilesCount);
 
@@ -697,6 +698,7 @@ void LoadDBCStores(const std::string& dataPath)
                     LfgDungeonsByRandomIdMap::value_type(entry->Random_ID, entry));
             }
         }
+    LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLfgDungeonsGroupingMapStore, dbcPath, "LFGDungeonsGroupingmap.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLiquidTypeStore,          dbcPath, "LiquidType.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sLockStore,                dbcPath, "Lock.dbc");
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sMailTemplateStore,        dbcPath, "MailTemplate.dbc");

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -281,6 +281,7 @@ extern DBCStorage <ItemSetEntry>                 sItemSetStore;
 extern DBCStorage <LfgDungeonsEntry>             sLfgDungeonsStore;
 extern LfgDungeonsByMapDifficultyMap             sLfgDungeonsByMapDifficultyMap;
 extern LfgDungeonsByRandomIdMap                  sLfgDungeonsByRandomIdMap;
+extern DBCStorage <LfgDungeonsGroupingMapEntry>  sLfgDungeonsGroupingMapStore;
 extern DBCStorage <LiquidTypeEntry>              sLiquidTypeStore;
 extern DBCStorage <LockEntry>                    sLockStore;
 extern DBCStorage <MailTemplateEntry>            sMailTemplateStore;

--- a/src/game/Server/DBCStructure.h
+++ b/src/game/Server/DBCStructure.h
@@ -1309,6 +1309,17 @@ struct LfgDungeonsEntry
     uint32 Entry() const { return ID + ((uint8)typeID << 24); }
 };
 
+/// LFGDungeonsGroupingmap.dbc (build 15595): maps a random-dungeon bucket to
+/// member dungeons LFGDungeons.group_id cannot express (Random Hour of
+/// Twilight 434 -> 435/437/439). 6 records.
+struct LfgDungeonsGroupingMapEntry
+{
+    uint32    ID;                                           // 0
+    uint32    dungeonID;                                    // 1 LFGDungeons.dbc member row
+    uint32    randomID;                                     // 2 LFGDungeons.dbc random row (typeID 6)
+    uint32    groupID;                                      // 3 LFGDungeonGroup.dbc id
+};
+
 /*struct LfgDungeonGroupEntry
 {
     m_ID

--- a/src/game/Server/DBCfmt.h
+++ b/src/game/Server/DBCfmt.h
@@ -94,6 +94,7 @@ const char ItemRandomSuffixfmt[]="nsxiiiiiiiiii";
 const char ItemReforgefmt[]="nifif";
 const char ItemSetEntryfmt[]="dsxxxxxxxxxxxxxxxxxiiiiiiiiiiiiiiiiii";
 const char LfgDungeonsEntryfmt[] = "nsiiiiiiiiixxixixiiii";
+const char LfgDungeonsGroupingMapEntryfmt[] = "niii";
 const char LiquidTypefmt[] = "nxxixixxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const char LockEntryfmt[] = "niiiiiiiiiiiiiiiiiiiiiiiixxxxxxxx";
 const char MailTemplateEntryfmt[]="nxs";

--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -626,7 +626,7 @@ void InitializeOpcodes()
     OPCODE(CMSG_CHANGEPLAYER_DIFFICULTY,                 STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     OPCODE(SMSG_RWHOIS,                                  STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(SMSG_LFG_PLAYER_REWARD,                       STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(SMSG_LFG_TELEPORT_DENIED,                     STATUS_LOGGEDIN, PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_LFG_TELEPORT_DENIED,                     STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_UNLEARN_SPELL,                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     OPCODE(CMSG_UNLEARN_SKILL,                           STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleUnlearnSkillOpcode        );
     OPCODE(SMSG_REMOVED_SPELL,                           STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
@@ -1015,7 +1015,7 @@ void InitializeOpcodes()
     //OPCODE(CMSG_LFG_SET_BOOT_VOTE,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     //OPCODE(SMSG_LFG_BOOT_PROPOSAL_UPDATE,                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_LFG_PLAYER_INFO,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
-    //OPCODE(CMSG_LFG_TELEPORT,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
+    OPCODE(CMSG_LFG_TELEPORT,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgTeleportOpcode         );
     OPCODE(SMSG_LFG_PARTY_INFO,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_TITLE_EARNED,                            STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_SET_TITLE,                               STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSetTitleOpcode            );

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -65,6 +65,7 @@
 #include "Player.h"
 #include "ObjectMgr.h"
 #include "Group.h"
+#include "LFGMgr.h"
 #include "CinematicFlyover.h"
 #include "Guild.h"
 #include "GuildMgr.h"
@@ -710,11 +711,14 @@ void WorldSession::LogoutPlayer(bool Save)
         _player->CleanupChannels();
 #ifndef ENABLE_PLAYERBOTS
         ///- If the player is in a group (or invited), remove him. If the group if then only 1 person, disband the group.
+        bool const retainLfgGroup = sLFGMgr.OnPlayerLogout(_player);
         _player->UninviteFromGroup();
 
         // remove player from the group if he is:
         // a) in group; b) not in raid group; c) logging out normally (not being kicked or disconnected)
-        if (_player->GetGroup() && !_player->GetGroup()->isRaidGroup() && m_Socket)
+        // LFD groups keep their offline members (retail behavior).
+        if (!retainLfgGroup && _player->GetGroup() &&
+            !_player->GetGroup()->isRaidGroup() && m_Socket)
         {
             _player->RemoveFromGroup();
         }

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1019,6 +1019,7 @@ class WorldSession
         void HandleLfgSetRolesOpcode(WorldPacket& recv_data);
         void HandleLfgGetStatusOpcode(WorldPacket& recv_data);
         void HandleLfgProposalResultOpcode(WorldPacket& recv_data);
+        void HandleLfgTeleportOpcode(WorldPacket& recv_data);
         void HandleSetTitleOpcode(WorldPacket& recv_data);
         void HandleRealmSplitOpcode(WorldPacket& recv_data);
         void HandleTimeSyncResp(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -65,6 +65,7 @@
 #include "DynamicObject.h"                                  // raid markers are dynamic objects
 #include "SpellMgr.h"                                       // GetSpellDuration / GetSpellRadius
 #include "DBCStores.h"
+#include "LFGMgr.h"
 #include <atomic>
 
 #ifdef ENABLE_ELUNA
@@ -748,6 +749,8 @@ bool Group::AddMember(ObjectGuid guid, const char* name)
         return false;
     }
 
+    sLFGMgr.OnGroupMemberAdded(GetObjectGuid(), guid);
+
     SendUpdate();
 
     if (Player* player = sObjectMgr.GetPlayer(guid))
@@ -807,6 +810,12 @@ uint32 Group::RemoveMember(ObjectGuid guid, uint8 removeMethod)
     if (GetMembersCount() > uint32(isBGGroup() ? 1 : 2))    // in BG group case allow 1 members group
     {
         bool leaderChanged = _removeMember(guid);
+
+        sLFGMgr.OnGroupMemberRemoved(GetObjectGuid(), guid);
+        if (leaderChanged)
+        {
+            sLFGMgr.OnGroupLeaderChanged(GetObjectGuid(), m_memberSlots.front().guid);
+        }
 
         if (Player* player = sObjectMgr.GetPlayer(guid))
         {
@@ -889,6 +898,8 @@ void Group::ChangeLeader(ObjectGuid guid)
 
     _setLeader(guid);
 
+    sLFGMgr.OnGroupLeaderChanged(GetObjectGuid(), guid);
+
     WorldPacket data(SMSG_GROUP_SET_LEADER, slot->name.size() + 1);
     data << slot->name;
     BroadcastPacket(&data, true);
@@ -902,6 +913,8 @@ void Group::ChangeLeader(ObjectGuid guid)
  */
 void Group::Disband(bool hideDestroy)
 {
+    sLFGMgr.OnGroupDisband(GetObjectGuid());
+
     Player* player;
 
     // markers outlive the group otherwise -- they carry a 4h duration
@@ -1774,15 +1787,20 @@ void Group::SendUpdate()
         }
         // guess size
         WorldPacket data(SMSG_GROUP_LIST, (1 + 1 + 1 + 1 + 8 + 4 + GetMembersCount() * 20));
+        LFGGroupUpdateData lfgData;
+        if (m_groupType & GROUPTYPE_LFD)
+        {
+            sLFGMgr.GetGroupUpdateData(GetObjectGuid(), citr->guid, lfgData);
+        }
         data << uint8(m_groupType);                         // group type (flags in 3.3)
         data << uint8(citr->group);                         // groupid
         data << uint8(GetFlags(*citr));                     // group flags
         data << uint8(citr->roles);                         // your own assigned role
         if (m_groupType & GROUPTYPE_LFD)
         {
-            data << uint8(0);
-            data << uint32(0);
-            data << uint8(0);
+            data << uint8(lfgData.state);                   // MyLfgFlags; 2 = finished
+            data << uint32(lfgData.dungeonEntry);           // LfgSlot; concrete Entry()
+            data << uint8(0);                               // LfgAborted -- Phase 8
         }
         data << GetObjectGuid();                            // group guid
         data << uint32(sequence);                           // roster version; client drops anything it has already seen

--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -152,7 +152,7 @@ enum GroupType
     GROUPTYPE_BG     = 0x01,
     GROUPTYPE_RAID   = 0x02,
     GROUPTYPE_BGRAID = GROUPTYPE_BG | GROUPTYPE_RAID,       // mask
-    // 0x04?
+    GROUPTYPE_LFD_RESTRICTED = 0x04,                       ///< client: Lua_HasLFGRestrictions
     GROUPTYPE_LFD    = 0x08,
     // 0x10, leave/change group?, I saw this flag when leaving group and after leaving BG while in group
     GROUPTYPE_ONE_PERSON_PARTY   = 0x20,                   ///< client: Lua_IsOnePersonParty
@@ -382,7 +382,8 @@ class Group
         }
 
         // member manipulation methods
-        void SetAsLfgGroup() { m_groupType = GroupType(m_groupType | GROUPTYPE_LFD); }
+        /// Sets both bits: 0x08 carries the LFG block, 0x04 drives HasLFGRestrictions.
+        void SetAsLfgGroup() { m_groupType = GroupType(m_groupType | GROUPTYPE_LFD | GROUPTYPE_LFD_RESTRICTED); }
         bool IsMember(ObjectGuid guid) const
         {
             return _getMemberCSlot(guid) != m_memberSlots.end();

--- a/src/game/WorldHandlers/GroupHandler.cpp
+++ b/src/game/WorldHandlers/GroupHandler.cpp
@@ -528,6 +528,12 @@ void WorldSession::HandleLootMethodOpcode(WorldPacket& recv_data)
     {
         return;
     }
+
+    // A dungeon-finder group keeps the loot rules it was formed with.
+    if (group->isLFGGroup())
+    {
+        return;
+    }
     /********************/
 
     // everything is fine, do it
@@ -703,7 +709,9 @@ void WorldSession::HandleGroupRaidConvertOpcode(WorldPacket& recv_data)
         return;
     }
 
-    if (_player->InBattleGround())
+    // A dungeon-finder group cannot be converted; the client hides the option
+    // behind HasLFGRestrictions, but that is presentation, not enforcement.
+    if (_player->InBattleGround() || group->isLFGGroup())
     {
         return;
     }

--- a/src/game/WorldHandlers/LFGDungeonResolution.h
+++ b/src/game/WorldHandlers/LFGDungeonResolution.h
@@ -1,0 +1,122 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_LFGDUNGEONRESOLUTION_H
+#define MANGOS_LFGDUNGEONRESOLUTION_H
+
+/**
+ * @file LFGDungeonResolution.h
+ * @brief Expands a random-dungeon row (LFGDungeons.dbc typeID 6) into the
+ *        concrete dungeons it can resolve to, and picks one.
+ *
+ * The bucket rule is group_id union LFGDungeonsGroupingmap.dbc -- group_id
+ * alone cannot express Random Hour of Twilight 434 (LFD_PHASE7B_SPEC.md
+ * section 1.1 C2). LFGMgr::JoinLFG (LFGMgrQueue.cpp) expands at join time so
+ * the queue entry stores the pruned concrete set; SendDungeonProposal
+ * (LFGMgrProposal.cpp) draws from it at proposal time.
+ *
+ * Deliberately self-contained: only Platform/Define.h and the standard
+ * library. Same proto-boundary gate as LFGProposalLogic.h / LFGRoleAssignment.h
+ * -- src/tests/CMakeLists.txt only links `proto`/`shared` into mangos_tests.
+ */
+
+#include "Platform/Define.h"
+
+#include <set>
+#include <vector>
+
+namespace LFGDungeonResolution
+{
+    /// Numeric parity with LFGMgr.h's LfgType, kept in sync by hand -- this
+    /// header stays game-free (precedent: LFGProposalLogic.h).
+    enum
+    {
+        TYPE_DUNGEON        = 1,
+        TYPE_HEROIC_DUNGEON = 5,
+        TYPE_RANDOM_DUNGEON = 6
+    };
+
+    /// One LFGDungeons.dbc row, reduced to what expansion depends on.
+    struct DungeonRow
+    {
+        uint32 id = 0;
+        uint32 typeID = 0;
+        uint32 groupID = 0;
+    };
+
+    /// One LFGDungeonsGroupingmap.dbc row.
+    struct GroupingRow
+    {
+        uint32 dungeonID = 0;
+        uint32 randomID = 0;
+    };
+
+    /// Concrete candidates for one random row: every 5-man sharing its
+    /// group_id plus every grouping-map member -- the client's own bucket
+    /// definition (LFGDungeonGroup.dbc names the buckets).
+    inline void ExpandRandom(DungeonRow const& randomRow,
+                             std::vector<DungeonRow> const& dungeons,
+                             std::vector<GroupingRow> const& grouping,
+                             std::set<uint32>& out)
+    {
+        out.clear();
+        for (DungeonRow const& row : dungeons)
+        {
+            if (row.typeID != TYPE_DUNGEON && row.typeID != TYPE_HEROIC_DUNGEON)
+            {
+                continue;
+            }
+
+            if (row.groupID != 0 && row.groupID == randomRow.groupID)
+            {
+                out.insert(row.id);
+            }
+        }
+
+        for (GroupingRow const& row : grouping)
+        {
+            if (row.randomID == randomRow.id)
+            {
+                out.insert(row.dungeonID);
+            }
+        }
+    }
+
+    /// Uniform pick over a candidate set; rng is any random value (the
+    /// caller rolls it -- this stays deterministic and testable). 0 on empty.
+    inline uint32 Pick(std::set<uint32> const& candidates, uint32 rng)
+    {
+        if (candidates.empty())
+        {
+            return 0;
+        }
+
+        std::set<uint32>::const_iterator itr = candidates.begin();
+        std::advance(itr, size_t(rng % uint32(candidates.size())));
+        return *itr;
+    }
+}
+
+#endif

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -150,6 +150,19 @@ void WorldSession::HandleLfgProposalResultOpcode(WorldPacket& recv_data)
                            request.accepted);
 }
 
+void WorldSession::HandleLfgTeleportOpcode(WorldPacket& recv_data)
+{
+    LFGPackets::TeleportRequest request;
+    LFGPackets::ReadTeleport(recv_data, request);
+
+    DEBUG_FILTER_LOG(LOG_FILTER_LFG, "CMSG_LFG_TELEPORT out %u",
+        uint32(request.teleportOut));
+
+    // No LFG.Enable gate: without LFG no group status exists and the
+    // manager denies with INVALID_LOCATION on its own.
+    sLFGMgr.TeleportPlayer(GetPlayer(), request.teleportOut, false);
+}
+
 void WorldSession::HandleSearchLfgJoinOpcode(WorldPacket& recv_data)
 {
     DEBUG_LOG("CMSG_LFG_SEARCH_JOIN");
@@ -405,9 +418,8 @@ void WorldSession::SendLfgProposalUpdate(LFGPackets::ProposalUpdate const& propo
 
 void WorldSession::SendLfgTeleportError(uint8 error)
 {
-    DEBUG_LOG("SMSG_LFG_TELEPORT_DENIED");
     WorldPacket data(SMSG_LFG_TELEPORT_DENIED, 4);
-    data << uint32(error);
+    LFGPackets::BuildTeleportDenied(data, uint32(error));
     SendPacket(&data);
 }
 

--- a/src/game/WorldHandlers/LFGMgr.cpp
+++ b/src/game/WorldHandlers/LFGMgr.cpp
@@ -490,10 +490,14 @@ void LFGMgr::AddToQueue(ObjectGuid guid)
     // This will be necessary for finding matches in the queue
     UpdateNeededRoles(guid, information);
 
-    // put info into wait time maps for starters
+    // put info into wait time maps for starters, keyed by what each member
+    // SELECTED (the random entry for random queuers) -- wait stats answer
+    // "how long for Random Cataclysm Heroic", not per concrete dungeon.
     for (roleMap::iterator it = information->currentRoles.begin(); it != information->currentRoles.end(); ++it)
     {
-        AddToWaitMap(it->second, information->dungeonList);
+        LFGPlayerStatus const memberStatus = GetPlayerStatus(it->first);
+        AddToWaitMap(it->second, memberStatus.dungeonList.empty()
+                     ? information->dungeonList : memberStatus.dungeonList);
     }
 
     // just in case someone's already been in the queue.
@@ -753,7 +757,6 @@ void LFGMgr::SendQueueStatusFor(ObjectGuid guid)
     }
 
     time_t timeNow = time(NULL);
-    uint32 dungeonId = *queueInfo->dungeonList.begin();
 
     for (roleMap::iterator rItr = queueInfo->currentRoles.begin();
          rItr != queueInfo->currentRoles.end(); ++rItr)
@@ -764,8 +767,12 @@ void LFGMgr::SendQueueStatusFor(ObjectGuid guid)
             continue;
         }
 
+        LFGPlayerStatus const memberStatus = GetPlayerStatus(rItr->first);
+        uint32 dungeonId = memberStatus.dungeonList.empty()
+            ? *queueInfo->dungeonList.begin() : *memberStatus.dungeonList.begin();
+
         LFGPackets::QueueStatus status;
-        status.ticket = GetPlayerStatus(rItr->first).ticket;
+        status.ticket = memberStatus.ticket;
         status.slot = GetDungeonEntry(dungeonId);
         status.queuedTime = uint32(timeNow - queueInfo->joinedTime);
         status.lastNeeded[0] = queueInfo->neededTanks;
@@ -799,7 +806,7 @@ void LFGMgr::SendQueueStatusFor(ObjectGuid guid)
     }
 }
 
-uint32 LFGMgr::GetDungeonEntry(uint32 ID)
+uint32 LFGMgr::GetDungeonEntry(uint32 ID) const
 {
     LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(ID);
     if (dungeon)

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -360,6 +360,16 @@ struct LFGGroupStatus //todo: check for this in joinlfg function, not lfgplayers
         : state(State), dungeonID(DungeonID), playerRoles(PlayerRoles), leaderGuid(LeaderGuid) { }
 };
 
+/// The client-facing LFD fields appended to SMSG_GROUP_LIST for one member.
+struct LFGGroupUpdateData
+{
+    uint8 role;
+    uint8 state;
+    uint32 dungeonEntry;
+
+    LFGGroupUpdateData() : role(PLAYER_ROLE_NONE), state(0), dungeonEntry(0) { }
+};
+
 /// For SMSG_LFG_PROPOSAL_UPDATE
 struct LFGProposal
 {
@@ -550,10 +560,10 @@ public:
     std::vector<LFGLockedDungeon> GetPlayerLockList(Player* plr);
 
     /// Given the ID of a dungeon, spit out its entry
-    uint32 GetDungeonEntry(uint32 ID);
+    uint32 GetDungeonEntry(uint32 ID) const;
 
-    /// Teleports a player out of a dungeon (called by CMSG_LFG_TELEPORT)
-    void TeleportPlayer(Player* pPlayer, bool out);
+    /// Enter or leave the group's validated LFD dungeon.
+    bool TeleportPlayer(Player* pPlayer, bool out, bool automatic);
 
     /// Queue Functions Below
 
@@ -633,6 +643,18 @@ public:
     // Called when a player votes yes or no on a boot vote
     void CastVote(Player* pPlayer, bool vote);
 
+    /// Fetch the client-facing LFD fields appended to SMSG_GROUP_LIST.
+    bool GetGroupUpdateData(ObjectGuid groupGuid, ObjectGuid playerGuid,
+                            LFGGroupUpdateData& data) const;
+
+    /// Group lifecycle hooks used by the core group implementation.
+    void OnGroupMemberAdded(ObjectGuid groupGuid, ObjectGuid playerGuid);
+    void OnGroupMemberRemoved(ObjectGuid groupGuid, ObjectGuid playerGuid);
+    void OnGroupDisband(ObjectGuid groupGuid);
+    void OnGroupLeaderChanged(ObjectGuid groupGuid, ObjectGuid newLeaderGuid);
+    /// Returns true when logout must retain active LFD group membership.
+    bool OnPlayerLogout(Player* player);
+
 protected:
     bool IsSeasonal(uint32 dbcFlags) { return ((dbcFlags & LFG_FLAG_SEASONAL) != 0) ? true : false; }
 
@@ -669,17 +691,21 @@ protected:
     /// Expire proposals older than LFG_TIME_PROPOSAL.
     void RemoveOldProposals();
 
+    /// True while a succeeded proposal is still moving this guid's players
+    /// between groups -- lifecycle hooks must not react to those moves.
+    bool IsSuccessfulProposalMove(ObjectGuid guid) const;
+
+    /// Drop one queue entry: notify its members, wipe their statuses.
+    void CancelQueueEntry(ObjectGuid unitGuid, LfgUpdateType reason);
+
     /// Build and send one member's view of a proposal.
     void SendProposalUpdateToPlayer(ObjectGuid plrGuid, LFGProposal const& proposal);
 
     /// Updates a wait map with the amount of time it took the last player to join
     void UpdateWaitMap(LFGRoles role, uint32 dungeonID, time_t waitTime);
 
-    /// Creates a group so they can enter a dungeon together
-    void CreateDungeonGroup(LFGProposal* proposal);
-
-    /// Sends a group to the dungeon assigned to them
-    void TeleportToDungeon(uint32 dungeonID, Group* pGroup);
+    /// Forms the LFD group for a succeeded proposal; false = caller unwinds.
+    bool CreateDungeonGroup(LFGProposal* proposal);
 
     /**
      * @brief Merges two players/groups/etc into one for dungeon assignment.

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -32,12 +32,14 @@
 #include "Group.h"
 #include "LFGMgr.h"
 #include "LFGProposalLogic.h"
+#include "LFGDungeonResolution.h"
 #include "Log.h"
 #include "Object.h"
 #include "Player.h"
 #include "PlayerRegistry.h"
 #include "ObjectMgr.h"
 #include "SharedDefines.h"
+#include "Util.h"
 #include "WorldSession.h"
 
 /**
@@ -231,7 +233,11 @@ void LFGMgr::SendDungeonProposal(ObjectGuid queueGuid, LFGPlayers* lfgGroup)
 
     LFGProposal proposal;
     proposal.id = m_proposalId;
-    proposal.dungeonID = *lfgGroup->dungeonList.begin();
+    // The entry's dungeonList is already the pruned concrete candidate set
+    // (JoinLFG expanded randoms at join; merges intersected) -- every member
+    // can enter whichever one we draw. Uniform pick, TC parity.
+    proposal.dungeonID = LFGDungeonResolution::Pick(lfgGroup->dungeonList,
+        urand(0, uint32(lfgGroup->dungeonList.size() - 1)));
     proposal.joinedQueue = lfgGroup->joinedTime;
     proposal.cancelTime = time(NULL) + LFG_TIME_PROPOSAL;
     proposal.queueEntryGuid = queueGuid;
@@ -434,8 +440,9 @@ void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted
         return;
     }
 
-    // Success: state 2, TC packet sequence, then wipe -- 7b replaces the
-    // wipe with group formation + teleport (CreateDungeonGroup).
+    // Success: state 2, rebroadcast, then FORM THE GROUP before any
+    // UPDATE_STATUS -- the client only hides the ready popup on
+    // GROUP_FOUND when it is already in a party (spec C6 / 7a C2).
     bool sendUpdate = proposal.state != LFG_PROPOSAL_SUCCESS;
     proposal.state = LFG_PROPOSAL_SUCCESS;
     time_t now = time(NULL);
@@ -443,33 +450,45 @@ void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted
     for (roleMap::const_iterator itr = proposal.currentRoles.begin();
          itr != proposal.currentRoles.end(); ++itr)
     {
-        ObjectGuid memberGuid = itr->first;
-        uint8 role = itr->second;
-        role &= ~PLAYER_ROLE_LEADER;
-
         if (sendUpdate)
         {
-            SendProposalUpdateToPlayer(memberGuid, proposal);
+            SendProposalUpdateToPlayer(itr->first, proposal);
         }
-
-        UpdateWaitMap(LFGRoles(role), proposal.dungeonID,
-                      time_t(now - proposal.joinedQueue));
-
-        bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
-        LFGPlayerStatus status = GetPlayerStatus(memberGuid);
-        status.updateType = LFG_UPDATE_GROUP_FOUND;
-        SendLfgUpdate(memberGuid, status, isParty);
     }
 
-    sLog.outString("LFGMgr: proposal %u succeeded for dungeon %u -- "
-                   "group formation lands in Phase 7b", proposal.id,
-                   proposal.dungeonID);
+    if (!CreateDungeonGroup(&proposal))
+    {
+        // Formation failed (someone vanished / group calls failed):
+        // everyone agreed, so RemoveProposal re-queues all of them.
+        sLog.outString("LFGMgr: proposal %u group formation FAILED, re-queueing",
+                       proposal.id);
+        RemoveProposal(proposalID, LFG_UPDATE_PROPOSAL_FAILED);
+        return;
+    }
 
     for (roleMap::const_iterator itr = proposal.currentRoles.begin();
          itr != proposal.currentRoles.end(); ++itr)
     {
-        m_playerStatusMap.erase(itr->first);
+        ObjectGuid memberGuid = itr->first;
+
+        roleMap::const_iterator seatItr = proposal.assignedRoles.find(memberGuid);
+        uint8 role = (seatItr != proposal.assignedRoles.end())
+            ? seatItr->second : itr->second;
+        role &= ~PLAYER_ROLE_LEADER;
+
+        LFGPlayerStatus status = GetPlayerStatus(memberGuid);
+        uint32 waitKey = status.dungeonList.empty()
+            ? proposal.dungeonID : *status.dungeonList.begin();
+        UpdateWaitMap(LFGRoles(role), waitKey,
+                      time_t(now - proposal.joinedQueue));
+
+        bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
+        status.updateType = LFG_UPDATE_GROUP_FOUND;
+        SendLfgUpdate(memberGuid, status, isParty);
     }
+
+    sLog.outString("LFGMgr: proposal %u formed an LFD group for dungeon %u",
+                   proposal.id, proposal.dungeonID);
 
     m_playerData.erase(proposal.queueEntryGuid);
     m_proposalMap.erase(itProposal);
@@ -487,184 +506,280 @@ bool LFGMgr::HasLeaderFlag(roleMap const& roles)
     return false;
 }
 
-void LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
+//todo(7c): offer-continue formation (proposal->groupRawGuid != 0)
+bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
 {
-    if (!proposal)
+    if (!proposal || proposal->currentRoles.empty() ||
+        proposal->currentRoles.size() > NORMAL_TOTAL_ROLE_COUNT)
     {
-        return;
+        return false;
     }
 
-    Group* pGroup = nullptr;
-
-    if (!proposal->groupRawGuid)
-    {
-        bool leaderIsSet = false;
-        bool leaderRoleIsSet = HasLeaderFlag(proposal->currentRoles);
-        ObjectGuid leaderGuid;
-
-        pGroup = new Group();
-
-        for (playerGroupMap::iterator it = proposal->groups.begin(); it != proposal->groups.end(); ++it)
-        {
-            // remove plr from group w/ guid it->second
-            // set leader on first loop, then set leaderisset to true
-            ObjectGuid pGroupPlrGuid = it->first;
-            Player* pGroupPlr = sPlayerRegistry.Find(pGroupPlrGuid);
-
-            if (pGroupPlr && it->second)
-            {
-                Group* existingGroup = pGroupPlr->GetGroup();
-                if (existingGroup)
-                {
-                    existingGroup->RemoveMember(pGroupPlrGuid, 0);
-                }
-            }
-
-            if (pGroupPlr && !leaderIsSet)
-            {
-                bool currentPlrIsLeader = false;
-                if (leaderRoleIsSet)
-                {
-                    for (roleMap::iterator itr = proposal->currentRoles.begin(); itr != proposal->currentRoles.end(); ++itr)
-                    {
-                        if (itr->second & PLAYER_ROLE_LEADER)
-                        {
-                            leaderGuid = itr->first;
-                            Player* leaderRef = sPlayerRegistry.Find(leaderGuid);
-
-                            if (leaderRef)
-                            {
-                                pGroup->Create(leaderRef->GetObjectGuid(), leaderRef->GetName());
-                                currentPlrIsLeader = (pGroupPlrGuid == leaderGuid);
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    pGroup->Create(pGroupPlrGuid, pGroupPlr->GetName());
-                }
-
-                if (!currentPlrIsLeader)
-                {
-                    pGroup->AddMember(pGroupPlrGuid, pGroupPlr->GetName());
-                }
-
-                leaderIsSet = true;
-            }
-            else if (leaderIsSet && pGroupPlr && pGroupPlrGuid != leaderGuid)
-            {
-                pGroup->AddMember(pGroupPlrGuid, pGroupPlr->GetName());
-            }
-        }
-        pGroup->SetAsLfgGroup();
-    }
-    else
-    {
-        Player* pGroupLeader = sPlayerRegistry.Find(ObjectGuid(proposal->groupLeaderGuid));
-
-        // Check if the group leader was found before accessing their group
-        if (pGroupLeader)
-        {
-            pGroup = pGroupLeader->GetGroup();
-        }
-        else
-        {
-            // Log that the group leader is missing and fall back to creating a new group
-            // In the future, we should determine the right actions for this scenario.
-            // LOG_ERROR("LFGMgr::CreateDungeonGroup", "Group leader with GUID %u not found. Creating new group.", proposal->groupLeaderGuid);
-
-            // Attempt to create a new group using the first available player in the proposal group
-            if (!proposal->groups.empty())
-            {
-                ObjectGuid fallbackLeaderGuid = proposal->groups.begin()->first;
-                Player* fallbackLeader = sPlayerRegistry.Find(fallbackLeaderGuid);
-
-                if (fallbackLeader)
-                {
-                    pGroup = new Group();
-                    pGroup->Create(fallbackLeader->GetObjectGuid(), fallbackLeader->GetName());
-                    pGroup->SetAsLfgGroup();
-
-                    // Add remaining members to the new group
-                    for (playerGroupMap::iterator it = proposal->groups.begin(); it != proposal->groups.end(); ++it)
-                    {
-                        ObjectGuid pGroupPlrGuid = it->first;
-                        if (pGroupPlrGuid != fallbackLeaderGuid)
-                        {
-                            Player* pGroupPlr = sPlayerRegistry.Find(pGroupPlrGuid);
-                            if (pGroupPlr)
-                            {
-                                pGroup->AddMember(pGroupPlrGuid, pGroupPlr->GetName());
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    // If no valid players are found, we return without proceeding
-                    // In the future, we should determine the right actions for this scenario.
-                    // LOG_ERROR("LFGMgr::CreateDungeonGroup", "No valid players found to create a fallback group.");
-                    return;
-                }
-            }
-            else
-            {
-                // Log if there are no players in the proposal groups map
-                // In the future, we should determine the right actions for this scenario.
-                // LOG_ERROR("LFGMgr::CreateDungeonGroup", "Proposal groups map is empty, cannot create fallback group.");
-                return;
-            }
-        }
-    }
-
-    // Set dungeon difficulty for group
     LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(proposal->dungeonID);
-    if (!dungeon || !pGroup)
+    MapEntry const* map = (dungeon && dungeon->mapID > 0)
+        ? sMapStore.LookupEntry(uint32(dungeon->mapID)) : NULL;
+    if (!dungeon || !map || !map->IsNonRaidDungeon() ||
+        (dungeon->typeID != LFG_TYPE_DUNGEON && dungeon->typeID != LFG_TYPE_HEROIC_DUNGEON))
     {
-        return;
+        return false;
     }
 
+    // Everyone must still be online; an offline member is the timeout's job.
+    for (roleMap::const_iterator itr = proposal->currentRoles.begin();
+         itr != proposal->currentRoles.end(); ++itr)
+    {
+        if (!sPlayerRegistry.Find(itr->first))
+        {
+            return false;
+        }
+    }
+
+    // Leader: the seat that carries the leader bit; lowest guid otherwise.
+    ObjectGuid leaderGuid;
+    for (roleMap::const_iterator itr = proposal->assignedRoles.begin();
+         itr != proposal->assignedRoles.end(); ++itr)
+    {
+        if (itr->second & PLAYER_ROLE_LEADER)
+        {
+            leaderGuid = itr->first;
+            break;
+        }
+
+        if (leaderGuid.IsEmpty() || itr->first < leaderGuid)
+        {
+            leaderGuid = itr->first;
+        }
+    }
+
+    Player* pLeader = sPlayerRegistry.Find(leaderGuid);
+    if (!pLeader)
+    {
+        return false;
+    }
+
+    // From here on, lifecycle hooks fired by the removes/adds below must
+    // not react -- IsSuccessfulProposalMove covers this proposal's guids.
+    if (Group* pOldGroup = pLeader->GetGroup())
+    {
+        if (pOldGroup->RemoveMember(leaderGuid, 0) <= 1)
+        {
+            sObjectMgr.RemoveGroup(pOldGroup);
+            delete pOldGroup;
+        }
+    }
+
+    Group* pGroup = new Group();
+    if (!pGroup->Create(leaderGuid, pLeader->GetName()))
+    {
+        delete pGroup;
+        return false;
+    }
+    sObjectMgr.AddGroup(pGroup);
+
+    for (roleMap::const_iterator itr = proposal->currentRoles.begin();
+         itr != proposal->currentRoles.end(); ++itr)
+    {
+        ObjectGuid memberGuid = itr->first;
+        if (memberGuid == leaderGuid || pGroup->IsMember(memberGuid))
+        {
+            continue;
+        }
+
+        Player* pMember = sPlayerRegistry.Find(memberGuid);
+        if (Group* pOldGroup = pMember->GetGroup())
+        {
+            if (pOldGroup->RemoveMember(memberGuid, 0) <= 1)
+            {
+                sObjectMgr.RemoveGroup(pOldGroup);
+                delete pOldGroup;
+            }
+        }
+
+        if (!pGroup->AddMember(memberGuid, pMember->GetName()))
+        {
+            pGroup->Disband(true);
+            sObjectMgr.RemoveGroup(pGroup);
+            delete pGroup;
+            return false;
+        }
+    }
+
+    // Seat everyone (leader bit kept -- the client draws the crown/roles
+    // from these bytes in SMSG_GROUP_LIST), then flag and configure.
+    for (roleMap::const_iterator itr = proposal->assignedRoles.begin();
+         itr != proposal->assignedRoles.end(); ++itr)
+    {
+        pGroup->SetLfgRoles(itr->first, itr->second);
+    }
+
+    pGroup->SetAsLfgGroup();
     pGroup->SetDungeonDifficulty(Difficulty(dungeon->difficulty));
 
-    // Add group to our group set and group map, then teleport to the dungeon
     ObjectGuid groupGuid = pGroup->GetObjectGuid();
-    LFGGroupStatus groupStatus(LFG_STATE_IN_DUNGEON, dungeon->ID, proposal->currentRoles, pGroup->GetLeaderGuid());
-
+    LFGGroupStatus groupStatus(LFG_STATE_IN_DUNGEON, dungeon->ID,
+                               proposal->assignedRoles, pGroup->GetLeaderGuid());
     m_groupSet.insert(groupGuid);
     m_groupStatusMap[groupGuid] = groupStatus;
-    TeleportToDungeon(dungeon->ID, pGroup);
 
+    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
+    {
+        if (Player* pGroupPlr = itr->getSource())
+        {
+            TeleportPlayer(pGroupPlr, false, true);
+        }
+    }
+
+    // Final roster broadcast now carries the filled LFG block (state /
+    // concrete dungeon entry / aborted) -- and precedes GROUP_FOUND.
     pGroup->SendUpdate();
+    return true;
 }
 
-void LFGMgr::TeleportToDungeon(uint32 dungeonID, Group* pGroup)
+bool LFGMgr::TeleportPlayer(Player* pPlayer, bool out, bool automatic)
 {
-    // if the group's leader is already in the dungeon, teleport anyone not in dungeon to them
-    // if nobody is in the dungeon, teleport all to beginning of dungeon (sObjectMgr.GetMapEntranceTrigger(mapid [not dungeonid]))
-    LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(dungeonID);
-    if (!dungeon || !pGroup)
+    if (!pPlayer)
     {
-        return;
+        return false;
     }
 
-    uint32 mapID = (uint32)dungeon->mapID;
-    float x, y, z, o;
+    Group* pGroup = pPlayer->GetGroup();
+    LFGGroupStatus* status = pGroup ? GetGroupStatus(pGroup->GetObjectGuid()) : NULL;
+    LfgDungeonsEntry const* dungeon = status
+        ? sLfgDungeonsStore.LookupEntry(status->dungeonID) : NULL;
+    if (!dungeon || dungeon->mapID <= 0)
+    {
+        pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+        return false;
+    }
+
+    uint32 mapID = uint32(dungeon->mapID);
+
+    if (out)
+    {
+        if (pPlayer->GetMapId() != mapID)
+        {
+            pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+            return false;
+        }
+
+        // A never-stored entry point is the zero location -- teleporting
+        // there would drop the player into the map-0 ocean (spec C10).
+        WorldLocation const& entryPoint = pPlayer->GetBattleGroundEntryPoint();
+        if (entryPoint.mapid == 0 && entryPoint.coord_x == 0.0f &&
+            entryPoint.coord_y == 0.0f && entryPoint.coord_z == 0.0f)
+        {
+            pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+            return false;
+        }
+
+        if (!pPlayer->TeleportToBGEntryPoint())
+        {
+            pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+            return false;
+        }
+
+        return true;
+    }
+
+    if (pPlayer->GetMapId() == mapID)
+    {
+        return true;                     // already inside
+    }
+
     LFGTeleportError err = LFG_TELEPORTERROR_OK;
-
-    Player* pGroupLeader = sPlayerRegistry.Find(pGroup->GetLeaderGuid());
-
-    if (pGroupLeader && pGroupLeader->GetMapId() == mapID) // Already in the dungeon
+    if (pPlayer->IsDead())
     {
-        // set teleport location to that of the group leader
-        x = pGroupLeader->Where().X();
-        y = pGroupLeader->Where().Y();
-        z = pGroupLeader->Where().Z();
-        o = pGroupLeader->Where().Facing();
+        err = LFG_TELEPORTERROR_PLAYER_DEAD;
     }
-    else
+    else if (pPlayer->IsFalling())
     {
-        if (AreaTrigger const* at = sObjectMgr.GetMapEntranceTrigger(mapID))
+        err = LFG_TELEPORTERROR_FALLING;
+    }
+    else if (pPlayer->GetVehicleInfo())
+    {
+        err = LFG_TELEPORTERROR_IN_VEHICLE;
+    }
+    else if (!pPlayer->GetCharmerGuid().IsEmpty())
+    {
+        err = LFG_TELEPORTERROR_CHARMING;
+    }
+    else if (pPlayer->IsInCombat() || pPlayer->IsTaxiFlying())
+    {
+        err = LFG_TELEPORTERROR_INVALID_LOCATION;
+    }
+
+    if (err == LFG_TELEPORTERROR_OK)
+    {
+        dungeonForbidden const lockedDungeons = FindRandomDungeonsNotForPlayer(pPlayer);
+        if (lockedDungeons.find(dungeon->Entry()) != lockedDungeons.end())
+        {
+            err = LFG_TELEPORTERROR_INVALID_LOCATION;
+        }
+    }
+
+    if (err == LFG_TELEPORTERROR_OK)
+    {
+        Map* pCurrentMap = pPlayer->GetMap();
+        if (!pCurrentMap || pCurrentMap->IsDungeon() || pCurrentMap->IsRaid() ||
+            pPlayer->InBattleGround())
+        {
+            err = LFG_TELEPORTERROR_INVALID_LOCATION;
+        }
+    }
+
+    if (err != LFG_TELEPORTERROR_OK)
+    {
+        pPlayer->GetSession()->SendLfgTeleportError(uint8(err));
+        return false;
+    }
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float o = 0.0f;
+    bool destinationFound = false;
+
+    // Formation-time: land beside a member who is already inside.
+    if (automatic)
+    {
+        Player* pInside = sPlayerRegistry.Find(pGroup->GetLeaderGuid());
+        if (!pInside || pInside == pPlayer || pInside->GetMapId() != mapID)
+        {
+            pInside = NULL;
+            for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
+            {
+                Player* pMember = itr->getSource();
+                if (pMember && pMember != pPlayer && pMember->GetMapId() == mapID)
+                {
+                    pInside = pMember;
+                    break;
+                }
+            }
+        }
+
+        if (pInside)
+        {
+            x = pInside->Where().X();
+            y = pInside->Where().Y();
+            z = pInside->Where().Z();
+            o = pInside->Where().Facing();
+            destinationFound = true;
+        }
+    }
+
+    if (!destinationFound)
+    {
+        // Multi-wing override first (lfg_dungeon_entrances), then the
+        // generic map entrance areatrigger.
+        if (ObjectMgr::LfgDungeonEntrance const* entrance =
+            sObjectMgr.GetLfgDungeonEntrance(status->dungeonID))
+        {
+            x = entrance->x;
+            y = entrance->y;
+            z = entrance->z;
+            o = entrance->o;
+        }
+        else if (AreaTrigger const* at = sObjectMgr.GetMapEntranceTrigger(mapID))
         {
             x = at->target_X;
             y = at->target_Y;
@@ -673,92 +788,50 @@ void LFGMgr::TeleportToDungeon(uint32 dungeonID, Group* pGroup)
         }
         else
         {
-            err = LFG_TELEPORTERROR_INVALID_LOCATION;
+            pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+            return false;
         }
     }
 
-    dungeonForbidden lockedDungeons;
-    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
+    pPlayer->SetBattleGroundEntryPoint();    // current map is validated outdoor
+
+    if (!pPlayer->TeleportTo(mapID, x, y, z, o))
     {
-        if (Player* pGroupPlr = itr->getSource())
-        {
-            // further checks: player is dead, in vehicle, in battleground, on taxi, etc
-            LFGTeleportError plrErr = LFG_TELEPORTERROR_OK;
-
-            if (pGroupPlr->IsDead())
-            {
-                plrErr = LFG_TELEPORTERROR_PLAYER_DEAD;
-            }
-            if (pGroupPlr->IsFalling())
-            {
-                plrErr = LFG_TELEPORTERROR_FALLING;
-            }
-            if (pGroupPlr->GetVehicleInfo())
-            {
-                plrErr = LFG_TELEPORTERROR_IN_VEHICLE;
-            }
-
-            lockedDungeons = FindRandomDungeonsNotForPlayer(pGroupPlr);
-            if (lockedDungeons.find(dungeon->Entry()) != lockedDungeons.end())
-            {
-                plrErr = LFG_TELEPORTERROR_INVALID_LOCATION;
-            }
-
-            if (err == LFG_TELEPORTERROR_OK && plrErr == LFG_TELEPORTERROR_OK && pGroupPlr->GetMapId() != mapID)
-            {
-                if (pGroupPlr->GetMap() && !pGroupPlr->GetMap()->IsDungeon() && !pGroupPlr->GetMap()->IsRaid() && !pGroupPlr->InBattleGround())
-                {
-                    pGroupPlr->SetBattleGroundEntryPoint(); // store current position and such
-                }
-
-                if (!pGroupPlr->TeleportTo(mapID, x, y, z, o))
-                {
-                    plrErr = LFG_TELEPORTERROR_INVALID_LOCATION;
-                }
-            }
-
-            if (err != LFG_TELEPORTERROR_OK)
-            {
-                pGroupPlr->GetSession()->SendLfgTeleportError(err);
-            }
-            else if (plrErr != LFG_TELEPORTERROR_OK)
-            {
-                pGroupPlr->GetSession()->SendLfgTeleportError(plrErr);
-            }
-            else
-            {
-                SetPlayerState(pGroupPlr->GetObjectGuid(), LFG_STATE_IN_DUNGEON);
-            }
-        }
+        pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
+        return false;
     }
+
+    SetPlayerState(pPlayer->GetObjectGuid(), LFG_STATE_IN_DUNGEON);
+    return true;
 }
 
-void LFGMgr::TeleportPlayer(Player* pPlayer, bool out)
+bool LFGMgr::IsSuccessfulProposalMove(ObjectGuid guid) const
 {
-    // Fetch necessary data first
-    Group* pGroup = pPlayer->GetGroup();
-    if (!pGroup)
+    for (proposalMap::const_iterator itr = m_proposalMap.begin();
+         itr != m_proposalMap.end(); ++itr)
     {
-        pPlayer->GetSession()->SendLfgTeleportError((uint8)LFG_TELEPORTERROR_INVALID_LOCATION);
-        return;
-    }
-
-    LFGGroupStatus* status = GetGroupStatus(pGroup->GetObjectGuid());
-    if (!status)
-    {
-        pPlayer->GetSession()->SendLfgTeleportError((uint8)LFG_TELEPORTERROR_INVALID_LOCATION);
-        return;
-    }
-
-    // Get dungeon info and then teleport the player out if applicable
-    if (out)
-    {
-        LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(status->dungeonID);
-        if (dungeon && pPlayer->GetMapId() == dungeon->mapID)
+        LFGProposal const& proposal = itr->second;
+        if (proposal.state != LFG_PROPOSAL_SUCCESS)
         {
-            pPlayer->TeleportToBGEntryPoint();
+            continue;
+        }
+
+        if (proposal.queueEntryGuid == guid)
+        {
+            return true;
+        }
+
+        for (playerGroupMap::const_iterator grpItr = proposal.groups.begin();
+             grpItr != proposal.groups.end(); ++grpItr)
+        {
+            if (grpItr->first == guid || grpItr->second == guid)
+            {
+                return true;
+            }
         }
     }
+
+    return false;
 }
 
 LFGGroupStatus* LFGMgr::GetGroupStatus(ObjectGuid guid)
@@ -772,6 +845,26 @@ LFGGroupStatus* LFGMgr::GetGroupStatus(ObjectGuid guid)
     {
         return NULL;
     }
+}
+
+bool LFGMgr::GetGroupUpdateData(ObjectGuid groupGuid, ObjectGuid playerGuid,
+                                LFGGroupUpdateData& data) const
+{
+    groupStatusMap::const_iterator itr = m_groupStatusMap.find(groupGuid);
+    if (itr == m_groupStatusMap.end())
+    {
+        return false;                    // caller keeps the value-initialized zeros
+    }
+
+    LFGGroupStatus const& status = itr->second;
+
+    roleMap::const_iterator roleItr = status.playerRoles.find(playerGuid);
+    data.role = (roleItr != status.playerRoles.end()) ? roleItr->second : uint8(PLAYER_ROLE_NONE);
+    // MyLfgFlags: 2 = dungeon finished (kills the client's backfill offer);
+    // the concrete dungeon's Entry() drives IsPartyLFG/IsInLFGDungeon (C7).
+    data.state = uint8((status.state == LFG_STATE_FINISHED_DUNGEON) ? 2 : 0);
+    data.dungeonEntry = GetDungeonEntry(status.dungeonID);
+    return true;
 }
 
 void LFGMgr::RemoveProposal(uint32 proposalId, LfgUpdateType type)
@@ -914,6 +1007,11 @@ bool LFGMgr::FailProposalForLeaver(ObjectGuid plrGuid)
         if (itAnswer == itr->second.answers.end())
         {
             continue;
+        }
+
+        if (itr->second.state != LFG_PROPOSAL_INITIATING)
+        {
+            return false;                // success is being formed; boots come later
         }
 
         itAnswer->second = LFG_ANSWER_DENY;

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -621,6 +621,15 @@ bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
     m_groupSet.insert(groupGuid);
     m_groupStatusMap[groupGuid] = groupStatus;
 
+    // Roster broadcast carrying the filled LFG block (state / concrete dungeon
+    // entry / aborted) -- and preceding GROUP_FOUND. This has to go out BEFORE
+    // the teleport: a far teleport is deferred behind the world-port ack, so a
+    // group list sent afterwards reaches the client mid-loading-screen and the
+    // last roster it actually applied stays the pre-SetAsLfgGroup one from
+    // AddMember -- leader crown instead of the guide, and raid conversion still
+    // offered.
+    pGroup->SendUpdate();
+
     for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
     {
         if (Player* pGroupPlr = itr->getSource())
@@ -629,9 +638,6 @@ bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
         }
     }
 
-    // Final roster broadcast now carries the filled LFG block (state /
-    // concrete dungeon entry / aborted) -- and precedes GROUP_FOUND.
-    pGroup->SendUpdate();
     return true;
 }
 

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -32,8 +32,10 @@
 #include "GameEventMgr.h"
 #include "Group.h"
 #include "LFGMgr.h"
+#include "LFGDungeonResolution.h"
 #include "Object.h"
 #include "Player.h"
+#include "PlayerRegistry.h"
 #include "ObjectMgr.h"
 #include "SharedDefines.h"
 #include "WorldSession.h"
@@ -142,24 +144,48 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
     // since our join result may have just changed, check it again
     if (result == ERR_LFG_OK && isRandom)
     {
-        // fetch all dungeons with our groupID and add to set
-        LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(randomDungeonID);
-
-        if (dungeon)
+        LfgDungeonsEntry const* randomDungeon = sLfgDungeonsStore.LookupEntry(randomDungeonID);
+        if (randomDungeon)
         {
-            uint32 group = dungeon->group_id;
-
+            // The client's own bucket definition: group_id plus the
+            // grouping-map rows (Random Hour of Twilight has ONLY the
+            // latter -- LFD_PHASE7B_SPEC.md section 1.1 C2).
+            std::vector<LFGDungeonResolution::DungeonRow> dungeonRows;
             for (uint32 id = 0; id < sLfgDungeonsStore.GetNumRows(); ++id)
             {
-                LfgDungeonsEntry const* dungeonList = sLfgDungeonsStore.LookupEntry(id);
-                if (dungeonList && dungeonList->group_id == group &&
-                    dungeonList->typeID != LFG_TYPE_RANDOM_DUNGEON)
+                if (LfgDungeonsEntry const* row = sLfgDungeonsStore.LookupEntry(id))
                 {
-                    dungeons.insert(dungeonList->ID); // adding to set
+                    LFGDungeonResolution::DungeonRow reduced;
+                    reduced.id = row->ID;
+                    reduced.typeID = row->typeID;
+                    reduced.groupID = row->group_id;
+                    dungeonRows.push_back(reduced);
                 }
             }
+
+            std::vector<LFGDungeonResolution::GroupingRow> groupingRows;
+            for (uint32 id = 0; id < sLfgDungeonsGroupingMapStore.GetNumRows(); ++id)
+            {
+                if (LfgDungeonsGroupingMapEntry const* row = sLfgDungeonsGroupingMapStore.LookupEntry(id))
+                {
+                    LFGDungeonResolution::GroupingRow reduced;
+                    reduced.dungeonID = row->dungeonID;
+                    reduced.randomID = row->randomID;
+                    groupingRows.push_back(reduced);
+                }
+            }
+
+            LFGDungeonResolution::DungeonRow randomRow;
+            randomRow.id = randomDungeon->ID;
+            randomRow.typeID = randomDungeon->typeID;
+            randomRow.groupID = randomDungeon->group_id;
+
+            // dungeons becomes the CONCRETE candidate set; the random row
+            // itself no longer rides along (old code left it in).
+            LFGDungeonResolution::ExpandRandom(randomRow, dungeonRows, groupingRows, dungeons);
         }
-        else
+
+        if (!randomDungeon || dungeons.empty())
         {
             result = ERR_LFG_INTERNAL_ERROR;
         }
@@ -243,6 +269,16 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
     ticket.type = RIDE_TYPE_LFG;
     ticket.time = int32(time(NULL));
 
+    // dungeons is now the pruned CONCRETE set the queue matches on; the
+    // client-facing selection (statuses, role check display) stays the
+    // random entry the player actually clicked.
+    std::set<uint32> displayDungeons = dungeons;
+    if (isRandom)
+    {
+        displayDungeons.clear();
+        displayDungeons.insert(randomDungeonID);
+    }
+
     if (pGroup)
     {
         LFGRoleCheck roleCheck;
@@ -251,14 +287,6 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
         roleCheck.randomDungeonID = randomDungeonID;
         roleCheck.leaderGuidRaw = pGroup->GetLeaderGuid().GetRawValue();
         roleCheck.waitForRoleTime = time_t(time(NULL) + LFG_TIME_ROLECHECK);
-
-        // place original dungeon ID back in the set -- dungeons is now the
-        // DISPLAY set (what gets shown/sent), roleCheck keeps the expanded one
-        if (isRandom)
-        {
-            dungeons.clear();
-            dungeons.insert(randomDungeonID);
-        }
 
         // populate every member's role slot BEFORE the role check is stored,
         // otherwise PerformRoleCheck sees a lone (leader) entry and finishes
@@ -279,7 +307,7 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
             {
                 ObjectGuid plrGuid = pGroupPlr->GetObjectGuid();
 
-                LFGPlayerStatus overallStatus(LFG_STATE_ROLECHECK, LFG_UPDATE_JOIN, dungeons, comments);
+                LFGPlayerStatus overallStatus(LFG_STATE_ROLECHECK, LFG_UPDATE_JOIN, displayDungeons, comments);
                 overallStatus.ticket = ticket;
                 m_playerStatusMap[plrGuid] = overallStatus;
 
@@ -295,13 +323,6 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
     }
     else
     {
-        // place original dungeon ID back in the set
-        if (isRandom)
-        {
-            dungeons.clear();
-            dungeons.insert(randomDungeonID);
-        }
-
         // set up a role map and then an lfgplayer struct
         roleMap playerRole;
         playerRole[guid] = uint8(roles);
@@ -309,7 +330,7 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
         m_playerData[guid] = LFGPlayers(LFG_STATE_QUEUED, dungeons, playerRole, comments, false, time(NULL), 0, 0, 0);
 
         // set up a status struct for client requests/updates
-        LFGPlayerStatus plrStatus(LFG_STATE_NONE, LFG_UPDATE_JOIN_INITIAL, dungeons, comments);
+        LFGPlayerStatus plrStatus(LFG_STATE_NONE, LFG_UPDATE_JOIN_INITIAL, displayDungeons, comments);
         plrStatus.ticket = ticket;
         m_playerStatusMap[guid] = plrStatus;
         SendLfgUpdate(guid, plrStatus, false);
@@ -402,6 +423,184 @@ void LFGMgr::LeaveLFG(Player* plr, bool isGroup)
         m_playerData.erase(plrGuid);
         m_playerStatusMap.erase(plrGuid);
     }
+}
+
+void LFGMgr::CancelQueueEntry(ObjectGuid unitGuid, LfgUpdateType reason)
+{
+    playerData::iterator itEntry = m_playerData.find(unitGuid);
+    if (itEntry == m_playerData.end())
+    {
+        return;
+    }
+
+    for (roleMap::const_iterator itr = itEntry->second.currentRoles.begin();
+         itr != itEntry->second.currentRoles.end(); ++itr)
+    {
+        ObjectGuid plrGuid = itr->first;
+
+        Player* pPlayer = sPlayerRegistry.Find(plrGuid);
+        bool isParty = pPlayer && pPlayer->GetGroup();
+
+        LFGPlayerStatus status = GetPlayerStatus(plrGuid);
+        status.updateType = reason;
+        status.state = LFG_STATE_NONE;
+        status.dungeonList.clear();
+        SendLfgUpdate(plrGuid, status, isParty);
+
+        m_playerStatusMap.erase(plrGuid);
+    }
+
+    m_playerData.erase(itEntry);
+    m_queueSet.erase(unitGuid);
+}
+
+void LFGMgr::OnGroupMemberAdded(ObjectGuid groupGuid, ObjectGuid playerGuid)
+{
+    if (IsSuccessfulProposalMove(groupGuid) || IsSuccessfulProposalMove(playerGuid))
+    {
+        return;
+    }
+
+    // A roster change invalidates anything this group had pending.
+    if (m_roleCheckMap.count(groupGuid))
+    {
+        if (Group* pGroup = sObjectMgr.GetGroupById(groupGuid.GetCounter()))
+        {
+            PerformRoleCheck(NULL, pGroup, 0);   // aborts the check and notifies everyone
+        }
+    }
+
+    CancelQueueEntry(groupGuid, LFG_UPDATE_REMOVED_FROM_QUEUE);
+    CancelQueueEntry(playerGuid, LFG_UPDATE_REMOVED_FROM_QUEUE);
+}
+
+void LFGMgr::OnGroupMemberRemoved(ObjectGuid groupGuid, ObjectGuid playerGuid)
+{
+    if (IsSuccessfulProposalMove(groupGuid) || IsSuccessfulProposalMove(playerGuid))
+    {
+        return;
+    }
+
+    // Mid-proposal: the leaver's whole unit declines (TC parity).
+    FailProposalForLeaver(playerGuid);
+
+    if (m_roleCheckMap.count(groupGuid))
+    {
+        if (Group* pGroup = sObjectMgr.GetGroupById(groupGuid.GetCounter()))
+        {
+            PerformRoleCheck(NULL, pGroup, 0);
+        }
+    }
+
+    CancelQueueEntry(groupGuid, LFG_UPDATE_REMOVED_FROM_QUEUE);
+
+    // In-dungeon LFD group bookkeeping.
+    groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
+    if (itStatus != m_groupStatusMap.end())
+    {
+        itStatus->second.playerRoles.erase(playerGuid);
+        m_playerStatusMap.erase(playerGuid);
+
+        if (itStatus->second.playerRoles.empty())
+        {
+            m_groupStatusMap.erase(itStatus);
+            m_groupSet.erase(groupGuid);
+        }
+    }
+}
+
+void LFGMgr::OnGroupDisband(ObjectGuid groupGuid)
+{
+    if (IsSuccessfulProposalMove(groupGuid))
+    {
+        m_groupStatusMap.erase(groupGuid);
+        m_groupSet.erase(groupGuid);
+        return;
+    }
+
+    if (m_roleCheckMap.count(groupGuid))
+    {
+        // The group object is mid-teardown -- clean the check directly.
+        LFGRoleCheck const& roleCheck = m_roleCheckMap.find(groupGuid)->second;
+        for (roleMap::const_iterator itr = roleCheck.currentRoles.begin();
+             itr != roleCheck.currentRoles.end(); ++itr)
+        {
+            SetPlayerState(itr->first, LFG_STATE_NONE);
+            SetPlayerUpdateType(itr->first, LFG_UPDATE_GROUP_DISBAND);
+            SendLfgUpdate(itr->first, GetPlayerStatus(itr->first), true);
+            m_playerStatusMap.erase(itr->first);
+        }
+        m_roleCheckMap.erase(groupGuid);
+    }
+
+    CancelQueueEntry(groupGuid, LFG_UPDATE_GROUP_DISBAND);
+
+    groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
+    if (itStatus != m_groupStatusMap.end())
+    {
+        for (roleMap::const_iterator itr = itStatus->second.playerRoles.begin();
+             itr != itStatus->second.playerRoles.end(); ++itr)
+        {
+            m_playerStatusMap.erase(itr->first);
+        }
+
+        m_groupStatusMap.erase(itStatus);
+        m_groupSet.erase(groupGuid);
+    }
+}
+
+void LFGMgr::OnGroupLeaderChanged(ObjectGuid groupGuid, ObjectGuid newLeaderGuid)
+{
+    roleCheckMap::iterator itCheck = m_roleCheckMap.find(groupGuid);
+    if (itCheck != m_roleCheckMap.end())
+    {
+        itCheck->second.leaderGuidRaw = newLeaderGuid.GetRawValue();
+    }
+
+    groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
+    if (itStatus != m_groupStatusMap.end())
+    {
+        itStatus->second.leaderGuid = newLeaderGuid;
+    }
+}
+
+bool LFGMgr::OnPlayerLogout(Player* player)
+{
+    if (!player)
+    {
+        return false;
+    }
+
+    ObjectGuid const playerGuid = player->GetObjectGuid();
+
+    if (Group* pGroup = player->GetGroup())
+    {
+        ObjectGuid const groupGuid = pGroup->GetObjectGuid();
+
+        // An LFD group keeps its offline members (retail behavior); the
+        // group-removal block in WorldSession::LogoutPlayer is skipped.
+        groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
+        if (itStatus != m_groupStatusMap.end() &&
+            itStatus->second.playerRoles.count(playerGuid))
+        {
+            return true;
+        }
+
+        FailProposalForLeaver(playerGuid);
+
+        if (m_roleCheckMap.count(groupGuid))
+        {
+            PerformRoleCheck(NULL, pGroup, 0);
+        }
+
+        CancelQueueEntry(groupGuid, LFG_UPDATE_GROUP_MEMBER_OFFLINE);
+        return false;
+    }
+
+    FailProposalForLeaver(playerGuid);
+    CancelQueueEntry(playerGuid, LFG_UPDATE_REMOVED_FROM_QUEUE);
+    m_playerStatusMap.erase(playerGuid);
+    return false;
 }
 
 LFGPlayers* LFGMgr::GetPlayerOrPartyData(ObjectGuid guid)

--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -61,6 +61,7 @@
 #include "OpcodeTable.h"
 #include "Log.h"
 #include "Corpse.h"
+#include "Group.h"
 #include "Player.h"
 #include "Vehicle.h"
 #include "SpellAuras.h"
@@ -328,9 +329,18 @@ void WorldSession::HandleMoveWorldportAckOpcode()
     GetPlayer()->ProcessDelayedOperations();
 
     // notify group after successful teleport
-    if (_player->GetGroup())
+    if (Group* group = _player->GetGroup())
     {
         _player->SetGroupUpdateFlag(GROUP_UPDATE_FULL);
+
+        // GROUP_UPDATE_FULL only refreshes member stats. An LFG group also
+        // carries roster flags the client reads once, out of SMSG_GROUP_LIST,
+        // and it drops that packet if it arrives during a loading screen --
+        // so re-send the roster now that this member has actually landed.
+        if (group->isLFGGroup())
+        {
+            group->SendUpdate();
+        }
     }
 }
 

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -672,6 +672,9 @@ void World::SetInitialWorldSettings()
     sLog.outString("Loading Dungeon Finder Items...");
     sObjectMgr.LoadDungeonFinderItems();
 
+    sLog.outString("Loading LFG Dungeon Entrances...");
+    sObjectMgr.LoadLfgDungeonEntrances();
+
     ///- Handle outdated emails (delete/return)
     sLog.outString("Returning old mails...");
     sObjectMgr.ReturnOrDeleteOldMails(false);

--- a/src/shared/revision_data.h.in
+++ b/src/shared/revision_data.h.in
@@ -55,9 +55,9 @@
     #define CHAR_DB_UPDATE_DESCRIPT     "Add_character_cuf_profiles"
 
     #define WORLD_DB_VERSION_NR         "22"
-    #define WORLD_DB_STRUCTURE_NR       "6"
+    #define WORLD_DB_STRUCTURE_NR       "7"
     #define WORLD_DB_CONTENT_NR         "1"
-    #define WORLD_DB_UPDATE_DESCRIPT    "Map_Columns_To_UInt32"
+    #define WORLD_DB_UPDATE_DESCRIPT    "LFG_group_formation_and_teleport"
 
     #define VER_COMPANY_NAME_STR        "MaNGOS Developers"
     #define VER_LEGALCOPYRIGHT_STR      "(c)2005-@rev_year@ MaNGOS"

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRC_GRP_TESTS
     LFGLockReasonTest.cpp
     LFGRoleAssignmentTest.cpp
     LFGProposalLogicTest.cpp
+    LFGDungeonResolutionTest.cpp
     SessionMailboxTest.cpp
     SessionProtocolPolicyTest.cpp
     DatabaseConcurrencyTest.cpp

--- a/src/tests/LFGDungeonResolutionTest.cpp
+++ b/src/tests/LFGDungeonResolutionTest.cpp
@@ -1,0 +1,205 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "LFGDungeonResolution.h"
+
+/**
+ * @file LFGDungeonResolutionTest.cpp
+ * @brief Coverage for LFGDungeonResolution -- expanding a random-dungeon row
+ * into its concrete candidates (group_id union LFGDungeonsGroupingmap.dbc)
+ * and the uniform pick over that set. The fixture below mirrors the real
+ * 15595 LFGDungeons.dbc / LFGDungeonsGroupingmap.dbc data (LFD_PHASE7B_SPEC.md
+ * section 1.1 C2 / V7), reduced to a representative subset.
+ */
+
+namespace
+{
+    using namespace LFGDungeonResolution;
+
+    DungeonRow D(uint32 id, uint32 typeID, uint32 groupID)
+    {
+        DungeonRow row;
+        row.id = id;
+        row.typeID = typeID;
+        row.groupID = groupID;
+        return row;
+    }
+
+    GroupingRow G(uint32 dungeonID, uint32 randomID)
+    {
+        GroupingRow row;
+        row.dungeonID = dungeonID;
+        row.randomID = randomID;
+        return row;
+    }
+
+    /// Representative LFGDungeons.dbc rows: Cata heroics (grp 12, including
+    /// the Hour of Twilight trio which ALSO carries grp 12 via group_id --
+    /// V7), Cata normals (grp 13), a seasonal boss (grp 11), an LFR wing
+    /// (group_id 0, V8), a raid sharing grp 12's id, and a random row that
+    /// happens to share grp 12.
+    std::vector<DungeonRow> Dungeons()
+    {
+        std::vector<DungeonRow> rows;
+        rows.push_back(D(319, TYPE_HEROIC_DUNGEON, 12));   // Vortex Pinnacle
+        rows.push_back(D(324, TYPE_HEROIC_DUNGEON, 12));   // Throne of the Tides
+        rows.push_back(D(326, TYPE_HEROIC_DUNGEON, 12));   // The Deadmines
+        rows.push_back(D(435, TYPE_HEROIC_DUNGEON, 12));   // End Time
+        rows.push_back(D(437, TYPE_HEROIC_DUNGEON, 12));   // Well of Eternity
+        rows.push_back(D(439, TYPE_HEROIC_DUNGEON, 12));   // Hour of Twilight
+        rows.push_back(D(302, TYPE_DUNGEON, 13));          // Cata normal
+        rows.push_back(D(303, TYPE_DUNGEON, 13));          // Cata normal
+        rows.push_back(D(285, TYPE_DUNGEON, 11));          // The Headless Horseman (seasonal)
+        rows.push_back(D(416, TYPE_DUNGEON, 0));           // Siege of Wyrmrest Temple (LFR, grp 0)
+        rows.push_back(D(800, 2, 12));                     // typeID 2 (raid) sharing grp 12
+        rows.push_back(D(999, TYPE_RANDOM_DUNGEON, 12));   // random row sharing grp 12
+        return rows;
+    }
+
+    /// LFGDungeonsGroupingmap.dbc: the Hour of Twilight trio maps to BOTH
+    /// Random Cataclysm Heroic (301) and Random Hour of Twilight (434).
+    std::vector<GroupingRow> Grouping()
+    {
+        std::vector<GroupingRow> rows;
+        rows.push_back(G(435, 301));
+        rows.push_back(G(435, 434));
+        rows.push_back(G(437, 301));
+        rows.push_back(G(437, 434));
+        rows.push_back(G(439, 301));
+        rows.push_back(G(439, 434));
+        return rows;
+    }
+
+    DungeonRow Random300() { return D(300, TYPE_RANDOM_DUNGEON, 13); }  ///< Random Cataclysm Dungeon
+    DungeonRow Random301() { return D(301, TYPE_RANDOM_DUNGEON, 12); }  ///< Random Cataclysm Heroic
+    DungeonRow Random434() { return D(434, TYPE_RANDOM_DUNGEON, 33); }  ///< Random Hour of Twilight Heroic
+}
+
+TEST(LFGDungeonResolution_cata_heroic_bucket_by_group)
+{
+    std::set<uint32> out;
+    ExpandRandom(Random301(), Dungeons(), Grouping(), out);
+
+    REQUIRE(out.size() == 6);
+    CHECK(out.count(319));
+    CHECK(out.count(324));
+    CHECK(out.count(326));
+    CHECK(out.count(435));
+    CHECK(out.count(437));
+    CHECK(out.count(439));
+}
+
+TEST(LFGDungeonResolution_cata_normal_bucket_by_group)
+{
+    std::set<uint32> out;
+    ExpandRandom(Random300(), Dungeons(), Grouping(), out);
+
+    REQUIRE(out.size() == 2);
+    CHECK(out.count(302));
+    CHECK(out.count(303));
+}
+
+TEST(LFGDungeonResolution_hour_of_twilight_via_grouping_map_only)
+{
+    std::set<uint32> out;
+    ExpandRandom(Random434(), Dungeons(), Grouping(), out);
+
+    REQUIRE(out.size() == 3);
+    CHECK(out.count(435));
+    CHECK(out.count(437));
+    CHECK(out.count(439));
+}
+
+TEST(LFGDungeonResolution_grouping_map_duplicates_dedupe)
+{
+    // 435/437/439 satisfy Random 301 through group_id AND the grouping map;
+    // the set must still hold exactly one copy of each (six total, not nine).
+    std::set<uint32> out;
+    ExpandRandom(Random301(), Dungeons(), Grouping(), out);
+
+    CHECK(out.size() == 6);
+}
+
+TEST(LFGDungeonResolution_random_rows_never_join_a_bucket)
+{
+    std::set<uint32> out;
+    ExpandRandom(Random301(), Dungeons(), Grouping(), out);
+
+    CHECK(!out.count(999));
+}
+
+TEST(LFGDungeonResolution_raid_and_zero_group_rows_excluded)
+{
+    std::set<uint32> out;
+    ExpandRandom(Random301(), Dungeons(), Grouping(), out);
+
+    CHECK(!out.count(800));
+    CHECK(!out.count(416));
+}
+
+TEST(LFGDungeonResolution_seasonal_group_isolated)
+{
+    std::set<uint32> heroic;
+    ExpandRandom(Random301(), Dungeons(), Grouping(), heroic);
+    CHECK(!heroic.count(285));
+
+    std::set<uint32> normal;
+    ExpandRandom(Random300(), Dungeons(), Grouping(), normal);
+    CHECK(!normal.count(285));
+}
+
+TEST(LFGDungeonResolution_pick_empty_returns_zero)
+{
+    std::set<uint32> empty;
+    CHECK(Pick(empty, 0) == 0);
+    CHECK(Pick(empty, 42) == 0);
+}
+
+TEST(LFGDungeonResolution_pick_is_rng_mod_size)
+{
+    std::set<uint32> candidates;
+    candidates.insert(319);
+    candidates.insert(324);
+    candidates.insert(326);
+    candidates.insert(435);
+    candidates.insert(437);
+    candidates.insert(439);
+
+    CHECK(Pick(candidates, 0) == 319);
+    CHECK(Pick(candidates, 5) == 439);
+    CHECK(Pick(candidates, 6) == 319);
+    CHECK(Pick(candidates, 7) == 324);
+}
+
+TEST(LFGDungeonResolution_pick_singleton_is_identity)
+{
+    std::set<uint32> candidates;
+    candidates.insert(322);   // e.g. Grim Batol -- a specific selection
+
+    CHECK(Pick(candidates, 0) == 322);
+    CHECK(Pick(candidates, 99) == 322);
+}


### PR DESCRIPTION
Turns an accepted proposal into a real group, resolves random categories to a concrete dungeon, and teleports everyone in and out. Builds on #330.

**Requires the paired migration in mangosthree/database#137** — the core reads `lfg_dungeon_entrances` for the multi-wing entrances `GetMapEntranceTrigger` cannot express. Without it the loader reports an empty table and falls back to the areatrigger lookup.

**Random resolution needed a DBC the core never loaded.** `LFGDungeonsGroupingmap.dbc` is now read (`DBCFilesCount` 129→130) and combined with `LFGDungeons.group_id` in a game-free `LFGDungeonResolution.h`. Random Hour of Twilight (434) carries `group_id 33`, which **no dungeon has**, so it could not resolve to anything at all; the grouping map is the only link to End Time, Well of Eternity and Hour of Twilight. `Random_ID` is unusable as the index — it is 0 for twelve endgame BC and LK normals. `JoinLFG` now stores the pruned concrete candidate set while statuses keep the player's original selection, and the pick happens at proposal time, which makes it lock-safe by construction.

**`CreateDungeonGroup` is rewritten**: leak-free, registers with ObjectMgr, checks `Group::Create`/`AddMember` results, seats members from the proposal's assigned roles, and returns a result so a failed formation re-queues everyone instead of silently doing nothing.

**Two client-truth fixes to the group roster.** `SMSG_GROUP_LIST`'s LFG block carries the concrete dungeon `Entry()`, because the client's `IsPartyLFG` tests the slot rather than the flag bit and a zero disables the eye dropdown. And `GROUPTYPE_LFD` (0x08) only carries that block — bit **0x04** is what drives `HasLFGRestrictions`, which is why the group showed a leader crown instead of the guide icon. The enum had a bare `// 0x04?` where that belonged.

The roster is sent **before** the teleport and again on world-port acknowledgement: a far teleport is deferred behind that ack, so a roster sent afterwards lands on a loading screen and is discarded.

Raid conversion and loot-method changes are now refused server-side for an LFD group; the client hiding those controls is presentation, not enforcement.

Verified in-game with five clients. 110 LFG tests, 0 failed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/331)
<!-- Reviewable:end -->
