### PR TITLE
[Feat] LFG premade party queueing

### DIFF
--- a/src/game/WorldHandlers/LFGEmpowerment.h
+++ b/src/game/WorldHandlers/LFGEmpowerment.h
@@ -1,0 +1,80 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_LFGEMPOWERMENT_H
+#define MANGOS_LFGEMPOWERMENT_H
+
+/**
+ * Server-side mirror of the client's LFD_IsEmpowered (UIParent.lua:3649).
+ *
+ * The client only greys the control; JoinLFG (0x140700860) carries no
+ * leadership test, so the server is the only enforcement point.
+ */
+namespace LFGEmpowerment
+{
+    /// Inputs mirroring the six client predicates, in the client's order.
+    struct State
+    {
+        State()
+            : inParty(false),
+              inRaid(false),
+              isPartyLeader(false),
+              isRaidLeader(false),
+              isRaidAssistant(false),
+              hasLfgRestrictions(false)
+        {
+        }
+
+        bool inParty;              ///< GetNumPartyMembers() > 0
+        bool inRaid;               ///< GetNumRaidMembers() > 0
+        bool isPartyLeader;        ///< IsPartyLeader()
+        bool isRaidLeader;         ///< IsRaidLeader()
+        bool isRaidAssistant;      ///< IsRaidOfficer()
+        bool hasLfgRestrictions;   ///< group carries GROUPTYPE_LFD_RESTRICTED
+    };
+
+    /// True when this player may queue or dequeue for the group.
+    inline bool IsEmpowered(State const& s)
+    {
+        if (!s.inParty && !s.inRaid)
+        {
+            return true;
+        }
+
+        if (s.isPartyLeader || s.isRaidLeader)
+        {
+            return true;
+        }
+
+        if (s.hasLfgRestrictions && (!s.inRaid || s.isRaidAssistant))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}
+
+#endif

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -57,12 +57,12 @@ void WorldSession::HandleLfgJoinOpcode(WorldPacket& recv_data)
     }
 
     Player* player = GetPlayer();
-    if (Group* group = player->GetGroup())
+
+    // The client only greys the button; refuse silently, exactly as retail
+    // does -- there is no "leader only" message in GlobalStrings.
+    if (!LFGMgr::IsEmpowered(player))
     {
-        if (group->GetLeaderGuid() != player->GetObjectGuid())
-        {
-            return;                     // only the leader may queue a group
-        }
+        return;
     }
 
     std::set<uint32> dungeons;
@@ -93,12 +93,16 @@ void WorldSession::HandleLfgLeaveOpcode(WorldPacket& recv_data)
     Player* player = GetPlayer();
     Group* group = player->GetGroup();
 
-    // Only the leader may dequeue a group; the ticket guid the client echoes
-    // is deliberately ignored in favour of the session's own identity.
-    if (!group || group->GetLeaderGuid() == player->GetObjectGuid())
+    // The client only greys the button; refuse silently, exactly as retail
+    // does -- there is no "leader only" message in GlobalStrings. The ticket
+    // guid the client echoes is deliberately ignored in favour of the
+    // session's own identity.
+    if (!LFGMgr::IsEmpowered(player))
     {
-        sLFGMgr.LeaveLFG(player, group != nullptr);
+        return;
     }
+
+    sLFGMgr.LeaveLFG(player, group != nullptr);
 }
 
 void WorldSession::HandleLfgSetRolesOpcode(WorldPacket& recv_data)

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -319,6 +319,7 @@ struct LFGRoleCheck
     uint32 randomDungeonID = 0;    // The random dungeon ID
     uint64 leaderGuidRaw = 0;      // ObjectGuid(raw) of leader
     time_t waitForRoleTime = 0;    // How long we'll wait for the players to confirm their roles
+    bool beginningSent = false;      ///< the initiating update has gone out
 };
 
 struct LFGWait
@@ -727,7 +728,9 @@ protected:
 
     /// Build the shared SMSG_LFG_ROLE_CHECK_UPDATE payload for one role
     /// check, so PerformRoleCheck and RemoveOldRoleChecks cannot drift.
