### PR TITLE
[Feat] LFG vote kick

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -3374,7 +3374,7 @@ void Player::DeleteFromDB(ObjectGuid playerguid, uint32 accountId, bool updateRe
         delete resultGroup;
         if (Group* group = sObjectMgr.GetGroupById(groupId))
         {
-            RemoveFromGroup(group, playerguid);
+            RemoveFromGroup(group, playerguid, playerguid, "");
         }
     }
 

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -2560,8 +2560,9 @@ class Player : public Unit
 
         // Uninvite the player from the group
         void UninviteFromGroup();
-        static void RemoveFromGroup(Group* group, ObjectGuid guid);
-        void RemoveFromGroup() { RemoveFromGroup(GetGroup(), GetObjectGuid()); }
+        static void RemoveFromGroup(Group* group, ObjectGuid guid,
+                                    ObjectGuid kicker, std::string reason);
+        void RemoveFromGroup() { RemoveFromGroup(GetGroup(), GetObjectGuid(), GetObjectGuid(), ""); }
         void SendUpdateToOutOfRangeGroupMembers();
         void SetAllowLowLevelRaid(bool allow) { ApplyModFlag(PLAYER_FLAGS, PLAYER_FLAGS_ENABLE_LOW_LEVEL_RAID, allow); }
         bool GetAllowLowLevelRaid() const { return HasFlag(PLAYER_FLAGS, PLAYER_FLAGS_ENABLE_LOW_LEVEL_RAID); }
@@ -3755,7 +3756,7 @@ class Player : public Unit
         Player* GetNextRandomRaidMember(float radius);
 
         // Check if the player can be uninvited from the group
-        PartyResult CanUninviteFromGroup() const;
+        PartyResult CanUninviteFromGroup(ObjectGuid guidMember = ObjectGuid()) const;
         void UpdateGroupLeaderFlag(const bool remove = false);
         // BattleGround Group System
 

--- a/src/game/Object/PlayerGroup.cpp
+++ b/src/game/Object/PlayerGroup.cpp
@@ -53,6 +53,8 @@
 #include "Group.h"
 #include "Guild.h"
 #include "GuildMgr.h"
+#include "LFGBootLogic.h"
+#include "LFGMgr.h"
 #include "Pet.h"
 #ifdef ENABLE_PLAYERBOTS
 #include "playerbot.h"
@@ -145,16 +147,25 @@ void Player::UninviteFromGroup()
 }
 
 /**
- * @brief Removes a member from a group and disposes of the group if it becomes empty.
+ * @brief Removes a member from a group, or starts a vote kick in an LFD group.
  *
  * @param group The group to remove the member from.
  * @param guid The GUID of the member to remove.
+ * @param kicker The GUID of the player requesting the removal; equal to \c guid
+ *   for a voluntary leave.
+ * @param reason The vote-kick reason; empty for a voluntary leave.
  */
-void Player::RemoveFromGroup(Group* group, ObjectGuid guid)
+void Player::RemoveFromGroup(Group* group, ObjectGuid guid, ObjectGuid kicker,
+                             std::string reason)
 {
     if (group)
     {
-        if (group->RemoveMember(guid, 0) <= 1)
+        if (group->isLFGGroup() && LFGBootLogic::ShouldVoteKick(
+            guid.GetRawValue(), kicker.GetRawValue()))
+        {
+            sLFGMgr.AttemptToKickPlayer(group, guid, kicker, reason);
+        }
+        else if (group->RemoveMember(guid, 0) <= 1)
         {
             // group->Disband(); already disbanded in RemoveMember
             sObjectMgr.RemoveGroup(group);
@@ -255,9 +266,14 @@ Player* Player::GetNextRandomRaidMember(float radius)
 /**
  * @brief Checks whether the player is allowed to uninvite someone from the group.
  *
+ * @param guidMember The member being targeted; not read by either branch
+ *   today (the LFG gate is group-wide, and the non-LFG gate never grew
+ *   TrinityCore's "can't kick the leader" check -- see the spec's cut line).
+ *   Kept in the signature for interface/TC parity and so a future check can
+ *   use it without another signature change.
  * @return The party result code describing whether uninvite is allowed.
  */
-PartyResult Player::CanUninviteFromGroup() const
+PartyResult Player::CanUninviteFromGroup(ObjectGuid guidMember) const
 {
     const Group* grp = GetGroup();
     if (!grp)
@@ -265,14 +281,54 @@ PartyResult Player::CanUninviteFromGroup() const
         return ERR_NOT_IN_GROUP;
     }
 
-    if (!grp->IsLeader(GetObjectGuid()) && !grp->IsAssistant(GetObjectGuid()))
+    if (grp->isLFGGroup())
     {
-        return ERR_NOT_LEADER;
-    }
+        ObjectGuid const groupGuid = grp->GetObjectGuid();
 
-    if (InBattleGround())
+        if (sLFGMgr.GetKicksLeft(groupGuid) == 0)
+        {
+            return ERR_PARTY_LFG_BOOT_LIMIT;
+        }
+
+        if (sLFGMgr.IsBootVoteActive(groupGuid))
+        {
+            return ERR_PARTY_LFG_BOOT_IN_PROGRESS;
+        }
+
+        if (grp->GetMembersCount() <= LFGBootLogic::RequiredVotes(grp->isLFRGroup()))
+        {
+            return ERR_PARTY_LFG_BOOT_TOO_FEW_PLAYERS;
+        }
+
+        if (sLFGMgr.GetGroupLfgState(groupGuid) == LFG_STATE_FINISHED_DUNGEON)
+        {
+            return ERR_PARTY_LFG_BOOT_DUNGEON_COMPLETE;
+        }
+
+        // ERR_PARTY_LFG_BOOT_LOOT_ROLLS (29): no cheap isRollLootActive()
+        // equivalent exists in this tree yet (OQ-8.5) -- gate point named,
+        // not filled.
+
+        for (GroupReference const* itr = grp->GetFirstMember(); itr != NULL; itr = itr->next())
+        {
+            Player* pMember = itr->getSource();
+            if (pMember && pMember->IsInMap(this) && pMember->IsInCombat())
+            {
+                return ERR_PARTY_LFG_BOOT_IN_COMBAT;
+            }
+        }
+    }
+    else
     {
-        return ERR_INVITE_RESTRICTED;
+        if (!grp->IsLeader(GetObjectGuid()) && !grp->IsAssistant(GetObjectGuid()))
+        {
+            return ERR_NOT_LEADER;
+        }
+
+        if (InBattleGround())
+        {
+            return ERR_INVITE_RESTRICTED;
+        }
     }
 
     return ERR_PARTY_RESULT_OK;

--- a/src/game/Server/OpcodeTable.cpp
+++ b/src/game/Server/OpcodeTable.cpp
@@ -788,7 +788,7 @@ void InitializeOpcodes()
     OPCODE(CMSG_BUYBACK_ITEM,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleBuybackItem               );
     OPCODE(SMSG_SERVER_MESSAGE,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_SET_SAVED_INSTANCE_EXTEND,               STATUS_UNHANDLED, PROCESS_INPLACE,     &WorldSession::Handle_NULL                     );
-    //OPCODE(SMSG_LFG_OFFER_CONTINUE,                      STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(SMSG_LFG_OFFER_CONTINUE,                      STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     //OPCODE(CMSG_TEST_DROP_RATE,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
     //OPCODE(SMSG_TEST_DROP_RATE_RESULT,                   STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_LFG_GET_STATUS,                          STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgGetStatusOpcode        );
@@ -1012,8 +1012,8 @@ void InitializeOpcodes()
     //OPCODE(SMSG_LFG_SLOT_INVALID,                        STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_LFG_SET_ROLES,                           STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgSetRolesOpcode         );
     OPCODE(CMSG_LFG_LOCK_INFO_REQUEST,                   STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgLockInfoRequestOpcode  );
-    //OPCODE(CMSG_LFG_SET_BOOT_VOTE,                       STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_NULL                     );
-    //OPCODE(SMSG_LFG_BOOT_PROPOSAL_UPDATE,                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
+    OPCODE(CMSG_LFG_SET_BOOT_VOTE,                       STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgSetBootVoteOpcode      );
+    OPCODE(SMSG_LFG_BOOT_PROPOSAL_UPDATE,                STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(SMSG_LFG_PLAYER_INFO,                         STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );
     OPCODE(CMSG_LFG_TELEPORT,                            STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleLfgTeleportOpcode         );
     OPCODE(SMSG_LFG_PARTY_INFO,                          STATUS_NEVER,    PROCESS_INPLACE,      &WorldSession::Handle_ServerSide               );

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -391,6 +391,7 @@ class WorldSession
         void SendLfgTeleportError(uint8 error);
         void SendLfgRewards(LFGRewards const& rewards);
         void SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNeeded);
+        void SendLfgOfferContinue(uint32 dungeonEntry);
         void SendLfgPlayerLockInfo();
         void SendLfgPartyLockInfo();
         void SendPartyResult(PartyOperation operation, const std::string& member,

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -390,7 +390,7 @@ class WorldSession
         void SendLfgProposalUpdate(LFGPackets::ProposalUpdate const& proposal);
         void SendLfgTeleportError(uint8 error);
         void SendLfgRewards(LFGRewards const& rewards);
-        void SendLfgBootUpdate(LFGBoot const& boot);
+        void SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNeeded);
         void SendLfgPlayerLockInfo();
         void SendLfgPartyLockInfo();
         void SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -393,7 +393,9 @@ class WorldSession
         void SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNeeded);
         void SendLfgPlayerLockInfo();
         void SendLfgPartyLockInfo();
-        void SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res);
+        void SendPartyResult(PartyOperation operation, const std::string& member,
+                             PartyResult res, uint32 val = 0,
+                             ObjectGuid guid = ObjectGuid());
         void SendGroupInvite(Player* player, bool alreadyInGroup = false);
         void SendGuildInvite(Player* player, bool alreadyInGuild = false);
         void SendAreaTriggerMessage(const char* Text, ...) ATTR_PRINTF(2, 3);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1022,6 +1022,7 @@ class WorldSession
         void HandleLfgGetStatusOpcode(WorldPacket& recv_data);
         void HandleLfgProposalResultOpcode(WorldPacket& recv_data);
         void HandleLfgTeleportOpcode(WorldPacket& recv_data);
