### PR TITLE
[LFG] Apply Luck of the Draw

### DIFF
--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -155,6 +155,10 @@ enum LFGSpells
 {
     LFG_DESERTER_SPELL = 71041,
     LFG_COOLDOWN_SPELL = 71328,
+    /// Luck of the Draw: 5% damage, healing and health per stack, for a
+    /// group put together out of strangers. Duration, stack cap and the
+    /// map-exit removal all come from the DBC.
+    LFG_LUCK_OF_THE_DRAW_SPELL = 72221,
 };
 
 enum LFGTimes
@@ -331,6 +335,9 @@ struct LFGPlayerStatus
     std::set<uint32> dungeonList;
     std::string comment;
     RideTicket ticket;
+    /// Queued alone rather than as part of a party. These are the "random
+    /// players" Luck of the Draw counts.
+    bool queuedSolo = false;
 
     LFGPlayerStatus() : state(LFG_STATE_NONE), updateType(LFG_UPDATE_DEFAULT) { }
     LFGPlayerStatus(LFGState State, LfgUpdateType UpdateType, std::set<uint32> DungeonList, std::string Comment)
@@ -664,6 +671,18 @@ public:
     */
     void OnDungeonEncounterComplete(Map* pMap);
 
+    /**
+    * Applies Luck of the Draw to a player arriving on their finder
+    * dungeon's map -- on the formation teleport, a corpse run back in, or
+    * a login inside it.
+    *
+    * \arg \c pPlayer
+    *   The arriving player.
+    * \arg \c pMap
+    *   The map being entered.
+    */
+    void OnPlayerEnterMap(Player* pPlayer, Map* pMap);
+
     /// Group kick hook
     void AttemptToKickPlayer(Group* pGroup, ObjectGuid guid, ObjectGuid kicker, std::string reason);
 
@@ -802,6 +821,11 @@ private:
     /// The random dungeon this player queued for, 0 when they picked a
     /// specific one. Read from their own selection, which the queue keeps.
     uint32 GetQueuedRandomID(ObjectGuid plrGuid);
+
+    /// Members of this group who queued alone. A member with no queue
+    /// status -- someone invited by hand after formation -- counts as a
+    /// friend rather than a stranger.
+    uint32 CountSoloJoinedMembers(LFGGroupStatus const& status);
 
     /// Casts or clears the leave/kick auras a removal from an LFD group
     /// earns, per LFGRewardLogic::PenaltyForRemoval under the two

--- a/src/game/WorldHandlers/LFGMgrProposal.cpp
+++ b/src/game/WorldHandlers/LFGMgrProposal.cpp
@@ -41,6 +41,7 @@
 #include "Player.h"
 #include "PlayerRegistry.h"
 #include "ObjectMgr.h"
+#include "SpellAuras.h"
 #include "SharedDefines.h"
 #include "Util.h"
 #include "WorldSession.h"
@@ -1429,6 +1430,79 @@ void LFGMgr::RewardDungeonCompletion(Player* pPlayer, LFGGroupStatus const& stat
     reward.addedXp = xp;
 
     pPlayer->GetSession()->SendLfgPlayerReward(reward);
+}
+
+uint32 LFGMgr::CountSoloJoinedMembers(LFGGroupStatus const& status)
+{
+    uint32 solo = 0;
+    for (roleMap::const_iterator itr = status.playerRoles.begin();
+         itr != status.playerRoles.end(); ++itr)
+    {
+        playerStatusMap::const_iterator statusItr = m_playerStatusMap.find(itr->first);
+        if (statusItr != m_playerStatusMap.end() && statusItr->second.queuedSolo)
+        {
+            ++solo;
+        }
+    }
+
+    return solo;
+}
+
+void LFGMgr::OnPlayerEnterMap(Player* pPlayer, Map* pMap)
+{
+    if (!pPlayer || !pMap)
+    {
+        return;
+    }
+
+    Group* pGroup = pPlayer->GetGroup();
+    if (!pGroup)
+    {
+        return;
+    }
+
+    LFGGroupStatus* status = GetGroupStatus(pGroup->GetObjectGuid());
+    if (!status)
+    {
+        return;
+    }
+
+    // The run counts as under way from the teleport until the group breaks
+    // up, so a corpse run back in after the last boss is still buffed.
+    if (status->state != LFG_STATE_IN_DUNGEON &&
+        status->state != LFG_STATE_FINISHED_DUNGEON)
+    {
+        return;
+    }
+
+    LfgDungeonsEntry const* dungeon = sLfgDungeonsStore.LookupEntry(status->dungeonID);
+    if (!dungeon || dungeon->mapID != int32(pMap->GetId()) ||
+        Difficulty(dungeon->difficulty) != pMap->GetDifficulty())
+    {
+        return;
+    }
+
+    // Strangers, not party size: a group that queued together as five gets
+    // nothing, and the count is the group's rather than each viewer's.
+    uint32 const stacks =
+        LFGRewardLogic::LuckOfTheDrawStacks(CountSoloJoinedMembers(*status));
+    if (stacks == 0)
+    {
+        return;
+    }
+
+    pPlayer->CastSpell(pPlayer, LFG_LUCK_OF_THE_DRAW_SPELL, true);
+
+    if (stacks > 1)
+    {
+        // The cast can be refused -- an immunity, a script -- and there is
+        // then nothing to stack.
+        if (SpellAuraHolder* holder =
+                pPlayer->GetSpellAuraHolder(LFG_LUCK_OF_THE_DRAW_SPELL))
+        {
+            holder->SetStackAmount(stacks);
+        }
+    }
 }
 
 void LFGMgr::OnDungeonEncounterComplete(Map* pMap)