-    void BuildRoleCheckPacket(LFGRoleCheck const& roleCheck, LFGPackets::RoleCheckUpdate& out);
+    /// \a isBeginning must be true on the first packet of a check only.
+    void BuildRoleCheckPacket(LFGRoleCheck const& roleCheck, bool isBeginning,
+                              LFGPackets::RoleCheckUpdate& out);
 
     /// Send SMSG_LFG_ROLE_CHECK_UPDATE to a specific player
     void SendRoleCheckUpdate(ObjectGuid plrGuid, LFGPackets::RoleCheckUpdate const& update);

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -715,6 +715,12 @@ protected:
     /// Forms the LFD group for a succeeded proposal; false = caller unwinds.
     bool CreateDungeonGroup(LFGProposal* proposal);
 
+    /// Detach \a plrGuid from \a pGroup, destroying the group only if we own it.
+    static void DetachFromGroup(Group* pGroup, ObjectGuid plrGuid);
+
+    /// The pre-existing party contributing most members to \a proposal.
+    static ObjectGuid PickHostGroup(LFGProposal const& proposal);
+
     /**
      * @brief Merges two players/groups/etc into one for dungeon assignment.
      *

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -31,6 +31,7 @@
 #include "Common/TimeConstants.h"
 #include <ctime>
 #include <string>
+#include "LFGEmpowerment.h"
 #include "LFGPackets.h"
 #include "Policies/Singleton.h"
 #include "Group.h"
@@ -460,6 +461,12 @@ public:
      * @param plr The pointer to the player
      */
     LfgJoinResult GetJoinResult(Player* plr);
+
+    /// Build the empowerment state for \a plr from its current group.
+    static LFGEmpowerment::State BuildEmpowermentState(Player* plr);
+
+    /// True when \a plr may queue or dequeue for its group (client parity).
+    static bool IsEmpowered(Player* plr);
 
     /**
      * @brief Fetch the playerstatus struct of a player on request, if existant

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -281,7 +281,12 @@ void LFGMgr::SendDungeonProposal(ObjectGuid queueGuid, LFGPlayers* lfgGroup)
          itr != stored.currentRoles.end(); ++itr)
     {
         ObjectGuid plrGuid = itr->first;
-        bool isParty = !stored.groups.find(plrGuid)->second.IsEmpty();
+
+        // The client silently drops SMSG_LFG_UPDATE_STATUS when IsParty
+        // disagrees with its own current group state (spec 7c, section 1.5b)
+        // -- derive it from live membership, not from the proposal snapshot.
+        Player* pPlayer = sPlayerRegistry.Find(plrGuid);
+        bool const isParty = pPlayer && pPlayer->GetGroup();
 
         SetPlayerState(plrGuid, LFG_STATE_PROPOSAL);
         SetPlayerUpdateType(plrGuid, LFG_UPDATE_PROPOSAL_BEGIN);
@@ -493,7 +498,11 @@ void LFGMgr::ProposalUpdate(uint32 proposalID, ObjectGuid plrGuid, bool accepted
         UpdateWaitMap(LFGRoles(role), waitKey,
                       time_t(now - proposal.joinedQueue));
 
-        bool isParty = !proposal.groups.find(memberGuid)->second.IsEmpty();
+        // CreateDungeonGroup has already run: every proposal player, premade
+        // and former solo queuer alike, is now in the formed group -- the
+        // pre-formation proposal.groups snapshot no longer reflects that.
+        Player* pMember = sPlayerRegistry.Find(memberGuid);
+        bool const isParty = pMember && pMember->GetGroup();
         status.updateType = LFG_UPDATE_GROUP_FOUND;
         SendLfgUpdate(memberGuid, status, isParty);
     }

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -47,7 +47,8 @@
  * @brief Cohesion split of LFGMgr.cpp -- role check, dungeon proposal and in-dungeon flow: PerformRoleCheck, proposal send/update/decline, dungeon group create, teleport, boss-kill, kick/vote and LFG packet senders. Same LFGMgr class; no behaviour change. CMake file(GLOB) picks this file up automatically; LFGMgr.h is unchanged.
  */
 