+        void HandleLfgSetBootVoteOpcode(WorldPacket& recv_data);
         void HandleSetTitleOpcode(WorldPacket& recv_data);
         void HandleRealmSplitOpcode(WorldPacket& recv_data);
         void HandleTimeSyncResp(WorldPacket& recv_data);

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -1800,7 +1800,7 @@ void Group::SendUpdate()
         {
             data << uint8(lfgData.state);                   // MyLfgFlags; 2 = finished
             data << uint32(lfgData.dungeonEntry);           // LfgSlot; concrete Entry()
-            data << uint8(0);                               // LfgAborted -- Phase 8
+            data << uint8(0);                               // LfgAborted; non-zero disables CanPartyLFGBackfill (sub_1406FB440)
         }
         data << GetObjectGuid();                            // group guid
         data << uint32(sequence);                           // roster version; client drops anything it has already seen

--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -356,6 +356,8 @@ class Group
             return m_bgGroup != NULL;
         }
         bool isLFGGroup() const { return m_groupType & GROUPTYPE_LFD; }
+        /// True for a Raid Finder group: an LFD group that is also a raid.
+        bool isLFRGroup() const { return isLFGGroup() && isRaidGroup(); }
         bool IsCreated()   const
         {
             return GetMembersCount() > 0;

--- a/src/game/WorldHandlers/GroupHandler.cpp
+++ b/src/game/WorldHandlers/GroupHandler.cpp
@@ -81,15 +81,18 @@
  * @param operation The party operation being reported.
  * @param member The related member name.
  * @param res The result code to send.
+ * @param val LFD cooldown seconds (ERR_PARTY_LFG_BOOT_COOLDOWN_S / _NOT_ELIGIBLE_S); 0 otherwise.
+ * @param guid Victim guid for ERR_VOTE_KICK_REASON_NEEDED; empty otherwise.
  */
-void WorldSession::SendPartyResult(PartyOperation operation, const std::string& member, PartyResult res)
+void WorldSession::SendPartyResult(PartyOperation operation, const std::string& member,
+                                   PartyResult res, uint32 val, ObjectGuid guid)
 {
     WorldPacket data(SMSG_PARTY_COMMAND_RESULT, 4 + member.size() + 1 + 4 + 4 + 8);
     data << uint32(operation);
     data << member;                                         // max len 48
     data << uint32(res);
-    data << uint32(0);                                      // LFD cooldown related (used with ERR_PARTY_LFG_BOOT_COOLDOWN_S and ERR_PARTY_LFG_BOOT_NOT_ELIGIBLE_S)
-    data << ObjectGuid();                                   // if result == 27 (ERR_VOTE_KICK_REASON_NEEDED), then it's guid of player being kicked (member's guid)
+    data << uint32(val);                                    // LFD cooldown related (used with ERR_PARTY_LFG_BOOT_COOLDOWN_S and ERR_PARTY_LFG_BOOT_NOT_ELIGIBLE_S)
+    data << guid;                                            // if result == 27 (ERR_VOTE_KICK_REASON_NEEDED), then it's guid of player being kicked (member's guid)
 
     SendPacket(&data);
 }
@@ -353,15 +356,17 @@ void WorldSession::HandleGroupInviteResponseOpcode(WorldPacket& recv_data)
 }
 
 /**
- * @brief Uninvites a group member or invitee by guid.
+ * @brief Uninvites a group member or invitee by guid, or starts a vote kick
+ *        when the target's group is an LFD group.
  *
  * @param recv_data The received opcode packet.
  */
 void WorldSession::HandleGroupUninviteGuidOpcode(WorldPacket& recv_data)
 {
     ObjectGuid guid;
+    std::string reason;
     recv_data >> guid;
-    recv_data.read_skip<std::string>();                     // reason
+    recv_data >> reason;
 
     // can't uninvite yourself
     if (guid == GetPlayer()->GetObjectGuid())
@@ -370,14 +375,39 @@ void WorldSession::HandleGroupUninviteGuidOpcode(WorldPacket& recv_data)
         return;
     }
 
-    PartyResult res = GetPlayer()->CanUninviteFromGroup();
-    if (res != ERR_PARTY_RESULT_OK)
+    // The client caps the reason at 64 bytes on copy (spec section 1.1); a
+    // modified client must not be able to push a longer string into the
+    // group broadcast.
+    trim(reason);
+    if (reason.size() > 64)
     {
-        SendPartyResult(PARTY_OP_LEAVE, "", res);
-        return;
+        reason.resize(64);
     }
 
     Group* grp = GetPlayer()->GetGroup();
+
+    // Resolved from member slots (not sObjectMgr.GetPlayer) so it works for
+    // an offline member -- needed below regardless of eligibility outcome.
+    std::string targetName;
+    if (grp)
+    {
+        for (Group::MemberSlot const& slot : grp->GetMemberSlots())
+        {
+            if (slot.guid == guid)
+            {
+                targetName = slot.name;
+                break;
+            }
+        }
+    }
+
+    PartyResult res = GetPlayer()->CanUninviteFromGroup(guid);
+    if (res != ERR_PARTY_RESULT_OK)
+    {
+        SendPartyResult(PARTY_OP_LEAVE, targetName, res);
+        return;
+    }
+
     if (!grp)
     {
         return;
@@ -385,7 +415,16 @@ void WorldSession::HandleGroupUninviteGuidOpcode(WorldPacket& recv_data)
 
     if (grp->IsMember(guid))
     {
-        Player::RemoveFromGroup(grp, guid);
+        if (grp->isLFGGroup() && reason.empty())
+        {
+            // Opens the client's "Please enter the reason to vote kick"
+            // box (VOTE_KICK_REASON_NEEDED, spec section 1.1).
+            SendPartyResult(PARTY_OP_LEAVE, targetName,
+                            ERR_VOTE_KICK_REASON_NEEDED, 0, guid);
+            return;
+        }
+
+        Player::RemoveFromGroup(grp, guid, GetPlayer()->GetObjectGuid(), reason);
         return;
     }
 
@@ -395,7 +434,7 @@ void WorldSession::HandleGroupUninviteGuidOpcode(WorldPacket& recv_data)
         return;
     }
 
