### PR TITLE
[Feat] Show the bot count on the console status bar

### DIFF
--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -885,6 +885,36 @@ void World::SetInitialWorldSettings()
     sLog.outString();
 }
 
+uint32 World::GetBotCount() const
+{
+#ifdef ENABLE_PLAYERBOTS
+    // Two homes to count: random bots belong to the one manager, while a bot
+    // a player summoned belongs to that player's own. Bots hold no entry in
+    // m_sessions, which is why the session counts never include them.
+    uint32 count = uint32(std::distance(sRandomPlayerbotMgr.GetPlayerBotsBegin(),
+                                        sRandomPlayerbotMgr.GetPlayerBotsEnd()));
+
+    for (SessionMap::const_iterator itr = m_sessions.begin(); itr != m_sessions.end(); ++itr)
+    {
+        Player* player = itr->second ? itr->second->GetPlayer() : NULL;
+        if (!player)
+        {
+            continue;
+        }
+
+        if (PlayerbotMgr* mgr = player->GetPlayerbotMgr())
+        {
+            count += uint32(std::distance(mgr->GetPlayerBotsBegin(),
+                                          mgr->GetPlayerBotsEnd()));
+        }
+    }
+
+    return count;
+#else
+    return 0;
+#endif
+}
+
 /**
  * @brief Prints the startup footer and enabled module summary.
  */

--- a/src/game/WorldHandlers/World.h
+++ b/src/game/WorldHandlers/World.h
@@ -558,6 +558,10 @@ class World
         uint32 GetActiveAndQueuedSessionCount() const { return m_sessions.size(); }
         uint32 GetActiveSessionCount() const { return m_sessions.size() - m_QueuedSessions.size(); }
         uint32 GetQueuedSessionCount() const { return m_QueuedSessions.size(); }
+
+        /// Player bots currently logged in. Always 0 when the module is not
+        /// built -- bots hold no session, so the counts above never see them.
+        uint32 GetBotCount() const;
         /// Get the maximum number of parallel sessions on the server since last reboot
         uint32 GetMaxQueuedSessionCount() const { return m_maxQueuedSessionCount; }
         uint32 GetMaxActiveSessionCount() const { return m_maxActiveSessionCount; }

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -294,17 +294,25 @@ void Master::PublishConsoleStatus(uint32 diff)
              sWorld.GetPlayerAmountLimit());
     ui.SetStatus(0, "Players", buf);
 
-    ui.SetStatus(1, "Queue", std::to_string(sWorld.GetQueuedSessionCount()),
+#ifdef ENABLE_PLAYERBOTS
+    // Only on a build that has bots -- a permanent "Bots 0" would be noise
+    // everywhere else. Bots hold no session, so this is a count of its own
+    // rather than a share of the player count beside it. An unset slot is
+    // skipped when the row is composed, so the gap left here closes up.
+    ui.SetStatus(1, "Bots", std::to_string(sWorld.GetBotCount()));
+#endif
+
+    ui.SetStatus(2, "Queue", std::to_string(sWorld.GetQueuedSessionCount()),
                  sWorld.GetQueuedSessionCount() ? MaNGOS::Console::STYLE_WARN
                                                 : MaNGOS::Console::STYLE_NORMAL);
 
     snprintf(buf, sizeof(buf), "%u ms", diff);
-    ui.SetStatus(2, "Diff", buf, diff > WORLD_SLEEP_CONST ? MaNGOS::Console::STYLE_WARN
+    ui.SetStatus(3, "Diff", buf, diff > WORLD_SLEEP_CONST ? MaNGOS::Console::STYLE_WARN
                                                           : MaNGOS::Console::STYLE_SUCCESS);
 
     snprintf(buf, sizeof(buf), "%ud %02u:%02u:%02u", uptime / 86400,
              (uptime / 3600) % 24, (uptime / 60) % 60, uptime % 60);
-    ui.SetStatus(3, "Uptime", buf);
+    ui.SetStatus(4, "Uptime", buf);
 }
 
 void Master::WorldLoop()


### PR DESCRIPTION
A server running player bots had no way to see how many were in the world. The player
count cannot answer it: bots hold no entry in `m_sessions`, so a realm with one player and
thirty bots reads `Players 1 / 100`.

This adds a `Bots` field beside it. `World::GetBotCount()` sums the two places a logged-in
bot lives -- `sRandomPlayerbotMgr` for random bots, and the per-player `PlayerbotMgr` for
bots a player summoned. `PlayerbotHolder` has exactly those two subclasses, so there is no
third place for one to hide. Both already expose public iterators, so no new API into the
module.

The field is compiled out entirely when `PLAYERBOTS` is off -- the upstream default --
rather than showing a permanent zero. `ENABLE_PLAYERBOTS` is `PUBLIC` on the `game`
target, so `mangosd` sees it. An unset status slot is skipped when the row is composed, so
the gap left behind closes up and the layout stays contiguous.

Verified against a live realm with 25 bots: `characters.online`, the random-bot table and
the module's own login log all agreed with the field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/336)
<!-- Reviewable:end -->