-void LFGMgr::BuildRoleCheckPacket(LFGRoleCheck const& roleCheck, LFGPackets::RoleCheckUpdate& out)
+void LFGMgr::BuildRoleCheckPacket(LFGRoleCheck const& roleCheck, bool isBeginning,
+                                  LFGPackets::RoleCheckUpdate& out)
 {
     std::set<uint32> dungeonBuff;
     if (roleCheck.randomDungeonID)
@@ -60,7 +61,7 @@ void LFGMgr::BuildRoleCheckPacket(LFGRoleCheck const& roleCheck, LFGPackets::Rol
     }
 
     out.status = uint32(roleCheck.state);
-    out.isBeginning = roleCheck.state == LFG_ROLECHECK_INITIALITING;
+    out.isBeginning = isBeginning;
 
     for (uint32 id : dungeonBuff)
     {
@@ -115,7 +116,6 @@ void LFGMgr::PerformRoleCheck(Player* pPlayer, Group* pGroup, uint8 roles)
 
     LFGRoleCheck& roleCheck = it->second;   // reference: mutations must stick (C3)
     ObjectGuid plrGuid = pPlayer ? pPlayer->GetObjectGuid() : ObjectGuid();
-    bool roleChosen = roleCheck.state != LFG_ROLECHECK_DEFAULT && !plrGuid.IsEmpty();
 
     if (!plrGuid)
     {
@@ -145,9 +145,20 @@ void LFGMgr::PerformRoleCheck(Player* pPlayer, Group* pGroup, uint8 roles)
         }
     }
 
+    // The client treats a set flag as "the check just started": it prints
+    // ERR_LFG_ROLE_CHECK_INITIATED, plays 17318 and replays ROLE_CHOSEN for
+    // every member who already answered. Exactly one packet may carry it.
+    bool const isBeginning = !roleCheck.beginningSent &&
+                             roleCheck.state == LFG_ROLECHECK_INITIALITING;
+    roleCheck.beginningSent = true;
+
+    // The isBeginning packet already replays ROLE_CHOSEN for everyone who has
+    // answered, so sending it here too prints the leader's line twice.
+    bool const roleChosen = !isBeginning && !plrGuid.IsEmpty();
+
     // Build ONE role-check packet for everyone in this check.
     LFGPackets::RoleCheckUpdate update;
-    BuildRoleCheckPacket(roleCheck, update);
+    BuildRoleCheckPacket(roleCheck, isBeginning, update);
 
     for (roleMap::iterator itr = roleCheck.currentRoles.begin(); itr != roleCheck.currentRoles.end(); ++itr)
     {
@@ -1388,7 +1399,7 @@ void LFGMgr::RemoveOldRoleChecks()
             roleCheck.state = LFG_ROLECHECK_MISSING_ROLE;   // TC parity (LFGMgr.cpp:310)
 
             LFGPackets::RoleCheckUpdate update;
-            BuildRoleCheckPacket(roleCheck, update);
+            BuildRoleCheckPacket(roleCheck, false, update);
 
             for (roleMap::iterator roleMapItr = roleCheck.currentRoles.begin(); roleMapItr != roleCheck.currentRoles.end(); ++roleMapItr)
             {

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -517,6 +517,43 @@ bool LFGMgr::HasLeaderFlag(roleMap const& roles)
     return false;
 }
 
+void LFGMgr::DetachFromGroup(Group* pGroup, ObjectGuid plrGuid)
+{
+    if (!pGroup)
+    {
+        return;
+    }
+
+    // RemoveMember disbands itself when the pre-removal count is <= 2, so the
+    // caller must decide ownership before the call, never after it. Disband
+    // never unregisters from ObjectMgr or deletes itself (Group.cpp:914-1009),
+    // so this is the only teardown -- not a double-free of a self-disbanded
+    // group.
+    bool const willDisband = pGroup->GetMembersCount() <= 2;
+
+    pGroup->RemoveMember(plrGuid, 0);
+
+    if (willDisband)
+    {
+        sObjectMgr.RemoveGroup(pGroup);
+        delete pGroup;
+    }
+}
+
+ObjectGuid LFGMgr::PickHostGroup(LFGProposal const& proposal)
+{
+    std::vector<LFGProposalLogic::PlayerGroupPair> playerToGroup;
+    playerToGroup.reserve(proposal.groups.size());
+    for (playerGroupMap::const_iterator itr = proposal.groups.begin();
+         itr != proposal.groups.end(); ++itr)
+    {
+        playerToGroup.push_back(LFGProposalLogic::PlayerGroupPair(
+            itr->first.GetRawValue(), itr->second.GetRawValue()));
+    }
+
+    return ObjectGuid(LFGProposalLogic::PickHostGroup(playerToGroup));
+}
+
 //todo(7c): offer-continue formation (proposal->groupRawGuid != 0)
 bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
 {
@@ -545,72 +582,73 @@ bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
         }
     }
 
-    // Leader: the seat that carries the leader bit; lowest guid otherwise.
-    ObjectGuid leaderGuid;
-    for (roleMap::const_iterator itr = proposal->assignedRoles.begin();
-         itr != proposal->assignedRoles.end(); ++itr)
+    // Prefer the pre-existing party contributing the most members: keep its
+    // Group object and leader instead of tearing the premade down and
+    // rebuilding it.
+    Group* pGroup = NULL;
+    ObjectGuid const hostGuid = PickHostGroup(*proposal);
+    if (!hostGuid.IsEmpty())
     {
-        if (itr->second & PLAYER_ROLE_LEADER)
+        pGroup = sObjectMgr.GetGroupById(hostGuid.GetCounter());
+    }
+
+    if (!pGroup)
+    {
+        // No premade in this proposal: build from scratch, as before.
+        // Leader: the seat that carries the leader bit; lowest guid otherwise.
+        ObjectGuid leaderGuid;
+        for (roleMap::const_iterator itr = proposal->assignedRoles.begin();
+             itr != proposal->assignedRoles.end(); ++itr)
         {
-            leaderGuid = itr->first;
-            break;
+            if (itr->second & PLAYER_ROLE_LEADER)
+            {
+                leaderGuid = itr->first;
+                break;
+            }
+
+            if (leaderGuid.IsEmpty() || itr->first < leaderGuid)
+            {
+                leaderGuid = itr->first;
+            }
         }
 
-        if (leaderGuid.IsEmpty() || itr->first < leaderGuid)
+        Player* pLeader = sPlayerRegistry.Find(leaderGuid);
+        if (!pLeader)
         {
-            leaderGuid = itr->first;
+            return false;
         }
-    }
 
-    Player* pLeader = sPlayerRegistry.Find(leaderGuid);
-    if (!pLeader)
-    {
-        return false;
-    }
-
-    // From here on, lifecycle hooks fired by the removes/adds below must
-    // not react -- IsSuccessfulProposalMove covers this proposal's guids.
-    if (Group* pOldGroup = pLeader->GetGroup())
-    {
-        if (pOldGroup->RemoveMember(leaderGuid, 0) <= 1)
+        pGroup = new Group();
+        if (!pGroup->Create(leaderGuid, pLeader->GetName()))
         {
-            sObjectMgr.RemoveGroup(pOldGroup);
-            delete pOldGroup;
+            delete pGroup;
+            return false;
         }
+        sObjectMgr.AddGroup(pGroup);
     }
 
-    Group* pGroup = new Group();
-    if (!pGroup->Create(leaderGuid, pLeader->GetName()))
-    {
-        delete pGroup;
-        return false;
-    }
-    sObjectMgr.AddGroup(pGroup);
-
+    // From here on, lifecycle hooks fired by the removes/adds below must not
+    // react -- IsSuccessfulProposalMove covers this proposal's guids. The
+    // host party keeps its own leader; only outsiders move.
     for (roleMap::const_iterator itr = proposal->currentRoles.begin();
          itr != proposal->currentRoles.end(); ++itr)
     {
-        ObjectGuid memberGuid = itr->first;
-        if (memberGuid == leaderGuid || pGroup->IsMember(memberGuid))
+        ObjectGuid const memberGuid = itr->first;
+        if (pGroup->IsMember(memberGuid))
         {
             continue;
         }
 
         Player* pMember = sPlayerRegistry.Find(memberGuid);
-        if (Group* pOldGroup = pMember->GetGroup())
+        if (!pMember)
         {
-            if (pOldGroup->RemoveMember(memberGuid, 0) <= 1)
-            {
-                sObjectMgr.RemoveGroup(pOldGroup);
-                delete pOldGroup;
-            }
+            return false;
         }
+
+        DetachFromGroup(pMember->GetGroup(), memberGuid);
 
         if (!pGroup->AddMember(memberGuid, pMember->GetName()))
         {
-            pGroup->Disband(true);
-            sObjectMgr.RemoveGroup(pGroup);
-            delete pGroup;
             return false;
         }
     }
@@ -838,6 +876,10 @@ bool LFGMgr::IsSuccessfulProposalMove(ObjectGuid guid) const
             return true;
         }
 