-    SendPartyResult(PARTY_OP_LEAVE, "", ERR_TARGET_NOT_IN_GROUP_S);
+    SendPartyResult(PARTY_OP_LEAVE, targetName, ERR_TARGET_NOT_IN_GROUP_S);
 }
 
 /**
@@ -436,7 +475,7 @@ void WorldSession::HandleGroupUninviteOpcode(WorldPacket& recv_data)
 
     if (ObjectGuid guid = grp->GetMemberGuid(membername))
     {
-        Player::RemoveFromGroup(grp, guid);
+        Player::RemoveFromGroup(grp, guid, GetPlayer()->GetObjectGuid(), "");
         return;
     }
 

--- a/src/game/WorldHandlers/LFGBootLogic.h
+++ b/src/game/WorldHandlers/LFGBootLogic.h
@@ -1,0 +1,137 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_LFGBOOTLOGIC_H
+#define MANGOS_LFGBOOTLOGIC_H
+
+/**
+ * @file LFGBootLogic.h
+ * @brief Threshold selection, tally resolution and remaining-time math for
+ *        the LFG boot (vote-kick) system, decoupled from LFGMgr.
+ *
+ * LFGMgr::AttemptToKickPlayer / CastVote / FinishBootVote (LFGMgrProposal.cpp)
+ * collect the votes and call into this header for every decision that does
+ * not need a live Player/Group -- the same boundary LFGProposalLogic.h and
+ * LFGRoleAssignment.h document: src/tests/CMakeLists.txt only links
+ * `proto`/`shared` into mangos_tests, so testable logic has to stay
+ * game-free. No Player, no Group, no ObjectGuid -- raw std::uint64_t for
+ * guids, matching m2's LFGLogic::ShouldVoteKick.
+ *
+ * The vote threshold (4 LFD / 15 LFR) is TrinityCore's number, adopted
+ * because nothing above it in this campaign's authority order speaks -- see
+ * LFD_PHASE8_SPEC.md section 1.4. It is isolated here, in one place, so it
+ * can be revisited without touching the tally/resolution machinery.
+ */
+
+#include <cstdint>
+
+namespace LFGBootLogic
+{
+    /// Votes needed to resolve a boot, by group kind. INFERRED from
+    /// TrinityCore; not proven against a 4.3.4 sniff.
+    enum BootVotesNeeded
+    {
+        LFD_BOOT_VOTES_NEEDED = 4,
+        LFR_BOOT_VOTES_NEEDED = 15
+    };
+
+    /// Boot votes a single group may win before the budget is spent.
+    enum BootBudget
+    {
+        BOOT_MAX_KICKS = 3
+    };
+
+    /// How a boot vote ended.
+    enum BootResolution
+    {
+        BOOT_PENDING = 0,
+        BOOT_PASSED,
+        BOOT_FAILED
+    };
+
+    /// Running tally of one boot vote.
+    struct BootTally
+    {
+        std::uint32_t total = 0;    ///< answers cast (agree or deny)
+        std::uint32_t agree = 0;
+        std::uint32_t deny = 0;
+    };
+
+    /// Votes needed for this group kind.
+    inline std::uint32_t RequiredVotes(bool isRaidFinder)
+    {
+        return isRaidFinder ? std::uint32_t(LFR_BOOT_VOTES_NEEDED)
+                             : std::uint32_t(LFD_BOOT_VOTES_NEEDED);
+    }
+
+    /// A player may never start a vote against themselves.
+    inline bool ShouldVoteKick(std::uint64_t target, std::uint64_t kicker)
+    {
+        return target != kicker;
+    }
+
+    /// Resolves a tally against the threshold. `>=`, never `==` -- a vote
+    /// that arrives after the deciding one must not be silently dropped.
+    /// Agree is checked first, so a simultaneous agree/deny majority (only
+    /// reachable with a tiny threshold) resolves as passed.
+    inline BootResolution Resolve(BootTally const& tally, std::uint32_t votesNeeded)
+    {
+        if (tally.agree >= votesNeeded)
+        {
+            return BOOT_PASSED;
+        }
+
+        if (tally.deny >= votesNeeded)
+        {
+            return BOOT_FAILED;
+        }
+
+        return BOOT_PENDING;
+    }
+
+    /// Seconds left, clamped at 0. Mirrors m2's LFGLogic::RemainingSeconds
+    /// semantics so the two forks stay comparable: 0 when duration <= 0 or
+    /// elapsed has reached duration; a negative elapsed (clock skew) is
+    /// treated as no time having passed yet rather than extending the timer.
+    inline std::int64_t RemainingSeconds(std::int64_t start, std::int64_t duration,
+                                         std::int64_t now)
+    {
+        if (duration <= 0)
+        {
+            return 0;
+        }
+
+        std::int64_t elapsed = now - start;
+        if (elapsed < 0)
+        {
+            elapsed = 0;
+        }
+
+        std::int64_t const remaining = duration - elapsed;
+        return (remaining > 0) ? remaining : 0;
+    }
+}
+
+#endif

--- a/src/game/WorldHandlers/LFGBootLogic.h
+++ b/src/game/WorldHandlers/LFGBootLogic.h
@@ -39,10 +39,10 @@
  * game-free. No Player, no Group, no ObjectGuid -- raw std::uint64_t for
  * guids, matching m2's LFGLogic::ShouldVoteKick.
  *
- * The vote threshold (4 LFD / 15 LFR) is TrinityCore's number, adopted
- * because nothing above it in this campaign's authority order speaks -- see
- * LFD_PHASE8_SPEC.md section 1.4. It is isolated here, in one place, so it
- * can be revisited without touching the tally/resolution machinery.
+ * The vote thresholds are server policy -- the client parses the
+ * votes-needed field and never reads it back -- so they are isolated here,
+ * in one place, and can be revisited without touching the tally or
+ * resolution machinery.
  */
 
 #include <cstdint>

--- a/src/game/WorldHandlers/LFGBootLogic.h
+++ b/src/game/WorldHandlers/LFGBootLogic.h
@@ -49,18 +49,20 @@
 
 namespace LFGBootLogic
 {
-    /// Votes needed to resolve a boot, by group kind. INFERRED from
-    /// TrinityCore; not proven against a 4.3.4 sniff.
+    /// Votes needed to resolve a boot, by group kind. The client cannot
+    /// settle this: it parses the votes-needed field and never reads it
+    /// back, so the number is server policy. A five-man kick is a majority
+    /// of the group, which is three -- not the four TrinityCore uses.
     enum BootVotesNeeded
     {
-        LFD_BOOT_VOTES_NEEDED = 4,
+        LFD_BOOT_VOTES_NEEDED = 3,
         LFR_BOOT_VOTES_NEEDED = 15
     };
 
     /// Boot votes a single group may win before the budget is spent.
     enum BootBudget
     {
-        BOOT_MAX_KICKS = 3
+        BOOT_MAX_KICKS = 2
     };
 
     /// How a boot vote ended.

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -458,41 +458,62 @@ void WorldSession::SendLfgRewards(LFGRewards const& rewards)
     SendPacket(&data);
 }
 
-void WorldSession::SendLfgBootUpdate(LFGBoot const& boot)
+/// Sends SMSG_LFG_BOOT_PROPOSAL_UPDATE for one recipient.
+///
+/// timeLeft is computed inline here rather than through
+/// LFGBootLogic::RemainingSeconds (LFGBootLogic.h, added in a later commit
+/// of this same series) so this commit stays independently buildable; the
+/// clamp formula is identical -- no `/1000`, no `uint8` truncation, floored
+/// at 0 (C-8).
+void WorldSession::SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNeeded)
 {
-    DEBUG_LOG("SMSG_LFG_BOOT_PLAYER");
+    DEBUG_LOG("SMSG_LFG_BOOT_PROPOSAL_UPDATE");
 
     ObjectGuid plrGuid = GetPlayer()->GetObjectGuid();
-    LFGProposalAnswer plrAnswer = boot.answers.find(plrGuid)->second;
 
-    uint32 voteCount = 0, yayCount = 0;
+    proposalAnswerMap::const_iterator ansItr = boot.answers.find(plrGuid);
+    LFGProposalAnswer plrAnswer = (ansItr != boot.answers.end()) ? ansItr->second : LFG_ANSWER_PENDING;
+
+    uint32 totalVotes = 0, bootVotes = 0;
     for (proposalAnswerMap::const_iterator it = boot.answers.begin(); it != boot.answers.end(); ++it)
     {
         if (it->second != LFG_ANSWER_PENDING)
         {
-            ++voteCount;
+            ++totalVotes;
             if (it->second == LFG_ANSWER_AGREE)
             {
-                ++yayCount;
+                ++bootVotes;
             }
         }
     }
 
-    uint32 timeLeft = uint8(((boot.startTime + LFG_TIME_BOOT) - time(NULL)) / 1000);
+    time_t const now = time(NULL);
+    time_t const deadline = boot.startTime + LFG_TIME_BOOT;
+    uint32 const timeLeft = (deadline > now) ? uint32(deadline - now) : 0;
 
-    WorldPacket data(SMSG_LFG_BOOT_PROPOSAL_UPDATE, 27 + boot.reason.length());
+    LFGPackets::BootProposalUpdate data;
+    data.voteInProgress = boot.inProgress;
+    data.votePassed = false;   // LFGBoot gains a real votePassed field in a
+                                // later commit of this series; wired there.
+    data.myVoteCompleted = plrAnswer != LFG_ANSWER_PENDING;
+    data.myVote = plrAnswer == LFG_ANSWER_AGREE;
+    data.target = boot.playerVotedOn.GetRawValue();
+    data.totalVotes = totalVotes;
+    data.bootVotes = bootVotes;
+    data.timeLeft = timeLeft;
+    data.votesNeeded = votesNeeded;
+    data.reason = boot.reason;
 
-    data << uint8(boot.inProgress);                   // Is boot still ongoing?
-    data << uint8(plrAnswer != LFG_ANSWER_PENDING);   // Did this player vote yet?
-    data << uint8(plrAnswer == LFG_ANSWER_AGREE);     // Did this player agree to boot them?
-    data << uint64(boot.playerVotedOn.GetRawValue()); // Potentially booted player's objectguid value
-    data << uint32(voteCount);                        // Number of players who've voted so far
-    data << uint32(yayCount);                         // Number of players who've voted against the plr so far
-    data << uint32(timeLeft);                         // Time left in seconds
-    data << uint32(REQUIRED_VOTES_FOR_BOOT);          // Number of votes needed to win
-    data << boot.reason.c_str();                      // Reason given for booting
-
-    SendPacket(&data);
+    WorldPacket packet(SMSG_LFG_BOOT_PROPOSAL_UPDATE, 28 + boot.reason.length() + 1);
+    if (LFGPackets::BuildBootProposalUpdate(packet, data))
+    {
+        SendPacket(&packet);
+    }
+    else
+    {
+        sLog.outError("WorldSession::SendLfgBootProposalUpdate: reason too long (%u bytes), packet not sent",
+                      uint32(boot.reason.length()));
+    }
 }
 
 /// Builds and sends SMSG_LFG_PLAYER_INFO for the requesting player. Drives

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -217,6 +217,17 @@ void WorldSession::HandleLfgLockInfoRequestOpcode(WorldPacket& recv_data)
     }
 }
 
