### PR TITLE
[Fix] Cap levels at 200 and add a .level command

### DIFF
--- a/src/game/ChatCommands/PlayerStateCommands.cpp
+++ b/src/game/ChatCommands/PlayerStateCommands.cpp
@@ -436,6 +436,59 @@ bool ChatHandler::HandleExploreCheatCommand(char* args)
 }
 
 /**
+ * @brief Handler for HandleLevelCommand command. Sets the level outright,
+ *        where .levelup adds to it.
+ *
+ * @param args Command arguments.
+ * @returns True if the command executed successfully, false otherwise.
+ */
+bool ChatHandler::HandleLevelCommand(char* args)
+{
+    if (!*args)
+    {
+        return false;
+    }
+
+    char* nameStr = ExtractOptNotLastArg(&args);
+
+    int32 newlevel;
+    if (!ExtractInt32(&args, newlevel))
+    {
+        return false;
+    }
+
+    Player* target;
+    ObjectGuid target_guid;
+    std::string target_name;
+    if (!ExtractPlayerTarget(&nameStr, &target, &target_guid, &target_name))
+    {
+        return false;
+    }
+
+    if (newlevel < 1)
+    {
+        newlevel = 1;
+    }
+
+    if (newlevel > STRONG_MAX_LEVEL)                        // hardcoded maximum level
+    {
+        newlevel = STRONG_MAX_LEVEL;
+    }
+
+    int32 oldlevel = target ? target->getLevel() : Player::GetLevelFromDB(target_guid);
+
+    HandleCharacterLevel(target, target_guid, oldlevel, newlevel);
+
+    if (!m_session || m_session->GetPlayer() != target)     // including chr==NULL
+    {
+        std::string nameLink = playerLink(target_name);
+        PSendSysMessage(LANG_YOU_CHANGE_LVL, nameLink.c_str(), newlevel);
+    }
+
+    return true;
+}
+
+/**
  * @brief Handler for HandleLevelUpCommand command.
  *
  * @param args Command arguments.

--- a/src/game/Server/DBCEnums.h
+++ b/src/game/Server/DBCEnums.h
@@ -37,7 +37,10 @@
 
 // Server side limitation. Base at used code requirements.
 // also see MAX_LEVEL and GT_MAX_LEVEL define
-#define STRONG_MAX_LEVEL 255
+// Everything above level 200 crashes the client: its tooltip path indexes
+// gtSpellScaling by level and reads past the end of the table, so the first
+// spell tooltip on such a character takes the client down.
+#define STRONG_MAX_LEVEL 200
 enum MountFlags
 {
     MOUNT_FLAG_CAN_PITCH                = 0x4,

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -877,6 +877,9 @@ ChatCommand* ChatHandler::getCommandTable()
         { "linkgrave",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleLinkGraveCommand,           "", NULL },
         { "neargrave",      SEC_ADMINISTRATOR,  false, &ChatHandler::HandleNearGraveCommand,           "", NULL },
         { "explorecheat",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleExploreCheatCommand,        "", NULL },
+        // Must precede "levelup": commands match by abbreviation in table
+        // order, so "levelup" would otherwise swallow a bare ".level".
+        { "level",          SEC_ADMINISTRATOR,  false, &ChatHandler::HandleLevelCommand,               "", NULL },
         { "levelup",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleLevelUpCommand,             "", NULL },
         { "showarea",       SEC_ADMINISTRATOR,  false, &ChatHandler::HandleShowAreaCommand,            "", NULL },
         { "hidearea",       SEC_ADMINISTRATOR,  false, &ChatHandler::HandleHideAreaCommand,            "", NULL },

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -660,6 +660,7 @@ class ChatHandler
         bool HandleLinkGraveCommand(char* args);
         bool HandleNearGraveCommand(char* args);
         bool HandleExploreCheatCommand(char* args);
+        bool HandleLevelCommand(char* args);
         bool HandleLevelUpCommand(char* args);
         bool HandleShowAreaCommand(char* args);
         bool HandleHideAreaCommand(char* args);

--- a/src/shared/revision_data.h.in
+++ b/src/shared/revision_data.h.in
@@ -56,8 +56,8 @@
 
     #define WORLD_DB_VERSION_NR         "22"
     #define WORLD_DB_STRUCTURE_NR       "7"
-    #define WORLD_DB_CONTENT_NR         "2"
-    #define WORLD_DB_UPDATE_DESCRIPT    "Lfg_Cata_Rewards"
+    #define WORLD_DB_CONTENT_NR         "3"
+    #define WORLD_DB_UPDATE_DESCRIPT    "Level_Command_Help"
 
     #define VER_COMPANY_NAME_STR        "MaNGOS Developers"
     #define VER_LEGALCOPYRIGHT_STR      "(c)2005-@rev_year@ MaNGOS"


### PR DESCRIPTION
Two related problems with GM level handling.

The hardcoded ceiling was 255, but the 4.3.4 client cannot survive a character above 200:
its tooltip path indexes `gtSpellScaling` by level and reads past the end of the table, so
the first spell tooltip on such a character takes the client down. Any GM could reach that
with one command. The ceiling is now 200, documented where it is defined. All existing
uses of `STRONG_MAX_LEVEL` are clamps or table validations -- none sizes an array -- so
the same constant now bounds `.level`, `.levelup`, `.character level`, the guild roster
sanity checks and the `player_levelstats` / `pet_levelstats` / `player_xp_for_level`
loaders.

And `.level` did not do what it looks like it does. Commands match by abbreviation in
table order, and there was no `level` entry, so a bare `.level` resolved to `.levelup` and
added levels instead of setting one -- `.level 85` on a level 85 character made it 170.
There is now a real `.level` command that sets the level outright, placed ahead of
`.levelup` in the table so the abbreviation resolves to it. `.levelup` still adds, as its
name says.

Note this clamps new commands only; characters already stored above 200 keep their level.

Paired with mangosthree/database#139 for the command's help row (world DB 22/07/003).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/335)
<!-- Reviewable:end -->