+        // The VALUE arm is what covers a preserved host group: AddMember on
+        // a kept premade fires OnGroupMemberAdded(hostGroupGuid, ...), and
+        // the host's guid appears as a value here for each of its own
+        // members -- do not "simplify" this to the KEY arm alone.
         for (playerGroupMap::const_iterator grpItr = proposal.groups.begin();
              grpItr != proposal.groups.end(); ++grpItr)
         {

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -603,6 +603,38 @@ bool LFGMgr::OnPlayerLogout(Player* player)
     return false;
 }
 
+LFGEmpowerment::State LFGMgr::BuildEmpowermentState(Player* plr)
+{
+    LFGEmpowerment::State state;
+    if (!plr)
+    {
+        return state;
+    }
+
+    Group* pGroup = plr->GetGroup();
+    if (!pGroup)
+    {
+        return state;
+    }
+
+    ObjectGuid const plrGuid = plr->GetObjectGuid();
+    bool const isRaid = pGroup->isRaidGroup();
+
+    state.inParty = !isRaid;
+    state.inRaid = isRaid;
+    state.isPartyLeader = !isRaid && pGroup->IsLeader(plrGuid);
+    state.isRaidLeader = isRaid && pGroup->IsLeader(plrGuid);
+    state.isRaidAssistant = isRaid && pGroup->IsAssistant(plrGuid);
+    state.hasLfgRestrictions = pGroup->isLFGGroup();
+
+    return state;
+}
+
+bool LFGMgr::IsEmpowered(Player* plr)
+{
+    return LFGEmpowerment::IsEmpowered(BuildEmpowermentState(plr));
+}
+
 LFGPlayers* LFGMgr::GetPlayerOrPartyData(ObjectGuid guid)
 {
     playerData::iterator it = m_playerData.find(guid);

--- a/src/game/WorldHandlers/LFGPackets.h
+++ b/src/game/WorldHandlers/LFGPackets.h
@@ -209,11 +209,14 @@ namespace LFGPackets
     // predates this branch and is left as-is.
     // ---------------------------------------------------------------------
 
-    /// Builds SMSG_ROLE_CHOSEN. Fixed shape, always succeeds.
+    /// TANK | HEALER | DAMAGE. The LEADER bit alone is not a role.
+    uint32 const ROLE_MASK_ANY = 0x0E;
+
+    /// Accepted is false unless a real role bit is set; the client asserts.
     inline void BuildRoleChosen(WorldPacket& out, uint64 guid, uint32 roleMask)
     {
         out << uint64(guid);
-        out << uint8(roleMask > 0);
+        out << uint8((roleMask & ROLE_MASK_ANY) != 0);
         out << roleMask;
     }
 

--- a/src/game/WorldHandlers/LFGProposalLogic.h
+++ b/src/game/WorldHandlers/LFGProposalLogic.h
@@ -45,6 +45,8 @@
 
 #include "Platform/Define.h"
 
+#include <map>
+#include <utility>
 #include <vector>
 
 namespace LFGProposalLogic
@@ -141,6 +143,43 @@ namespace LFGProposalLogic
             if (best == 0 || members[i].unitGuid < best)
             {
                 best = members[i].unitGuid;
+            }
+        }
+
+        return best;
+    }
+
+    /// One proposal player's own party, flattened: (player guid, party guid).
+    /// A solo player's party guid is 0.
+    typedef std::pair<uint64, uint64> PlayerGroupPair;
+
+    /// The pre-existing party contributing the most members to a proposal --
+    /// so CreateDungeonGroup can keep that Group object and its leader
+    /// instead of tearing the premade down and rebuilding it (spec 7c,
+    /// section 3.3). Ties break on the lowest guid; 0 when nobody in
+    /// \a playerToGroup has a party (every player's second is 0).
+    inline uint64 PickHostGroup(std::vector<PlayerGroupPair> const& playerToGroup)
+    {
+        std::map<uint64, uint32> counts;
+        for (PlayerGroupPair const& entry : playerToGroup)
+        {
+            if (entry.second != 0)
+            {
+                ++counts[entry.second];
+            }
+        }
+
+        uint64 best = 0;
+        uint32 bestCount = 0;
+        for (std::map<uint64, uint32>::const_iterator itr = counts.begin();
+             itr != counts.end(); ++itr)
+        {
+            // Most members wins; lowest guid breaks the tie deterministically.
+            if (itr->second > bestCount ||
+                (itr->second == bestCount && best != 0 && itr->first < best))
+            {
+                best = itr->first;
+                bestCount = itr->second;
             }
         }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRC_GRP_TESTS
     Utf8Test.cpp
     ByteBufferTest.cpp
     LFGPacketsTest.cpp
+    LFGEmpowermentTest.cpp
     LFGLockReasonTest.cpp
     LFGRoleAssignmentTest.cpp
     LFGProposalLogicTest.cpp

--- a/src/tests/LFGEmpowermentTest.cpp
+++ b/src/tests/LFGEmpowermentTest.cpp
@@ -1,0 +1,97 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "LFGEmpowerment.h"
+
+/**
+ * @file LFGEmpowermentTest.cpp
+ * @brief Coverage for LFGEmpowerment::IsEmpowered against the client's
+ * LFD_IsEmpowered decision table (UIParent.lua:3649-3666).
+ */
+
+TEST(LFGEmpowerment_solo_is_always_empowered)
+{
+    LFGEmpowerment::State state;
+    CHECK(LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_party_leader_is_empowered)
+{
+    LFGEmpowerment::State state;
+    state.inParty = true;
+    state.isPartyLeader = true;
+
+    CHECK(LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_party_member_is_not_empowered)
+{
+    LFGEmpowerment::State state;
+    state.inParty = true;
+
+    CHECK(!LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_lfd_party_member_is_empowered)
+{
+    LFGEmpowerment::State state;
+    state.inParty = true;
+    state.hasLfgRestrictions = true;
+
+    CHECK(LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_lfd_raid_assistant_is_empowered)
+{
+    LFGEmpowerment::State state;
+    state.inRaid = true;
+    state.hasLfgRestrictions = true;
+    state.isRaidAssistant = true;
+
+    CHECK(LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_lfd_raid_member_is_not_empowered)
+{
+    LFGEmpowerment::State state;
+    state.inRaid = true;
+    state.hasLfgRestrictions = true;
+
+    CHECK(!LFGEmpowerment::IsEmpowered(state));
+}
+
+TEST(LFGEmpowerment_raid_leader_beats_missing_restrictions)
+{
+    // The client's second clause (leader) fires before the third
+    // (restrictions), so a raid leader is empowered even when the raid
+    // was never LFD-formed.
+    LFGEmpowerment::State state;
+    state.inRaid = true;
+    state.isRaidLeader = true;
+
+    CHECK(LFGEmpowerment::IsEmpowered(state));
+}

--- a/src/tests/LFGPacketsTest.cpp
+++ b/src/tests/LFGPacketsTest.cpp
@@ -117,6 +117,21 @@ TEST(LFGPackets_RoleChosen_no_roles_is_not_accepted)
     });
 }
 
+TEST(LFGPackets_RoleChosen_leader_bit_alone_is_not_accepted)
+{
+    // PLAYER_ROLE_LEADER (0x01) with no TANK/HEALER/DAMAGE bit: the client
+    // builds a roleList from roles & (2|4|8) and asserts it is non-nil
+    // (LFGFrame.lua:166). Accepted = 1 here would crash the default UI.
+    WorldPacket packet(SMSG_ROLE_CHOSEN, 16);
+    LFGPackets::BuildRoleChosen(packet, 0x1122334455667788ULL, 0x01);
+
+    CHECK_BYTES(packet.contents(), packet.size(), {
+        0x88,0x77,0x66,0x55,0x44,0x33,0x22,0x11,
+        0x00,
+        0x01,0x00,0x00,0x00
+    });
+}
+
 // ---------------------------------------------------------------------
 // SMSG_LFG_TELEPORT_DENIED (0x0E14)
 // ---------------------------------------------------------------------

--- a/src/tests/LFGProposalLogicTest.cpp
+++ b/src/tests/LFGProposalLogicTest.cpp
@@ -227,3 +227,56 @@ TEST(LFGProposalLogic_requeue_key_zero_when_none_survive)
     uint64 key = PickRequeueKey(members, dispositions, 1);
     CHECK(key == 0);
 }
+
+// -------------------------------------------------------------------------
+// PickHostGroup -- which pre-existing party a formed proposal preserves
+// -------------------------------------------------------------------------
+
+TEST(LFGProposalLogic_PickHostGroup_most_members_wins)
+{
+    // Party 100 contributes 3 players, party 200 contributes 2.
+    std::vector<PlayerGroupPair> playerToGroup;
+    playerToGroup.push_back(PlayerGroupPair(1, 100));
+    playerToGroup.push_back(PlayerGroupPair(2, 100));
+    playerToGroup.push_back(PlayerGroupPair(3, 100));
+    playerToGroup.push_back(PlayerGroupPair(4, 200));
+    playerToGroup.push_back(PlayerGroupPair(5, 200));
+
+    CHECK(PickHostGroup(playerToGroup) == 100);
+}
+
+TEST(LFGProposalLogic_PickHostGroup_tie_breaks_on_lowest_guid)
+{
+    // Two 2-member parties tie; the lower party guid wins deterministically.
+    std::vector<PlayerGroupPair> playerToGroup;
+    playerToGroup.push_back(PlayerGroupPair(1, 300));
+    playerToGroup.push_back(PlayerGroupPair(2, 300));
+    playerToGroup.push_back(PlayerGroupPair(3, 150));
+    playerToGroup.push_back(PlayerGroupPair(4, 150));
+    playerToGroup.push_back(PlayerGroupPair(5, 0));
+
+    CHECK(PickHostGroup(playerToGroup) == 150);
+}
+
+TEST(LFGProposalLogic_PickHostGroup_all_solo_returns_zero)
+{
+    std::vector<PlayerGroupPair> playerToGroup;
+    playerToGroup.push_back(PlayerGroupPair(1, 0));
+    playerToGroup.push_back(PlayerGroupPair(2, 0));
+    playerToGroup.push_back(PlayerGroupPair(3, 0));
+
+    CHECK(PickHostGroup(playerToGroup) == 0);
+}
+
+TEST(LFGProposalLogic_PickHostGroup_single_premade_returns_it)
+{
+    // 3 + 2 solo: the only party in the proposal is the host.
+    std::vector<PlayerGroupPair> playerToGroup;
+    playerToGroup.push_back(PlayerGroupPair(1, 42));
+    playerToGroup.push_back(PlayerGroupPair(2, 42));
+    playerToGroup.push_back(PlayerGroupPair(3, 42));
+    playerToGroup.push_back(PlayerGroupPair(4, 0));
+    playerToGroup.push_back(PlayerGroupPair(5, 0));
+
+    CHECK(PickHostGroup(playerToGroup) == 42);
+}


### PR DESCRIPTION
Continues the Dungeon Finder work from #331. Everything so far assumed a solo queuer; this makes an existing party able to queue together.

**Keep the party that already exists.** `CreateDungeonGroup` always built a fresh `Group` and called `RemoveMember` on every proposal player's old group — including a real premade's. That sent its leader a solo `SMSG_GROUP_LIST`, homebound them if they stood in an instance, and on the second removal took `Group::RemoveMember`'s own `Disband(true)` branch, disbanding a group the caller still meant to delete itself. The pre-existing party contributing the most members now hosts the dungeon group, ties broken on the lowest guid; only outsiders are moved into it. Build-from-scratch remains for an all-solo proposal. The original leader keeps leadership, verified in-game.

**Announce a role check once.** `LFGRoleCheck::state` stays `INITIALITING` across every member's selection, so the old `isBeginning` derivation set the flag on each intermediate update. The client reads a set flag as "the check just started" — `ERR_LFG_ROLE_CHECK_INITIATED`, sound 17318, and a replayed `ROLE_CHOSEN` for everyone who already answered — so a real party got escalating chat spam and repeated sounds. Solo queueing never runs a role check, which is why this only surfaces now.

**Leader-only masks are not a choice.** `Accepted` was `roleMask > 0`, but a `PLAYER_ROLE_LEADER`-only mask (0x01) carries no TANK/HEALER/DAMAGE bit. `LFGFrame.lua:166` builds a role list from bits 2/4/8 and asserts it non-nil, so that combination threw a Lua error in the default UI. Gated on `TANK|HEALER|DAMAGE`; a genuine decline still reports `Accepted = 0`.

**Empowerment is now enforced.** `LFD_IsEmpowered` (`UIParent.lua:3649`) only greys the button — `JoinLFG` (0x140700860) has no leadership check — so m3's leader-only gate was simultaneously too strict (any LFD party member may queue or dequeue) and unenforced against a client that skips the grey-out. `LFGEmpowerment.h` mirrors the client's six predicates. Refusal is silent because `GlobalStrings.lua` has no "leader only" string.

**`IsParty` must be live.** The client discards a whole `SMSG_LFG_UPDATE_STATUS` whose `IsParty` disagrees with its current group state, freezing the UI with no error. Two sites read a pre-formation snapshot; both now read live membership.

122 LFG unit tests pass. Verified in-game with a 3-person premade plus solo queuers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/332)
<!-- Reviewable:end -->