+/// CMSG_LFG_SET_BOOT_VOTE: records this player's answer to a boot vote.
+void WorldSession::HandleLfgSetBootVoteOpcode(WorldPacket& recv_data)
+{
+    DEBUG_LOG("CMSG_LFG_SET_BOOT_VOTE");
+
+    LFGPackets::SetBootVoteRequest request;
+    LFGPackets::ReadSetBootVote(recv_data, request);
+
+    sLFGMgr.CastVote(GetPlayer(), request.vote);
+}
+
 void WorldSession::SendLfgSearchResults(LfgType type, uint32 entry)
 {
     WorldPacket data(SMSG_LFG_SEARCH_RESULTS);

--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -504,8 +504,7 @@ void WorldSession::SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNe
 
     LFGPackets::BootProposalUpdate data;
     data.voteInProgress = boot.inProgress;
-    data.votePassed = false;   // LFGBoot gains a real votePassed field in a
-                                // later commit of this series; wired there.
+    data.votePassed = boot.votePassed;
     data.myVoteCompleted = plrAnswer != LFG_ANSWER_PENDING;
     data.myVote = plrAnswer == LFG_ANSWER_AGREE;
     data.target = boot.playerVotedOn.GetRawValue();
@@ -525,6 +524,16 @@ void WorldSession::SendLfgBootProposalUpdate(LFGBoot const& boot, uint32 votesNe
         sLog.outError("WorldSession::SendLfgBootProposalUpdate: reason too long (%u bytes), packet not sent",
                       uint32(boot.reason.length()));
     }
+}
+
+/// SMSG_LFG_OFFER_CONTINUE: offers the group a backfill for its dungeon.
+void WorldSession::SendLfgOfferContinue(uint32 dungeonEntry)
+{
+    DEBUG_LOG("SMSG_LFG_OFFER_CONTINUE %u", dungeonEntry);
+
+    WorldPacket data(SMSG_LFG_OFFER_CONTINUE, 4);
+    LFGPackets::BuildOfferContinue(data, dungeonEntry);
+    SendPacket(&data);
 }
 
 /// Builds and sends SMSG_LFG_PLAYER_INFO for the requesting player. Drives

--- a/src/game/WorldHandlers/LFGMgr.cpp
+++ b/src/game/WorldHandlers/LFGMgr.cpp
@@ -74,13 +74,16 @@ LFGMgr::~LFGMgr()
 
 void LFGMgr::Update()
 {
-    //todo: remove old queues & boot votes
+    //todo: remove old queues
 
     // remove old role checks
     RemoveOldRoleChecks();
 
     // remove expired dungeon proposals (45 s -- LFG_TIME_PROPOSAL)
     RemoveOldProposals();
+
+    // fail expired boot votes (120 s -- LFG_TIME_BOOT)
+    RemoveOldBoots();
 
     // go through a waitTimeMap::iterator for each wait map and update times based on player count
     for (waitTimeMap::iterator tankItr = m_tankWaitTime.begin(); tankItr != m_tankWaitTime.end(); ++tankItr)

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -31,6 +31,7 @@
 #include "Common/TimeConstants.h"
 #include <ctime>
 #include <string>
+#include "LFGBootLogic.h"
 #include "LFGEmpowerment.h"
 #include "LFGPackets.h"
 #include "Policies/Singleton.h"
@@ -255,9 +256,6 @@ const uint32 WOTLK_SPECIAL_HEROIC_AMNT = 2;
 /// Default average queue time (in case we don't have data to base calculations on)
 const int32 QUEUE_DEFAULT_TIME = 15*MINUTE;                              // 15 minutes [system is measured in seconds]
 
-/// Amount of votes needed to kick a player out of a group
-const int32 REQUIRED_VOTES_FOR_BOOT = 3;
-
 typedef std::set<uint32> dailyEntries;                                   // for players who did one of X type instance per day
 typedef std::set<ObjectGuid> queueSet;                                   // List of players / groups in the queue
 typedef std::set<ObjectGuid> groupSet;                                   // List of groups doing a dungeon via the finder
@@ -356,10 +354,14 @@ struct LFGGroupStatus //todo: check for this in joinlfg function, not lfgplayers
     uint32 dungeonID;      // ID of the dungeon the group should be in
     roleMap playerRoles;   // Container holding each player's objectguid and their roles
     ObjectGuid leaderGuid; // The group leader's object guid
+    uint8 kicksLeft;       // Boot votes this group may still win before ERR_PARTY_LFG_BOOT_LIMIT
 
-    LFGGroupStatus() { }
+    LFGGroupStatus()
+        : state(LFG_STATE_NONE), dungeonID(0),
+          kicksLeft(uint8(LFGBootLogic::BOOT_MAX_KICKS)) { }
     LFGGroupStatus(LFGState State, uint32 DungeonID, roleMap PlayerRoles, ObjectGuid LeaderGuid)
-        : state(State), dungeonID(DungeonID), playerRoles(PlayerRoles), leaderGuid(LeaderGuid) { }
+        : state(State), dungeonID(DungeonID), playerRoles(PlayerRoles), leaderGuid(LeaderGuid),
+          kicksLeft(uint8(LFGBootLogic::BOOT_MAX_KICKS)) { }
 };
 
 /// The client-facing LFD fields appended to SMSG_GROUP_LIST for one member.
@@ -414,14 +416,22 @@ struct LFGRewards
 struct LFGBoot
 {
     bool inProgress;           // Is the boot vote still occurring?
+    bool votePassed;           // Resolved outcome once inProgress goes false
+    LFGState previousState;    // Group state to restore when the vote resolves
     ObjectGuid playerVotedOn;  // ObjectGuid of the player being voted on
     std::string reason;        // Reason stated for the vote
     proposalAnswerMap answers; // Player's votes
     time_t startTime;          // When the vote started
 
-    LFGBoot() { }
-    LFGBoot(bool InProgress, ObjectGuid PlayerVotedOn, std::string Reason, proposalAnswerMap Answers, time_t StartTime)
-        : inProgress(InProgress), playerVotedOn(PlayerVotedOn), reason(Reason), answers(Answers), startTime(StartTime) { }
+    LFGBoot()
+        : inProgress(false), votePassed(false),
+          previousState(LFG_STATE_NONE), startTime(0) { }
+    LFGBoot(bool InProgress, bool VotePassed, LFGState PreviousState,
+            ObjectGuid PlayerVotedOn, std::string const& Reason,
+            proposalAnswerMap const& Answers, time_t StartTime)
+        : inProgress(InProgress), votePassed(VotePassed), previousState(PreviousState),
+          playerVotedOn(PlayerVotedOn), reason(Reason), answers(Answers),
+          startTime(StartTime) { }
 };
 
 // End Section: Structures
@@ -651,6 +661,19 @@ public:
     // Called when a player votes yes or no on a boot vote
     void CastVote(Player* pPlayer, bool vote);
 
+    /// Cancel any in-flight boot for this group without penalty.
+    void CancelBootVote(ObjectGuid groupGuid);
+
+    /// True while \a groupGuid has an unresolved boot vote.
+    bool IsBootVoteActive(ObjectGuid groupGuid) const;
+
+    /// Kicks remaining before ERR_PARTY_LFG_BOOT_LIMIT; 0 when the group is
+    /// not tracked as an in-dungeon LFD group.
+    uint8 GetKicksLeft(ObjectGuid groupGuid) const;
+
+    /// The group's dungeon-finder state; LFG_STATE_NONE when untracked.
+    LFGState GetGroupLfgState(ObjectGuid groupGuid) const;
+
     /// Fetch the client-facing LFD fields appended to SMSG_GROUP_LIST.
     bool GetGroupUpdateData(ObjectGuid groupGuid, ObjectGuid playerGuid,
                             LFGGroupUpdateData& data) const;
@@ -698,6 +721,12 @@ protected:
 
     /// Expire proposals older than LFG_TIME_PROPOSAL.
     void RemoveOldProposals();
+
+    /// Resolve one boot vote and restore the group's previous state.
+    void FinishBootVote(ObjectGuid groupGuid, bool succeeded);
+
+    /// Fail boot votes older than LFG_TIME_BOOT.
+    void RemoveOldBoots();
 
     /// True while a succeeded proposal is still moving this guid's players
     /// between groups -- lifecycle hooks must not react to those moves.

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -580,8 +580,16 @@ public:
     /// Given the ID of a dungeon, spit out its entry
     uint32 GetDungeonEntry(uint32 ID) const;
 
-    /// Enter or leave the group's validated LFD dungeon.
-    bool TeleportPlayer(Player* pPlayer, bool out, bool automatic);
+    /**
+     * Enter or leave the group's validated LFD dungeon.
+     *
+     * \arg \c dungeonID
+     *   Dungeon to teleport out of, for a caller that has already removed
+     *   the player from the group and so has no group to look one up on.
+     *   0 derives it from the player's current group, as every entering
+     *   caller does.
+     */
+    bool TeleportPlayer(Player* pPlayer, bool out, bool automatic, uint32 dungeonID = 0);
 
     /// Queue Functions Below
 

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -1282,7 +1282,7 @@ void LFGMgr::AttemptToKickPlayer(Group* pGroup, ObjectGuid guid, ObjectGuid kick
     {
         if (Player* groupPlr = it->getSource())
         {
-            groupPlr->GetSession()->SendLfgBootUpdate(boot);
+            groupPlr->GetSession()->SendLfgBootProposalUpdate(boot, REQUIRED_VOTES_FOR_BOOT);
         }
     }
 }