--- a/src/game/WorldHandlers/LFGMgrQueue.cpp
+++ b/src/game/WorldHandlers/LFGMgrQueue.cpp
@@ -332,6 +332,9 @@ void LFGMgr::JoinLFG(uint32 roles, std::set<uint32> dungeons, std::string commen
         // set up a status struct for client requests/updates
         LFGPlayerStatus plrStatus(LFG_STATE_NONE, LFG_UPDATE_JOIN_INITIAL, displayDungeons, comments);
         plrStatus.ticket = ticket;
+        // Queued alone: this player is a stranger to whoever they are matched
+        // with, which is what Luck of the Draw counts.
+        plrStatus.queuedSolo = true;
         m_playerStatusMap[guid] = plrStatus;
         SendLfgUpdate(guid, plrStatus, false);
 

--- a/src/game/WorldHandlers/LFGRewardLogic.h
+++ b/src/game/WorldHandlers/LFGRewardLogic.h
@@ -194,6 +194,15 @@ namespace LFGRewardLogic
             ? RemovalPenalty::DESERTER : RemovalPenalty::NONE;
     }
 
+    /// Luck of the Draw stacks for a group holding this many solo-queued
+    /// members. One stack each, capped at three -- the cap is the spell's
+    /// own, from SpellAuraOptions, not a number chosen here.
+    inline std::uint32_t LuckOfTheDrawStacks(std::uint32_t soloJoinedMembers)
+    {
+        std::uint32_t const maxStacks = 3;
+        return (soloJoinedMembers < maxStacks) ? soloJoinedMembers : maxStacks;
+    }
+
     /// Multiplier on the stored reward row. dungeonfinder_rewards holds the
     /// subsequent-run value, so the first run of the day pays double.
     inline std::uint32_t FirstRewardMultiplier(bool hasDoneDaily)

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -64,6 +64,7 @@
 #include "CorpseManager.h"
 #include "ObjectMgr.h"
 #include "World.h"
+#include "LFGMgr.h"
 #include "ScriptMgr.h"
 #include "Group.h"
 #include "MapRefManager.h"
@@ -750,6 +751,14 @@ bool Map::Add(Player* player)
     if (i_data)
     {
         i_data->OnPlayerEnter(player);
+    }
+
+    // Every way into a map arrives here -- the formation teleport, a corpse
+    // run back in, and a login inside one -- which is what Luck of the Draw
+    // needs: it is applied on entry and taken away on exit by the spell.
+    if (sWorld.getConfig(CONFIG_BOOL_LFG_ENABLE))
+    {
+        sLFGMgr.OnPlayerEnterMap(player, this);
     }
 
     return true;

--- a/src/tests/LFGRewardLogicTest.cpp
+++ b/src/tests/LFGRewardLogicTest.cpp
@@ -124,6 +124,18 @@ TEST(LFGRewardLogic_FirstRewardMultiplier)
     CHECK(FirstRewardMultiplier(false) == 2u);
 }
 
+TEST(LFGRewardLogic_LuckOfTheDrawStacks)
+{
+    // One stack per stranger, capped at the spell's own maximum of three.
+    // A group that queued together as five has no strangers and no buff.
+    CHECK(LuckOfTheDrawStacks(0) == 0u);
+    CHECK(LuckOfTheDrawStacks(1) == 1u);
+    CHECK(LuckOfTheDrawStacks(2) == 2u);
+    CHECK(LuckOfTheDrawStacks(3) == 3u);
+    CHECK(LuckOfTheDrawStacks(4) == 3u);
+    CHECK(LuckOfTheDrawStacks(5) == 3u);
+}
+
 TEST(LFGRewardLogic_ItemRewardMatches_band)
 {
     CHECK(ItemRewardMatches(70, 80, 4, 75, 4) == true);


### PR DESCRIPTION
Players thrown together by the Dungeon Finder are strangers to each other, and 4.0.6 started paying them for putting up with it: Luck of the Draw, 5% to damage, healing and health per stack. One stack per member who queued alone, capped at three by the spell's own `SpellAuraOptions` row rather than by a number chosen here.

Applied on entry to the dungeon map instead of at group formation, so it survives a corpse run back in and a relog, and goes when the group does. A party that queued together has no strangers in it and gets nothing.

The stack arithmetic is unit tested. Everything downstream of it — the aura landing, the stack count on the icon, removal on leaving — needs a five-client run and is on the release-testing list.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosthree/server/337)
<!-- Reviewable:end -->