@@ -1349,7 +1349,7 @@ void LFGMgr::CastVote(Player* pPlayer, bool vote)
             if (plrGuid != boot.playerVotedOn)
             {
                 SetPlayerState(plrGuid, LFG_STATE_IN_DUNGEON);
-                pGroupPlr->GetSession()->SendLfgBootUpdate(boot);
+                pGroupPlr->GetSession()->SendLfgBootProposalUpdate(boot, REQUIRED_VOTES_FOR_BOOT);
             }
         }
     }

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -700,7 +700,7 @@ bool LFGMgr::CreateDungeonGroup(LFGProposal* proposal)
     return true;
 }
 
-bool LFGMgr::TeleportPlayer(Player* pPlayer, bool out, bool automatic)
+bool LFGMgr::TeleportPlayer(Player* pPlayer, bool out, bool automatic, uint32 dungeonID)
 {
     if (!pPlayer)
     {
@@ -708,9 +708,19 @@ bool LFGMgr::TeleportPlayer(Player* pPlayer, bool out, bool automatic)
     }
 
     Group* pGroup = pPlayer->GetGroup();
-    LFGGroupStatus* status = pGroup ? GetGroupStatus(pGroup->GetObjectGuid()) : NULL;
-    LfgDungeonsEntry const* dungeon = status
-        ? sLfgDungeonsStore.LookupEntry(status->dungeonID) : NULL;
+
+    // An explicit dungeon is for callers that have already detached the
+    // player from the group -- a boot -- and so cannot look one up.
+    if (!dungeonID)
+    {
+        if (LFGGroupStatus* status = pGroup ? GetGroupStatus(pGroup->GetObjectGuid()) : NULL)
+        {
+            dungeonID = status->dungeonID;
+        }
+    }
+
+    LfgDungeonsEntry const* dungeon = dungeonID
+        ? sLfgDungeonsStore.LookupEntry(dungeonID) : NULL;
     if (!dungeon || dungeon->mapID <= 0)
     {
         pPlayer->GetSession()->SendLfgTeleportError(uint8(LFG_TELEPORTERROR_INVALID_LOCATION));
@@ -837,7 +847,7 @@ bool LFGMgr::TeleportPlayer(Player* pPlayer, bool out, bool automatic)
         // Multi-wing override first (lfg_dungeon_entrances), then the
         // generic map entrance areatrigger.
         if (ObjectMgr::LfgDungeonEntrance const* entrance =
-            sObjectMgr.GetLfgDungeonEntrance(status->dungeonID))
+            sObjectMgr.GetLfgDungeonEntrance(dungeonID))
         {
             x = entrance->x;
             y = entrance->y;
@@ -1441,21 +1451,36 @@ void LFGMgr::FinishBootVote(ObjectGuid groupGuid, bool succeeded)
 
     if (pGroup && pGroup->IsMember(boot.playerVotedOn))
     {
-        if (Player* pVictim = sPlayerRegistry.Find(boot.playerVotedOn))
+        Player* pVictim = sPlayerRegistry.Find(boot.playerVotedOn);
+        if (pVictim)
         {
             // A booted player keeps no deserter debuff and gets the random
             // dungeon cooldown back. RemoveAurasDueToSpell is a no-op today
             // -- 71328 is never applied in this tree -- written now so the
             // branch is correct once a later phase starts applying it.
             pVictim->RemoveAurasDueToSpell(LFG_COOLDOWN_SPELL);
-
-            if (pVictim->GetMap() && pVictim->GetMap()->IsDungeon())
-            {
-                TeleportPlayer(pVictim, true, true);
-            }
         }
 
+        // Read the dungeon before the removal takes the group away, so the
+        // teleport below still knows where the victim is being pulled out of.
+        uint32 const bootedFrom = status ? status->dungeonID : 0;
+        bool const victimInDungeon =
+            pVictim && pVictim->GetMap() && pVictim->GetMap()->IsDungeon();
+
+        // Remove BEFORE teleporting. RemoveMember is what tells the victim
+        // they are out -- SMSG_GROUP_UNINVITE plus an empty SMSG_GROUP_LIST
+        // -- and a far teleport puts them behind a loading screen that
+        // discards both, leaving them staring at a group they already left
+        // while everyone else sees them gone. The world-port ack cannot
+        // repair it either: its roster re-send only fires for a player who
+        // still has a group.
         bool const groupSurvived = pGroup->RemoveMember(boot.playerVotedOn, 1) > 1;
+
+        if (victimInDungeon)
+        {
+            TeleportPlayer(pVictim, true, true, bootedFrom);
+        }
+
         if (!groupSurvived)
         {
             // group->Disband(); already disbanded in RemoveMember

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -31,6 +31,7 @@
 #include "GameEventMgr.h"
 #include "Group.h"
 #include "LFGMgr.h"
+#include "LFGBootLogic.h"
 #include "LFGProposalLogic.h"
 #include "LFGDungeonResolution.h"
 #include "Log.h"
@@ -1239,50 +1240,65 @@ void LFGMgr::HandleBossKilled(Player* pPlayer)
 
 void LFGMgr::AttemptToKickPlayer(Group* pGroup, ObjectGuid guid, ObjectGuid kicker, std::string reason)
 {
-    ObjectGuid groupGuid = pGroup->GetObjectGuid();
-    LFGGroupStatus* status = GetGroupStatus(groupGuid);
-
-    bootStatusMap::iterator bIt = m_bootStatusMap.find(groupGuid);
-    if (!status)
+    if (!pGroup || !LFGBootLogic::ShouldVoteKick(guid.GetRawValue(), kicker.GetRawValue()) ||
+        !pGroup->IsMember(guid) || !pGroup->IsMember(kicker))
     {
         return;
     }
 
-    status->state = LFG_STATE_BOOT;
-    m_groupStatusMap[groupGuid] = *status;
-
-    // This function is only called when a group is set/in a dungeon so we can go straight to the boot packets
-    time_t now = time(NULL);
-    proposalAnswerMap votes;
-
-    // safe to say the person attempting to kick them will vote yes, the kick-ee will vote no
-    votes[guid] = LFG_ANSWER_DENY;
-    votes[kicker] = LFG_ANSWER_AGREE;
-
-    // set group state to boot vote, same for player states until it's over
-    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next()) //todo: check if we will need to use mail or not
+    ObjectGuid groupGuid = pGroup->GetObjectGuid();
+    LFGGroupStatus* status = GetGroupStatus(groupGuid);
+    if (!status || status->state != LFG_STATE_IN_DUNGEON)
     {
-        if (Player* pGroupPlr = itr->getSource())
-        {
-            ObjectGuid pGroupPlrGuid = pGroupPlr->GetObjectGuid();
-
-            SetPlayerState(pGroupPlrGuid, LFG_STATE_BOOT);
-
-            if ( (pGroupPlrGuid != guid) && (pGroupPlrGuid != kicker) )
-            {
-                votes[pGroupPlrGuid] = LFG_ANSWER_PENDING;
-            }
-        }
+        return;
     }
 
-    LFGBoot boot(true, guid, reason, votes, now);
+    if (m_bootStatusMap.find(groupGuid) != m_bootStatusMap.end())
+    {
+        return;                     // a boot is already running for this group
+    }
+
+    LFGState const previousState = status->state;
+    status->state = LFG_STATE_BOOT;   // mutate through the pointer -- no write-back copy
+
+    uint32 const votesNeeded = LFGBootLogic::RequiredVotes(pGroup->isLFRGroup());
+
+    // Seed votes from playerRoles (not GetFirstMember()) so offline members
+    // stay in the tally: victim DENY, kicker AGREE, everyone else PENDING.
+    proposalAnswerMap votes;
+    for (roleMap::const_iterator itr = status->playerRoles.begin();
+         itr != status->playerRoles.end(); ++itr)
+    {
+        ObjectGuid const memberGuid = itr->first;
+
+        if (memberGuid == guid)
+        {
+            votes[memberGuid] = LFG_ANSWER_DENY;
+        }
+        else if (memberGuid == kicker)
+        {
+            votes[memberGuid] = LFG_ANSWER_AGREE;
+        }
+        else
+        {
+            votes[memberGuid] = LFG_ANSWER_PENDING;
+        }
+
+        SetPlayerState(memberGuid, LFG_STATE_BOOT);
+    }
+
+    LFGBoot boot(true, false, previousState, guid, reason, votes, time(NULL));
     m_bootStatusMap[groupGuid] = boot;
 
-    for (GroupReference* it = pGroup->GetFirstMember(); it != NULL; it = it->next())
+    // Include the victim: their myVoteCompleted suppresses the popup
+    // (section 1.1), but voteInProgress must be set so the terminating
+    // packet can clear it later.
+    for (proposalAnswerMap::const_iterator itr = boot.answers.begin();
+         itr != boot.answers.end(); ++itr)
     {
-        if (Player* groupPlr = it->getSource())
+        if (Player* pMember = sPlayerRegistry.Find(itr->first))
         {
-            groupPlr->GetSession()->SendLfgBootProposalUpdate(boot, REQUIRED_VOTES_FOR_BOOT);
+            pMember->GetSession()->SendLfgBootProposalUpdate(boot, votesNeeded);
         }
     }
 }
@@ -1295,10 +1311,13 @@ void LFGMgr::CastVote(Player* pPlayer, bool vote)
     }
 
     Group* pGroup = pPlayer->GetGroup();
+    if (!pGroup)
+    {
+        return;
+    }
+
     ObjectGuid groupGuid = pGroup->GetObjectGuid();
-
     LFGGroupStatus* status = GetGroupStatus(groupGuid);
-
     if (!status || status->state != LFG_STATE_BOOT)
     {
         return;
@@ -1310,61 +1329,209 @@ void LFGMgr::CastVote(Player* pPlayer, bool vote)
         return;
     }
 
-    LFGBoot boot = it->second;
-    boot.answers[pPlayer->GetObjectGuid()] = LFGProposalAnswer(vote);
+    LFGBoot& boot = it->second;   // a reference: mutations must stick
 
-    int32 yay = 0, nay = 0; // keep a count of votes
-    for (proposalAnswerMap::iterator pIt = boot.answers.begin(); pIt != boot.answers.end(); ++pIt)
+    proposalAnswerMap::iterator ansItr = boot.answers.find(pPlayer->GetObjectGuid());
+    if (ansItr == boot.answers.end() || ansItr->second != LFG_ANSWER_PENDING)
     {
-        LFGProposalAnswer answer = pIt->second;
-        if (answer == LFG_ANSWER_AGREE)
+        return;                     // not a voter, or already voted
+    }
+
+    ansItr->second = LFGProposalAnswer(vote);
+
+    uint32 const votesNeeded = LFGBootLogic::RequiredVotes(pGroup->isLFRGroup());
+
+    LFGBootLogic::BootTally tally;
+    for (proposalAnswerMap::const_iterator pIt = boot.answers.begin(); pIt != boot.answers.end(); ++pIt)
+    {
+        if (pIt->second == LFG_ANSWER_AGREE)
         {
-            ++yay;
+            ++tally.agree;
+            ++tally.total;
         }
-        else if (answer == LFG_ANSWER_DENY)
+        else if (pIt->second == LFG_ANSWER_DENY)
         {
-            ++nay;
+            ++tally.deny;
+            ++tally.total;
         }
     }
 
-    if (yay < REQUIRED_VOTES_FOR_BOOT && nay < REQUIRED_VOTES_FOR_BOOT)
+    LFGBootLogic::BootResolution const resolution = LFGBootLogic::Resolve(tally, votesNeeded);
+    if (resolution == LFGBootLogic::BOOT_PASSED)
     {
-        m_bootStatusMap[groupGuid] = boot;
+        FinishBootVote(groupGuid, true);
         return;
     }
 
-    // if we dont have enough votes to kick or keep plr, don't send packet update
-    // if else, set boot.inProgress to false, set plr + group states back to lfg-state-dungeon,
-    // send packet update to group, kick plr if we had the votes, and then erase entry from boot map
+    if (resolution == LFGBootLogic::BOOT_FAILED)
+    {
+        FinishBootVote(groupGuid, false);
+        return;
+    }
+
+    // Still pending: re-broadcast. Safe on the voter's own client too --
+    // noCancelOnReuse means a fresh update never fires a spurious OnCancel.
+    for (proposalAnswerMap::const_iterator pIt = boot.answers.begin(); pIt != boot.answers.end(); ++pIt)
+    {
+        if (Player* pMember = sPlayerRegistry.Find(pIt->first))
+        {
+            pMember->GetSession()->SendLfgBootProposalUpdate(boot, votesNeeded);
+        }
+    }
+}
+
+/// Resolves one boot vote, notifies the group and applies the outcome.
+void LFGMgr::FinishBootVote(ObjectGuid groupGuid, bool succeeded)
+{
+    bootStatusMap::iterator it = m_bootStatusMap.find(groupGuid);
+    if (it == m_bootStatusMap.end())
+    {
+        return;
+    }
+
+    // Copy-then-erase-then-act: RemoveMember below re-enters through
+    // OnGroupMemberRemoved -> CancelBootVote, and the entry must already be
+    // gone for that recursive call to be a no-op (section 1.7 item 4).
+    LFGBoot boot = it->second;
+    m_bootStatusMap.erase(it);
 
     boot.inProgress = false;
-    status->state = LFG_STATE_IN_DUNGEON;
+    boot.votePassed = succeeded;
 
-    for (GroupReference* itr = pGroup->GetFirstMember(); itr != NULL; itr = itr->next())
+    LFGGroupStatus* status = GetGroupStatus(groupGuid);
+    if (status)
     {
-        if (Player* pGroupPlr = itr->getSource())
+        status->state = boot.previousState;
+        for (proposalAnswerMap::const_iterator ansItr = boot.answers.begin();
+             ansItr != boot.answers.end(); ++ansItr)
         {
-            ObjectGuid plrGuid = pGroupPlr->GetObjectGuid();
-
-            if (plrGuid != boot.playerVotedOn)
-            {
-                SetPlayerState(plrGuid, LFG_STATE_IN_DUNGEON);
-                pGroupPlr->GetSession()->SendLfgBootProposalUpdate(boot, REQUIRED_VOTES_FOR_BOOT);
-            }
+            SetPlayerState(ansItr->first, boot.previousState);
         }
     }
 
-    if (yay == REQUIRED_VOTES_FOR_BOOT)
+    Group* pGroup = sObjectMgr.GetGroupById(groupGuid.GetCounter());
+    uint32 const votesNeeded = LFGBootLogic::RequiredVotes(pGroup && pGroup->isLFRGroup());
+
+    // Broadcast BEFORE touching the group: this is what closes the popup on
+    // every client (the only thing that does) and what prints the pass/fail
+    // line while the victim's guid still resolves. The victim is included --
+    // see OQ-8.1 in the PR body for the TrinityCore divergence and why.
+    for (proposalAnswerMap::const_iterator ansItr = boot.answers.begin();
+         ansItr != boot.answers.end(); ++ansItr)
     {
-        // kick player from group
+        if (Player* pMember = sPlayerRegistry.Find(ansItr->first))
+        {
+            pMember->GetSession()->SendLfgBootProposalUpdate(boot, votesNeeded);
+        }
+    }
+
+    if (!succeeded)
+    {
+        if (pGroup)
+        {
+            pGroup->SendUpdate();
+        }
+        return;
+    }
+
+    if (status)
+    {
+        status->kicksLeft = (status->kicksLeft > 0) ? status->kicksLeft - 1 : 0;
+    }
+
+    if (pGroup && pGroup->IsMember(boot.playerVotedOn))
+    {
         if (pGroup->RemoveMember(boot.playerVotedOn, 1) <= 1)
         {
             // group->Disband(); already disbanded in RemoveMember
             sObjectMgr.RemoveGroup(pGroup);
             delete pGroup;
-            // removemember sets the player's group pointer to NULL
+            // RemoveMember sets the player's group pointer to NULL
         }
     }
+}
+
+/// Fails boot votes that have run past LFG_TIME_BOOT.
+void LFGMgr::RemoveOldBoots()
+{
+    time_t const now = time(NULL);
+
+    // Collect first: FinishBootVote erases from the map being walked, so a
+    // single-phase loop is UB (mirrors RemoveOldProposals above).
+    std::vector<ObjectGuid> expired;
+    for (bootStatusMap::const_iterator itr = m_bootStatusMap.begin();
+         itr != m_bootStatusMap.end(); ++itr)
+    {
+        if (itr->second.startTime + LFG_TIME_BOOT <= now)
+        {
+            expired.push_back(itr->first);
+        }
+    }
+
+    for (std::vector<ObjectGuid>::const_iterator itr = expired.begin();
+         itr != expired.end(); ++itr)
+    {
+        FinishBootVote(*itr, false);
+    }
+}
+
+/// Cancel any in-flight boot for this group without penalty -- called from
+/// the group lifecycle seam (OnGroupMemberRemoved / OnGroupDisband) when a
+/// member is already leaving. Must not route through FinishBootVote's
+/// removal path.
+void LFGMgr::CancelBootVote(ObjectGuid groupGuid)
+{
+    bootStatusMap::iterator it = m_bootStatusMap.find(groupGuid);
+    if (it == m_bootStatusMap.end())
+    {
+        return;
+    }
+
+    LFGBoot boot = it->second;
+    m_bootStatusMap.erase(it);
+
+    boot.inProgress = false;
+    boot.votePassed = false;
+
+    LFGGroupStatus* status = GetGroupStatus(groupGuid);
+    if (status)
+    {
+        status->state = boot.previousState;
+        for (proposalAnswerMap::const_iterator ansItr = boot.answers.begin();
+             ansItr != boot.answers.end(); ++ansItr)
+        {
+            SetPlayerState(ansItr->first, boot.previousState);
+        }
+    }
+
+    Group* pGroup = sObjectMgr.GetGroupById(groupGuid.GetCounter());
+    uint32 const votesNeeded = LFGBootLogic::RequiredVotes(pGroup && pGroup->isLFRGroup());
+
+    for (proposalAnswerMap::const_iterator ansItr = boot.answers.begin();
+         ansItr != boot.answers.end(); ++ansItr)
+    {
+        if (Player* pMember = sPlayerRegistry.Find(ansItr->first))
+        {
+            pMember->GetSession()->SendLfgBootProposalUpdate(boot, votesNeeded);
+        }
+    }
+}
+
+bool LFGMgr::IsBootVoteActive(ObjectGuid groupGuid) const
+{
+    return m_bootStatusMap.find(groupGuid) != m_bootStatusMap.end();
+}
+
+uint8 LFGMgr::GetKicksLeft(ObjectGuid groupGuid) const
+{
+    groupStatusMap::const_iterator it = m_groupStatusMap.find(groupGuid);
+    return (it != m_groupStatusMap.end()) ? it->second.kicksLeft : 0;
+}
+
+LFGState LFGMgr::GetGroupLfgState(ObjectGuid groupGuid) const
+{
+    groupStatusMap::const_iterator it = m_groupStatusMap.find(groupGuid);
+    return (it != m_groupStatusMap.end()) ? it->second.state : LFG_STATE_NONE;
 }
 
 void LFGMgr::SendRoleChosen(ObjectGuid plrGuid, ObjectGuid confirmedGuid, uint8 roles)

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -1441,12 +1441,37 @@ void LFGMgr::FinishBootVote(ObjectGuid groupGuid, bool succeeded)
 
     if (pGroup && pGroup->IsMember(boot.playerVotedOn))
     {
-        if (pGroup->RemoveMember(boot.playerVotedOn, 1) <= 1)
+        if (Player* pVictim = sPlayerRegistry.Find(boot.playerVotedOn))
+        {
+            // A booted player keeps no deserter debuff and gets the random
+            // dungeon cooldown back. RemoveAurasDueToSpell is a no-op today
+            // -- 71328 is never applied in this tree -- written now so the
+            // branch is correct once a later phase starts applying it.
+            pVictim->RemoveAurasDueToSpell(LFG_COOLDOWN_SPELL);
+
+            if (pVictim->GetMap() && pVictim->GetMap()->IsDungeon())
+            {
+                TeleportPlayer(pVictim, true, true);
+            }
+        }
+
+        bool const groupSurvived = pGroup->RemoveMember(boot.playerVotedOn, 1) > 1;
+        if (!groupSurvived)
         {
             // group->Disband(); already disbanded in RemoveMember
             sObjectMgr.RemoveGroup(pGroup);
             delete pGroup;
             // RemoveMember sets the player's group pointer to NULL
+        }
+
+        // Guarded against the group having just been deleted above.
+        if (groupSurvived && status && status->state != LFG_STATE_FINISHED_DUNGEON)
+        {
+            if (Player* pLeader = sPlayerRegistry.Find(pGroup->GetLeaderGuid()))
+            {
+                pLeader->GetSession()->SendLfgOfferContinue(
+                    GetDungeonEntry(status->dungeonID));
+            }
         }
     }
 }

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -494,6 +494,13 @@ void LFGMgr::OnGroupMemberRemoved(ObjectGuid groupGuid, ObjectGuid playerGuid)
 
     CancelQueueEntry(groupGuid, LFG_UPDATE_REMOVED_FROM_QUEUE);
 
+    // Without this, a boot whose group changed mid-vote leaks in
+    // m_bootStatusMap until RemoveOldBoots reaps it (section 1.7 item 3).
+    // Must run after the proposal-move early-return above and before the
+    // m_groupStatusMap teardown below, which destroys the state
+    // CancelBootVote needs.
+    CancelBootVote(groupGuid);
+
     // In-dungeon LFD group bookkeeping.
     groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
     if (itStatus != m_groupStatusMap.end())
@@ -534,6 +541,10 @@ void LFGMgr::OnGroupDisband(ObjectGuid groupGuid)
     }
 
     CancelQueueEntry(groupGuid, LFG_UPDATE_GROUP_DISBAND);
+
+    // Same reasoning as OnGroupMemberRemoved: cancel before the
+    // m_groupStatusMap teardown below removes the state CancelBootVote needs.
+    CancelBootVote(groupGuid);
 
     groupStatusMap::iterator itStatus = m_groupStatusMap.find(groupGuid);
     if (itStatus != m_groupStatusMap.end())

--- a/src/game/WorldHandlers/LFGPackets.h
+++ b/src/game/WorldHandlers/LFGPackets.h
@@ -234,20 +234,25 @@ namespace LFGPackets
 
     // ---------------------------------------------------------------------
     // SMSG_LFG_BOOT_PROPOSAL_UPDATE (0x0F05) -- sub_1406FA6F0
+    // Flag names from the client's own log string at 0x1409F89E0 ("In
+    // Progress / I Voted / My Vote", slots 1/3/4) and from slot 2 selecting
+    // ERR_PARTY_LFG_BOOT_VOTE_SUCCEEDED (680) vs _FAILED (681) at
+    // 0x1406FA86E. votesNeeded is parsed but never pushed to Lua.
     // ---------------------------------------------------------------------
 
     struct BootProposalUpdate
     {
         bool voteInProgress = false;
+        bool votePassed = false;    ///< selects the client's "vote passed" vs
+                                     ///< "vote failed" line; only read when
+                                     ///< voteInProgress is false
         bool myVoteCompleted = false;
         bool myVote = false;
-        bool voteEcho = false;      ///< fourth wire flag; not read back by
-                                     ///< this handler, name is inferred
         uint64 target = 0;          ///< victim guid, raw
         uint32 totalVotes = 0;
         uint32 bootVotes = 0;
         uint32 timeLeft = 0;        ///< seconds
-        uint32 votesNeeded = 0;
+        uint32 votesNeeded = 0;     ///< wire-only; never reaches Lua
         std::string reason;         ///< NUL-terminated on the wire, max 256
                                      ///< bytes including the terminator
     };
@@ -263,9 +268,9 @@ namespace LFGPackets
         }
 
         out << uint8(data.voteInProgress);
+        out << uint8(data.votePassed);
         out << uint8(data.myVoteCompleted);
         out << uint8(data.myVote);
-        out << uint8(data.voteEcho);
         out << uint64(data.target);
         out << data.totalVotes;
         out << data.bootVotes;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRC_GRP_TESTS
     LFGLockReasonTest.cpp
     LFGRoleAssignmentTest.cpp
     LFGProposalLogicTest.cpp
+    LFGBootLogicTest.cpp
     LFGDungeonResolutionTest.cpp
     SessionMailboxTest.cpp
     SessionProtocolPolicyTest.cpp

--- a/src/tests/LFGBootLogicTest.cpp
+++ b/src/tests/LFGBootLogicTest.cpp
@@ -38,7 +38,8 @@ using namespace LFGBootLogic;
 
 TEST(LFGBootLogic_RequiredVotes_lfd)
 {
-    CHECK(RequiredVotes(false) == 4u);
+    // A majority of the five-man group, so one dissenter is not a veto.
+    CHECK(RequiredVotes(false) == 3u);
 }
 
 TEST(LFGBootLogic_RequiredVotes_lfr)
@@ -148,12 +149,24 @@ TEST(LFGBootLogic_five_man_unanimity_all_three_agree_passes)
     CHECK(Resolve(tally, RequiredVotes(false)) == BOOT_PASSED);
 }
 
-TEST(LFGBootLogic_five_man_unanimity_one_abstention_deadlocks)
+TEST(LFGBootLogic_five_man_majority_passes_despite_one_dissenter)
 {
-    // Same group, but one survivor never votes: neither side reaches 4.
+    // Three of the five agree, so the kick carries. A single dissenter --
+    // or an abstention -- is not a veto, which is what a threshold of four
+    // would have made it.
     BootTally tally;
     tally.agree = 1 + 2;   // kicker + two survivors
     tally.deny = 1;        // victim
+    tally.total = tally.agree + tally.deny;
+
+    CHECK(Resolve(tally, RequiredVotes(false)) == BOOT_PASSED);
+}
+
+TEST(LFGBootLogic_five_man_two_agreeing_is_not_yet_a_majority)
+{
+    BootTally tally;
+    tally.agree = 2;
+    tally.deny = 1;
     tally.total = tally.agree + tally.deny;
 
     CHECK(Resolve(tally, RequiredVotes(false)) == BOOT_PENDING);
@@ -161,5 +174,5 @@ TEST(LFGBootLogic_five_man_unanimity_one_abstention_deadlocks)
 
 TEST(LFGBootLogic_budget_constant)
 {
-    CHECK(int(BOOT_MAX_KICKS) == 3);
+    CHECK(int(BOOT_MAX_KICKS) == 2);
 }

--- a/src/tests/LFGBootLogicTest.cpp
+++ b/src/tests/LFGBootLogicTest.cpp
@@ -1,0 +1,165 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "TestHarness.h"
+
+#include "LFGBootLogic.h"
+
+/**
+ * @file LFGBootLogicTest.cpp
+ * @brief Coverage for LFGBootLogic -- vote threshold selection, self-kick
+ * refusal, tally resolution and the clamped remaining-time math behind the
+ * LFG boot (vote-kick) system.
+ */
+
+using namespace LFGBootLogic;
+
+TEST(LFGBootLogic_RequiredVotes_lfd)
+{
+    CHECK(RequiredVotes(false) == 4u);
+}
+
+TEST(LFGBootLogic_RequiredVotes_lfr)
+{
+    CHECK(RequiredVotes(true) == 15u);
+}
+
+TEST(LFGBootLogic_ShouldVoteKick_distinct_players)
+{
+    CHECK(ShouldVoteKick(1, 2) == true);
+}
+
+TEST(LFGBootLogic_ShouldVoteKick_self_is_refused)
+{
+    CHECK(ShouldVoteKick(1, 1) == false);
+}
+
+TEST(LFGBootLogic_Resolve_below_both_thresholds_is_pending)
+{
+    BootTally tally;
+    tally.total = 2;
+    tally.agree = 1;
+    tally.deny = 1;
+
+    CHECK(Resolve(tally, 4) == BOOT_PENDING);
+}
+
+TEST(LFGBootLogic_Resolve_at_threshold_passes)
+{
+    BootTally tally;
+    tally.agree = 4;
+
+    // Proves >=, not ==.
+    CHECK(Resolve(tally, 4) == BOOT_PASSED);
+}
+
+TEST(LFGBootLogic_Resolve_above_threshold_passes)
+{
+    BootTally tally;
+    tally.agree = 5;
+
+    // The == regression guard.
+    CHECK(Resolve(tally, 4) == BOOT_PASSED);
+}
+
+TEST(LFGBootLogic_Resolve_deny_wins)
+{
+    BootTally tally;
+    tally.deny = 4;
+
+    CHECK(Resolve(tally, 4) == BOOT_FAILED);
+}
+
+TEST(LFGBootLogic_Resolve_agree_beats_deny)
+{
+    BootTally tally;
+    tally.agree = 4;
+    tally.deny = 4;
+
+    // Order is defined: agree is checked first.
+    CHECK(Resolve(tally, 4) == BOOT_PASSED);
+}
+
+TEST(LFGBootLogic_Resolve_lfr_threshold_not_yet_reached)
+{
+    BootTally tally;
+    tally.agree = 4;
+
+    CHECK(Resolve(tally, 15) == BOOT_PENDING);
+}
+
+TEST(LFGBootLogic_RemainingSeconds_mid_vote)
+{
+    CHECK(RemainingSeconds(1000, 120, 1030) == 90);
+}
+
+TEST(LFGBootLogic_RemainingSeconds_exactly_expired)
+{
+    CHECK(RemainingSeconds(1000, 120, 1120) == 0);
+}
+
+TEST(LFGBootLogic_RemainingSeconds_well_past_does_not_wrap)
+{
+    // C-8 fault (c): no clamp meant this wrapped through uint8 in the
+    // legacy sender. Confirm the replacement floors at 0 instead.
+    CHECK(RemainingSeconds(1000, 120, 9999) == 0);
+}
+
+TEST(LFGBootLogic_RemainingSeconds_clock_skew_returns_full_duration)
+{
+    CHECK(RemainingSeconds(1000, 120, 500) == 120);
+}
+
+TEST(LFGBootLogic_RemainingSeconds_zero_duration)
+{
+    CHECK(RemainingSeconds(1000, 0, 1000) == 0);
+}
+
+TEST(LFGBootLogic_five_man_unanimity_all_three_agree_passes)
+{
+    // Victim auto-DENY, kicker auto-AGREE, three survivors all AGREE.
+    BootTally tally;
+    tally.agree = 1 + 3;   // kicker + three survivors
+    tally.deny = 1;        // victim
+    tally.total = tally.agree + tally.deny;
+
+    CHECK(Resolve(tally, RequiredVotes(false)) == BOOT_PASSED);
+}
+
+TEST(LFGBootLogic_five_man_unanimity_one_abstention_deadlocks)
+{
+    // Same group, but one survivor never votes: neither side reaches 4.
+    BootTally tally;
+    tally.agree = 1 + 2;   // kicker + two survivors
+    tally.deny = 1;        // victim
+    tally.total = tally.agree + tally.deny;
+
+    CHECK(Resolve(tally, RequiredVotes(false)) == BOOT_PENDING);
+}
+
+TEST(LFGBootLogic_budget_constant)
+{
+    CHECK(int(BOOT_MAX_KICKS) == 3);
+}

--- a/src/tests/LFGPacketsTest.cpp
+++ b/src/tests/LFGPacketsTest.cpp
@@ -152,9 +152,9 @@ TEST(LFGPackets_BootProposalUpdate_exact_fixture)
 {
     LFGPackets::BootProposalUpdate data;
     data.voteInProgress = true;
-    data.myVoteCompleted = true;
-    data.myVote = false;
-    data.voteEcho = true;
+    data.votePassed = true;
+    data.myVoteCompleted = false;
+    data.myVote = true;
     data.target = 0x0011223344556677ULL;   // leading zero byte, raw GUID
     data.totalVotes = 5;
     data.bootVotes = 3;
@@ -177,6 +177,24 @@ TEST(LFGPackets_BootProposalUpdate_exact_fixture)
         0x03,0x00,0x00,0x00,
         0x41,0x46,0x4B,0x00
     });
+}
+
+TEST(LFGPackets_BootProposalUpdate_four_byte_prefix)
+{
+    // C-5 regression guard: the legacy sender wrote three leading bytes
+    // where the client reads four. Pin all four flag bytes with a
+    // distinguishable 1/0/1/0 pattern so a dropped byte fails this test.
+    LFGPackets::BootProposalUpdate data;
+    data.voteInProgress = true;
+    data.votePassed = false;
+    data.myVoteCompleted = true;
+    data.myVote = false;
+
+    WorldPacket packet(SMSG_LFG_BOOT_PROPOSAL_UPDATE, 64);
+    REQUIRE(LFGPackets::BuildBootProposalUpdate(packet, data));
+
+    CHECK(packet.size() >= 4);
+    CHECK_BYTES(packet.contents(), 4, { 0x01, 0x00, 0x01, 0x00 });
 }
 
 TEST(LFGPackets_BootProposalUpdate_empty_reason_is_just_the_terminator)


### PR DESCRIPTION
Continues the Dungeon Finder work from #332. Adds the LFD boot (vote kick), which m3 had no working path for: `FinishBootVote` and `RemoveOldBoots` did not exist, and `CMSG_LFG_SET_BOOT_VOTE` was never registered.

**The kick path.** `Player::RemoveFromGroup` and `CanUninviteFromGroup` had no LFG awareness — every uninvite went straight to a hard removal, and eligibility required leader or assistant. That is wrong for a vote kick: the client offers it to *every* member of an LFD group and deliberately omits the leader check (`UnitPopup.lua:708-715`), keying off `HasLFGRestrictions` rather than `isLFGGroup`. `RemoveFromGroup` takes m2's 4-argument shape (guid, kicker, reason), with the kicker defaulting to self so the voluntary-leave path still falls through to a plain removal. `CanUninviteFromGroup` takes a target and gains an LFD branch checking, in order, the kick budget, an in-progress vote, group size, dungeon-finished state, and whether anyone on the initiator's map is in combat.

**Thresholds are server policy.** The client parses the votes-needed field and never reads it back, so nothing in the client can settle this. A five-man kick is a majority of the group — **3**, not the 4 TrinityCore uses — and a group gets **2** successful kicks. Both live in `LFGBootLogic.h`, a game-free header alongside `LFGProposalLogic.h` and `LFGRoleAssignment.h`, so the tally, threshold and timer math get unit coverage without linking `game`. 20 new tests; 142 LFG tests pass.

**Boot consequences.** No deserter — m3 never casts 71041 on any path, so "no deserter for a boot" was already true by omission, and the branch is placed to stay excluded when a later phase adds deserter on voluntary leave. The random-dungeon cooldown is stripped (a no-op today; 71328 is never applied in this tree, so this is a branch made correct rather than a working refund added). The victim is teleported out, and a surviving leader gets `SMSG_LFG_OFFER_CONTINUE` so the backfill UI can open.

**One ordering bug found in testing and fixed here.** The victim was teleported *before* `RemoveMember`, so `SMSG_GROUP_UNINVITE` and the empty `SMSG_GROUP_LIST` were written into a loading screen — a far teleport sets the world-port semaphore synchronously and the ack cannot be processed until a later tick, so the loss was guaranteed, not racy. Everyone else saw the victim leave while the victim kept a full party frame. Removal now precedes the teleport, matching the order the group-formation path already uses; `TeleportPlayer` takes an optional explicit dungeon id because a removed player no longer has a group to derive one from.

`SMSG_GROUP_LIST`'s `LfgAborted` byte stays hardcoded 0 — a non-zero value disables `CanPartyLFGBackfill` (`sub_1406FB440`), which is precisely the offer `SMSG_LFG_OFFER_CONTINUE` exists to make. Only the comment promising a change here is corrected.

Verified in-game with five characters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/333)
<!-- Reviewable:end -->
